### PR TITLE
publish at_lookup for secondary address cache

### DIFF
--- a/at_lookup/CHANGELOG.md
+++ b/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.17
+- Added cache for secondary url lookup from root server
 ## 3.0.16
 - Rename NotifyDelete to NotifyRemove
 ## 3.0.15

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.16
+version: 3.0.17
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
- publish at_lookup

**- How I did it**
- added changelog for secondary address cache
- changed pubspec version from 3.0.16 to 3.0.17
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->