### PR TITLE
bug fix for find secondary

### DIFF
--- a/at_lookup/CHANGELOG.md
+++ b/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.22
+- find secondary bug fix
 ## 3.0.21
 - Added CacheableSecondaryAddressFinder
 ## 3.0.20

--- a/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:convert';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/src/cache/secondary_address_finder.dart';
 import 'package:at_lookup/src/util/lookup_util.dart';
 import 'package:at_utils/at_logger.dart';
+
 
 class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
   static const Duration defaultCacheDuration = Duration(hours: 1);
@@ -137,7 +139,7 @@ class SecondaryUrlFinder {
       socket = await SecureSocket.connect(_rootDomain, _rootPort);
       // listen to the received data event stream
       socket.listen((List<int> event) async {
-        answer = ''; //TODO utf8.decode(event);
+        answer = utf8.decode(event);
 
         if (answer.endsWith('@') && prompt == false && once == true) {
           prompt = true;

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.21
+version: 3.0.22
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/at_onboarding_cli/functional_tests/pubspec.yaml
+++ b/at_onboarding_cli/functional_tests/pubspec.yaml
@@ -11,12 +11,18 @@ dependencies:
   at_onboarding_cli:
     path: ../
 
-# dependency_overrides:
+dependency_overrides:
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: findsecondary_bug
 #   at_client:
 #         git:
 #           url: https://github.com/atsign-foundation/at_client_sdk.git
 #           path: at_client
 #           ref: trunk
+
 
 dev_dependencies:
   lints: ^1.0.0

--- a/at_onboarding_cli/pubspec.yaml
+++ b/at_onboarding_cli/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
    at_utils: ^3.0.4
    at_client: ^3.0.14
-   at_lookup: ^3.0.7
+   at_lookup: ^3.0.21
    zxing2: ^0.1.0
    image: ^3.1.1
    crypton: ^2.0.3
@@ -19,7 +19,13 @@ dependencies:
    at_server_status: ^1.0.3
    path: ^1.8.1
 
-# dependency_overrides:
+dependency_overrides:
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: findsecondary_bug
+
 #   at_client:
 #         git:
 #           url: https://github.com/atsign-foundation/at_client_sdk.git


### PR DESCRIPTION
**- What I did**
- decode of data in refactored CacheableSecondaryAddressFinder is missing due to accidental code comment

**- How I did it**
- uncommented the code
**- How to verify it**
- update functional tests/end2end test pubspec to use findsecondary_bug branch of at_lookup and run the tests
