### PR TITLE
export secondary cache from at_lookup

### DIFF
--- a/at_lookup/CHANGELOG.md
+++ b/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.19
+- Export secondary address cache from the package
+- Update at_commons and at_utils version
 ## 3.0.18
 - Updated dependencies
 ## 3.0.17

--- a/at_lookup/lib/at_lookup.dart
+++ b/at_lookup/lib/at_lookup.dart
@@ -9,3 +9,4 @@ export 'src/connection/outbound_connection.dart';
 export 'src/connection/outbound_connection_impl.dart';
 export 'src/exception/at_lookup_exception.dart';
 export 'src/monitor_client.dart';
+export 'src/cache/secondary_address_cache.dart';

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.18
+version: 3.0.19
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 
@@ -11,8 +11,8 @@ dependencies:
   path: ^1.8.0
   crypton: ^2.0.1
   crypto: ^3.0.1
-  at_utils: ^3.0.8
-  at_commons: ^3.0.11
+  at_utils: ^3.0.9
+  at_commons: ^3.0.13
   mutex: ^3.0.0
   mocktail: ^0.3.0
 


### PR DESCRIPTION
**- What I did**
- exported secondary address cache from at_lookup package
-  updated at_commons and at_utils version
**- How I did it**
- added secondary_address_cache.dart to at_lookup.dart
- updated pubspec.yaml  at_utils to ^3.0.9 and at_commons to ^3.0.13
 
