### PR TITLE
Migrated from package:pedantic

### DIFF
--- a/at_contact/pubspec.yaml
+++ b/at_contact/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
 #      ref: trunk
-      
+
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.15.4

--- a/at_lookup/analysis_options.yaml
+++ b/at_lookup/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.1

--- a/at_server_status/analysis_options.yaml
+++ b/at_server_status/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_server_status/pubspec.yaml
+++ b/at_server_status/pubspec.yaml
@@ -1,5 +1,5 @@
 name: at_server_status
-description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign. 
+description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
 documentation: https://atsign.dev/apidocs
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
@@ -15,5 +15,5 @@ dependencies:
   uuid: ^3.0.4
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.1

--- a/base2e15/pubspec.yaml
+++ b/base2e15/pubspec.yaml
@@ -7,5 +7,5 @@ version: 0.3.0-null-safety
 homepage: https://github.com/rinick/base2e15
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.1

--- a/dart_utf7/pubspec.yaml
+++ b/dart_utf7/pubspec.yaml
@@ -11,5 +11,5 @@ environment:
 #  path: ^1.6.0
 
 dev_dependencies:
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   test: ^1.17.1

--- a/redis-dart/pubspec.yaml
+++ b/redis-dart/pubspec.yaml
@@ -9,4 +9,5 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
+  lints: ^1.0.1
   test: ^1.17.3


### PR DESCRIPTION
I have migrated from package:pedantic to package:lints.

In each `pubspec.yaml`, I have changed the following:
```
- pedantic: ^1.11.0  
+ lints: ^1.0.1
```

In each `analysis_options.yaml`, I have changed the following:
```
- include: package:pedantic/analysis_options.yaml
+ include: package:lints/recommended.yaml
```
Changelog:
Migrated from package:pedantic to package:lints

Closes #120 