### PR TITLE
feat: Add network checker before writing to socket

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -39,18 +39,18 @@ class AtLookupImpl implements AtLookUp {
 
   var outboundConnectionTimeout;
 
+  NetworkUtil networkUtil = NetworkUtil();
+
   AtLookupImpl(
     String atSign,
     String rootDomain,
     int rootPort, {
-    String? privateKey,
-    String? cramSecret,
+    String? this.privateKey,
+    String? this.cramSecret,
   }) {
     _currentAtSign = atSign;
     _rootDomain = rootDomain;
     _rootPort = rootPort;
-    this.privateKey = privateKey;
-    this.cramSecret = cramSecret;
   }
 
   @Deprecated('use CacheableSecondaryAddressFinder')
@@ -492,8 +492,12 @@ class AtLookupImpl implements AtLookUp {
     await _connection!.close();
   }
 
+  /// Throws [AtConnectException] if network is not available
   Future<void> _sendCommand(String command) async {
     await createConnection();
-    await _connection!.write(command);
+    // verify if network is available before writing to socket.
+    if (await networkUtil.checkConnectivity()) {
+      await _connection!.write(command);
+    }
   }
 }

--- a/at_lookup/lib/src/util/lookup_util.dart
+++ b/at_lookup/lib/src/util/lookup_util.dart
@@ -1,3 +1,6 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:internet_connection_checker/internet_connection_checker.dart';
+
 /// LookUpUtil class
 class LookUpUtil {
   /// Returns List contains domain and port
@@ -7,6 +10,16 @@ class LookUpUtil {
       var arr = url.split(':');
       result.add(arr[0]);
       result.add(arr[1]);
+    }
+    return result;
+  }
+}
+
+class NetworkUtil {
+  Future<bool> checkConnectivity() async {
+    var result = await InternetConnectionChecker().hasConnection;
+    if (!result) {
+      throw AtConnectException('Internet connection unavailable');
     }
     return result;
   }

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   at_commons: ^3.0.17
   mutex: ^3.0.0
   mocktail: ^0.3.0
+  internet_connection_checker: ^0.0.1+2
 
 #dependency_overrides:
 #  at_commons:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Add check network connectivity before writing command to server. If network connectivity fails throws `AtConnectException`

Fixes the [issue-546](https://github.com/atsign-foundation/at_client_sdk/issues/546), where at_lookup throws exception when there is no network and the apps might have to initiate a retry.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->