### PR TITLE
Quick fix at_lookup race condition

### DIFF
--- a/at_lookup/CHANGELOG.md
+++ b/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.8
+- at_lookup fix race condition when not using await with lookup requests
 ## 3.0.7
 - at_utils version change for fix formatAtSign bug for null value
 ## 3.0.6

--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -476,25 +476,27 @@ class AtLookupImpl implements AtLookUp {
   Mutex requestResponseMutex = Mutex();
 
   Future<String?> _process(String command, {bool auth = false}) async {
-    await requestResponseMutex.acquire();
-
-    if (auth && _isAuthRequired()) {
-      if (privateKey != null) {
-        await authenticate(privateKey);
-      } else if (cramSecret != null) {
-        await authenticate_cram(cramSecret);
-      } else {
-        throw UnAuthenticatedException(
-            'Unable to perform atlookup auth. Private key/cram secret is not set');
-      }
-    }
     try {
-      await _sendCommand(command);
-      var result = await messageListener.read();
-      return result;
-    } on Exception catch (e) {
-      logger.severe('Exception in sending to server, ${e.toString()}');
-      rethrow;
+      await requestResponseMutex.acquire();
+
+      if (auth && _isAuthRequired()) {
+        if (privateKey != null) {
+          await authenticate(privateKey);
+        } else if (cramSecret != null) {
+          await authenticate_cram(cramSecret);
+        } else {
+          throw UnAuthenticatedException(
+              'Unable to perform atlookup auth. Private key/cram secret is not set');
+        }
+      }
+      try {
+        await _sendCommand(command);
+        var result = await messageListener.read();
+        return result;
+      } on Exception catch (e) {
+        logger.severe('Exception in sending to server, ${e.toString()}');
+        rethrow;
+      }
     } finally {
       requestResponseMutex.release();
     }

--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -489,7 +489,7 @@ class AtLookupImpl implements AtLookUp {
 
   Mutex requestResponseMutex = Mutex();
 
-  Future<String?> _process(String command, {bool auth = false}) async {
+  Future<String> _process(String command, {bool auth = false}) async {
     try {
       await requestResponseMutex.acquire();
 

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.7
+version: 3.0.8
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   crypto: ^3.0.1
   at_utils: ^3.0.5
   at_commons: ^3.0.3
+  mutex: ^3.0.0
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
* Added use of a mutex into `AtLookupImpl._process()` to prevent race condition which surfaced during testing the mwc_demo end-to-end

**- How I did it**
* Added dependency on mutex package
* Created a Mutex for use by `_process()`; modified `_process()` to acquire the mutex to start with, and release it in a `finally` block

**- How to verify it**
* DONE: Verified this fixed the issue for mwc_demo
* DONE: Run all tests in `at_client_sdk` with a dependency override for at_lookup to this branch
* DONE: test atmospherepro with this branch
* DONE: [Added a test to at_client_sdk/at_functional_test](https://github.com/atsign-foundation/at_client_sdk/pull/408). (To see the test failing, add `at_lookup: 3.0.7` to at_client_sdk/at_functional_test/pubspec.yaml)

**- Description for the changelog**
* Added use of a mutex into `AtLookupImpl._process()` to prevent race condition