### PR TITLE
add secondary address cache

### DIFF
--- a/at_lookup/lib/src/cache/secondary_address_cache.dart
+++ b/at_lookup/lib/src/cache/secondary_address_cache.dart
@@ -41,7 +41,7 @@ class SecondaryAddressCacheImpl implements SecondaryAddressCache {
     }
     try {
       String? secondaryUrl =
-          await AtLookupImpl.findSecondary(atSign, rootDomain, rootPort!);
+          await AtLookupImpl.findSecondary(atSign, rootDomain, rootPort);
       if (secondaryUrl == null ||
           secondaryUrl.isEmpty ||
           secondaryUrl == 'data:null') {

--- a/at_lookup/lib/src/cache/secondary_address_cache.dart
+++ b/at_lookup/lib/src/cache/secondary_address_cache.dart
@@ -3,9 +3,95 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/util/lookup_util.dart';
 import 'package:at_utils/at_logger.dart';
 
-abstract class SecondaryAddressCache {
-  Future<SecondaryAddress> getAddress(
-      String atSign, String rootDomain, int rootPort);
+class SecondaryAddressCache {
+  static const Duration defaultCacheDuration = Duration(hours: 1);
+
+  final Map<String, SecondaryAddressCacheEntry> _map = {};
+  final _logger = AtSignLogger('SecondaryAddressCacheImpl');
+
+  final String _rootDomain;
+  final int _rootPort;
+  late SecondaryAddressFinder _secondaryFinder;
+
+  SecondaryAddressCache(this._rootDomain, this._rootPort, {SecondaryAddressFinder? secondaryFinder}) {
+    _secondaryFinder = secondaryFinder ?? SecondaryAddressFinder();
+  }
+
+  bool cacheContains(String atSign) {
+    return _map.containsKey(stripAtSignFromAtSign(atSign));
+  }
+
+  /// Returns the expiry time of this entry in millisecondsSinceEpoch, or null if this atSign is not in cache
+  int? getCacheExpiryTime(String atSign) {
+    atSign = stripAtSignFromAtSign(atSign);
+    if (_map.containsKey(atSign)) {
+      return _map[atSign]!.expiresAt;
+    } else {
+      return null;
+    }
+  }
+
+  Future<SecondaryAddress> getAddress(String atSign, {bool refreshCacheNow = false, Duration cacheFor = defaultCacheDuration}) async {
+    atSign = stripAtSignFromAtSign(atSign);
+
+    if (refreshCacheNow || _cacheIsEmptyOrExpired(atSign)) {
+      // _updateCache will either populate the cache, or throw an exception
+      await _updateCache(atSign, cacheFor);
+    }
+
+    if (_map.containsKey(atSign)) {
+      // should always be true, since _updateCache will throw an exception if it fails
+      return _map[atSign]!.secondaryAddress;
+    } else {
+      // but just in case, we'll throw an exception if it's not
+      throw Exception("Failed to find secondary, in a theoretically impossible way");
+    }
+  }
+
+  bool _cacheIsEmptyOrExpired(String atSign) {
+    if (_map.containsKey(atSign)) {
+      SecondaryAddressCacheEntry entry = _map[atSign]!;
+      if (entry.expiresAt < DateTime.now().millisecondsSinceEpoch) {
+        // expiresAt is in the past - cache has expired
+        return true;
+      } else {
+        // cache has not yet expired
+        return false;
+      }
+    } else {
+      // cache is empty
+      return true;
+    }
+  }
+
+  static String stripAtSignFromAtSign(String atSign) {
+    if (atSign.startsWith('@')) {
+      atSign = atSign.replaceFirst('@', '');
+    }
+    return atSign;
+  }
+  static String getNotFoundExceptionMessage(String atSign) {
+    return 'Unable to find secondary address for atSign:$atSign';
+  }
+  Future<void> _updateCache(String atSign, Duration cacheFor) async {
+    try {
+      String? secondaryUrl = await _secondaryFinder.findSecondary(atSign, _rootDomain, _rootPort);
+      if (secondaryUrl == null ||
+          secondaryUrl.isEmpty ||
+          secondaryUrl == 'data:null') {
+        throw SecondaryNotFoundException(getNotFoundExceptionMessage(atSign));
+      }
+      var secondaryInfo = LookUpUtil.getSecondaryInfo(secondaryUrl);
+      String secondaryHost = secondaryInfo[0];
+      int secondaryPort = int.parse(secondaryInfo[1]);
+
+      SecondaryAddress addr = SecondaryAddress(secondaryHost, secondaryPort);
+      _map[atSign] = SecondaryAddressCacheEntry(addr, DateTime.now().add(cacheFor).millisecondsSinceEpoch);
+    } on Exception catch (e) {
+      _logger.severe('${getNotFoundExceptionMessage(atSign)} - ${e.toString()}');
+      rethrow;
+    }
+  }
 }
 
 class SecondaryAddress {
@@ -15,57 +101,20 @@ class SecondaryAddress {
 
   @override
   String toString() {
-    return 'SecondaryAddress{host: $host, port: $port}';
+    return '$host:$port';
   }
 }
 
-class SecondaryAddressCacheImpl implements SecondaryAddressCache {
-  final Map<String, SecondaryAddress> _map = {};
-  static final _logger = AtSignLogger('SecondaryAddressCacheImpl');
+class SecondaryAddressCacheEntry {
+  final SecondaryAddress secondaryAddress;
+  /// milliseconds since epoch
+  final int expiresAt;
 
-  static final int expiryHrs = 1;
-  static final SecondaryAddressCacheImpl _singleton =
-      SecondaryAddressCacheImpl._internal();
+  SecondaryAddressCacheEntry(this.secondaryAddress, this.expiresAt);
+}
 
-  factory SecondaryAddressCacheImpl.getInstance() {
-    return _singleton;
-  }
-
-  SecondaryAddressCacheImpl._internal();
-
-  @override
-  Future<SecondaryAddress> getAddress(
-      String atSign, String rootDomain, int rootPort) async {
-    if (_map.containsKey(atSign)) {
-      return _map[atSign]!;
-    }
-    try {
-      String? secondaryUrl =
-          await AtLookupImpl.findSecondary(atSign, rootDomain, rootPort);
-      if (secondaryUrl == null ||
-          secondaryUrl.isEmpty ||
-          secondaryUrl == 'data:null') {
-        throw SecondaryNotFoundException(
-            'Unable find secondary url for atSign:$atSign');
-      }
-      var secondaryInfo = LookUpUtil.getSecondaryInfo(secondaryUrl);
-      String secondaryHost = secondaryInfo[0];
-      int secondaryPort = int.parse(secondaryInfo[1]);
-      _add(atSign, SecondaryAddress(secondaryHost, secondaryPort));
-    } on Exception catch (e) {
-      _logger.severe(
-          'unable to find secondary address for atSign:$atSign - ${e.toString()}');
-      rethrow;
-    }
-    return _map[atSign]!;
-  }
-
-  void _add(String atSign, SecondaryAddress address) {
-    _map[atSign] = address;
-    Future.delayed(Duration(hours: expiryHrs), () => _remove(atSign));
-  }
-
-  void _remove(String atSign) {
-    _map.remove(atSign);
+class SecondaryAddressFinder {
+  Future<String?> findSecondary(String atSign, String rootDomain, int rootPort) async {
+    return await AtLookupImpl.findSecondary(atSign, rootDomain, rootPort);
   }
 }

--- a/at_lookup/lib/src/cache/secondary_address_cache.dart
+++ b/at_lookup/lib/src/cache/secondary_address_cache.dart
@@ -1,0 +1,71 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/util/lookup_util.dart';
+import 'package:at_utils/at_logger.dart';
+
+abstract class SecondaryAddressCache {
+  Future<SecondaryAddress> getAddress(
+      String atSign, String rootDomain, int rootPort);
+}
+
+class SecondaryAddress {
+  final String host;
+  final int port;
+  SecondaryAddress(this.host, this.port);
+
+  @override
+  String toString() {
+    return 'SecondaryAddress{host: $host, port: $port}';
+  }
+}
+
+class SecondaryAddressCacheImpl implements SecondaryAddressCache {
+  final Map<String, SecondaryAddress> _map = {};
+  static final _logger = AtSignLogger('SecondaryAddressCacheImpl');
+
+  static final int expiryHrs = 1;
+  static final SecondaryAddressCacheImpl _singleton =
+      SecondaryAddressCacheImpl._internal();
+
+  factory SecondaryAddressCacheImpl.getInstance() {
+    return _singleton;
+  }
+
+  SecondaryAddressCacheImpl._internal();
+
+  @override
+  Future<SecondaryAddress> getAddress(
+      String atSign, String rootDomain, int rootPort) async {
+    if (_map.containsKey(atSign)) {
+      return _map[atSign]!;
+    }
+    try {
+      String? secondaryUrl =
+          await AtLookupImpl.findSecondary(atSign, rootDomain, rootPort!);
+      if (secondaryUrl == null ||
+          secondaryUrl.isEmpty ||
+          secondaryUrl == 'data:null') {
+        throw SecondaryNotFoundException(
+            'Unable find secondary url for atSign:$atSign');
+      }
+      var secondaryInfo = LookUpUtil.getSecondaryInfo(secondaryUrl);
+      String secondaryHost = secondaryInfo[0];
+      int secondaryPort = int.parse(secondaryInfo[1]);
+      _add(atSign, SecondaryAddress(secondaryHost, secondaryPort));
+    } on Exception catch (e) {
+      _logger.severe(
+          'unable to find secondary address for atSign:$atSign - ${e.toString()}');
+      rethrow;
+    }
+    return _map[atSign]!;
+  }
+
+  void _add(String atSign, SecondaryAddress address) {
+    _map[atSign] = address;
+    Future.delayed(Duration(hours: expiryHrs), () => _remove(atSign));
+  }
+
+  void _remove(String atSign) {
+    _map.remove(atSign);
+  }
+}

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   at_utils: ^3.0.6
   at_commons: ^3.0.9
   mutex: ^3.0.0
+  mocktail: ^0.3.0
 
 #dependency_overrides:
 #  at_commons:

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -1,13 +1,69 @@
+import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/src/cache/secondary_address_cache.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockSecondaryFinder extends Mock implements SecondaryAddressFinder {}
 
 void main() async {
-  test(' test create a group', () async {
-    var secondaryAddress = await SecondaryAddressCacheImpl.getInstance()
-        .getAddress('@colin', 'root.atsign.org', 64);
-    expect(secondaryAddress.port, isNotNull);
-    expect(secondaryAddress.host, isNotNull);
-    print(secondaryAddress.toString());
+  String rootDomain = 'root.atsign.unit.tests';
+  int rootPort = 64;
+  SecondaryAddressFinder mockSecondaryFinder = MockSecondaryFinder();
+
+  String _addressFromAtSign(String atSign) {
+    if (atSign.startsWith('@')) {
+      atSign = atSign.replaceFirst('@', '');
+    }
+    return '$atSign.secondaries.unit.tests:1001';
+  }
+
+  group('this should be moved to functional tests', () {
+    test('look up @cicd1 from root.atsign.wtf:64', () async {
+      var secondaryAddress = await SecondaryAddressCache('root.atsign.wtf', 64)
+          .getAddress('@cicd1');
+      expect(secondaryAddress.port, isNotNull);
+      expect(secondaryAddress.host, isNotNull);
+      print(secondaryAddress.toString());
+    });
+  });
+
+  group('some cache tests', () {
+    late SecondaryAddressCache cache;
+
+    setUp(() {
+      reset(mockSecondaryFinder);
+      when(() => mockSecondaryFinder.findSecondary(any(that: startsWith('registered')), rootDomain, rootPort))
+          .thenAnswer((invocation) async => _addressFromAtSign(invocation.positionalArguments.first));
+      when(() => mockSecondaryFinder.findSecondary(any(that: startsWith('notRegistered')), rootDomain, rootPort))
+          .thenAnswer((invocation) async {
+        throw SecondaryNotFoundException(SecondaryAddressCache.getNotFoundExceptionMessage(invocation.positionalArguments.first));
+      });
+
+      cache = SecondaryAddressCache(rootDomain, rootPort, secondaryFinder: mockSecondaryFinder);
+    });
+
+    test('test simple lookup for @registeredAtSign1', () async {
+      var atSign = '@registeredAtSign1';
+      var secondaryAddress = await cache.getAddress(atSign);
+      expect(secondaryAddress.port, isNotNull);
+      expect(secondaryAddress.host, isNotNull);
+      expect(secondaryAddress.toString(), _addressFromAtSign(atSign));
+    });
+    test('test simple lookup for registeredAtSign1', () async {
+      var atSign = 'registeredAtSign1';
+      var secondaryAddress = await cache.getAddress(atSign);
+      expect(secondaryAddress.port, isNotNull);
+      expect(secondaryAddress.host, isNotNull);
+      expect(secondaryAddress.toString(), _addressFromAtSign(atSign));
+    });
+    test('test simple lookup for notRegisteredAtSign1', () async {
+      var atSign = 'notRegisteredAtSign1';
+      expect(
+          () async => await cache.getAddress(atSign),
+          throwsA(
+              predicate((e) => e is SecondaryNotFoundException && e.message == SecondaryAddressCache.getNotFoundExceptionMessage(atSign))));
+    });
+    // TODO add tests for isCached
   });
 }

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -108,6 +108,7 @@ void main() async {
 
     test('test update cache for atsign which is not yet cached', () async {
       var atSign = 'notCachedAtSign1';
+      expect(cache.cacheContains(atSign), false);
       await cache.getAddress(atSign, refreshCacheNow: true);
       expect(cache.cacheContains(atSign), true);
     });

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -1,0 +1,13 @@
+import 'package:at_lookup/src/cache/secondary_address_cache.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() async {
+  test(' test create a group', () async {
+    var secondaryAddress = await SecondaryAddressCacheImpl.getInstance()
+        .getAddress('@colin', 'root.atsign.org', 64);
+    expect(secondaryAddress.port, isNotNull);
+    expect(secondaryAddress.host, isNotNull);
+    print(secondaryAddress.toString());
+  });
+}

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -38,6 +38,10 @@ void main() async {
           .thenAnswer((invocation) async =>
               _addressFromAtSign(invocation.positionalArguments.first));
       when(() => mockSecondaryFinder.findSecondary(
+              any(that: startsWith('notCached')), rootDomain, rootPort))
+          .thenAnswer((invocation) async =>
+              _addressFromAtSign(invocation.positionalArguments.first));
+      when(() => mockSecondaryFinder.findSecondary(
               any(that: startsWith('notRegistered')), rootDomain, rootPort))
           .thenAnswer((invocation) async {
         throw SecondaryNotFoundException(
@@ -100,6 +104,12 @@ void main() async {
           DateTime.now().add(Duration(seconds: 30)).millisecondsSinceEpoch;
       expect(cache.getCacheExpiryTime(atSign), isNotNull);
       expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
+    });
+
+    test('test update cache for atsign which is not yet cached', () async {
+      var atSign = 'notCachedAtSign1';
+      await cache.getAddress(atSign, refreshCacheNow: true);
+      expect(cache.cacheContains(atSign), true);
     });
   });
 }

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -88,7 +88,6 @@ void main() async {
       await cache.getAddress(atSign);
       final approxExpiry =
           DateTime.now().add(Duration(hours: 1)).millisecondsSinceEpoch;
-      print(cache.getCacheExpiryTime(atSign));
       expect(cache.getCacheExpiryTime(atSign), isNotNull);
       expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
     });
@@ -99,8 +98,6 @@ void main() async {
       await cache.getAddress(atSign, cacheFor: Duration(seconds: 30));
       final approxExpiry =
           DateTime.now().add(Duration(seconds: 30)).millisecondsSinceEpoch;
-      print(cache.getCacheExpiryTime(atSign));
-      print(approxExpiry);
       expect(cache.getCacheExpiryTime(atSign), isNotNull);
       expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
     });


### PR DESCRIPTION
**- What I did**
- added cache for secondary url result from root server

**- How I did it**
- added SecondaryAddressCache to at_lookup 

**- How to verify it**
- run the unit test secondary_address_cache_test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->