### PR TITLE
fix: handle partial prompt response and add unit tests

### DIFF
--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -8,48 +8,88 @@ import 'package:at_utils/at_logger.dart';
 ///Listener class for messages received by [RemoteSecondary]
 class OutboundMessageListener {
   final logger = AtSignLogger('OutboundMessageListener');
-  final _buffer = ByteBuffer(capacity: 10240000);
-  late Queue _queue;
+  late ByteBuffer _buffer;
+  final Queue _queue = Queue();
   final _connection;
   Function? syncCallback;
+  final int newLineCodeUnit = 10;
+  final int atCharCodeUnit = 64;
 
-  OutboundMessageListener(this._connection);
+  OutboundMessageListener(this._connection, {int bufferCapacity = 10240000}) {
+    _buffer = ByteBuffer(capacity: bufferCapacity);
+  }
 
   /// Listens to the underlying connection's socket if the connection is created.
   /// @throws [AtConnectException] if the connection is not yet created
   void listen() {
-    _connection.getSocket().listen(_messageHandler,
+    _connection.getSocket().listen(messageHandler,
         onDone: _finishedHandler, onError: _errorHandler);
-    _queue = Queue();
   }
 
   /// Handles messages on the inbound client's connection and calls the verb executor
   /// Closes the inbound connection in case of any error.
   /// Throw a [BufferOverFlowException] if buffer is unable to hold incoming data
-  Future<void> _messageHandler(data) async {
+  Future<void> messageHandler(List data) async {
     String result;
-    if (!_buffer.isOverFlow(data)) {
-      // skip @ prompt
-      if (data.length == 1 && data.first == 64) {
-        return;
-      }
-      //ignore prompt(@ or @<atSign>@) after '\n'
-      // If data contains 10(utf8 character for '\n'), trim the string after the '\n'
-      if (data.contains(10)) {
-        data = data.sublist(0, data.lastIndexOf(10) + 1);
-      }
-      _buffer.append(data);
+    var offset;
+    // check buffer overflow
+    _checkBufferOverFlow(data);
+
+    // If the data contains a new line character, add until the new line char to buffer
+    if (data.contains(newLineCodeUnit)) {
+      offset = data.lastIndexOf(newLineCodeUnit);
+      var dataSubList = data.getRange(0, offset).toList();
+      _buffer.append(dataSubList);
     } else {
+      offset = 0;
+    }
+    // Loop from last index to until the end of data.
+    // If a new line character and followed by @ character is found, then it is end
+    // of server response. process the data.
+    // Else add the byte to buffer.
+    for (int element = offset; element < data.length; element++) {
+      // If element is @ character and lastCharacter in the buffer is \n,
+      // then complete data is received. process it.
+      if (data[element] == atCharCodeUnit &&
+          _buffer.getData().last == newLineCodeUnit) {
+        // remove the terminating character (last \n) from the server response.
+        // preserve other new line characters.
+        List<int> temp = (_buffer.getData().toList())..removeLast();
+        result = utf8.decode(temp);
+        result = _stripPrompt(result);
+        _queue.add(result);
+        //clear the buffer after adding result to queue
+        _buffer.clear();
+        _buffer.addByte(data[element]);
+      } else {
+        _buffer.addByte(data[element]);
+      }
+    }
+  }
+
+  /// The methods verifies if buffer has the capacity to accept the data.
+  ///
+  /// Throw BufferOverFlowException if data length exceeds the buffer capacity
+  _checkBufferOverFlow(data) {
+    if (_buffer.isOverFlow(data)) {
+      int bufferLength = (_buffer.length() + data.length) as int;
       _buffer.clear();
       throw BufferOverFlowException(
-          'Buffer overflow on outbound connection result');
+          'data length exceeded the buffer limit. Data length : $bufferLength and Buffer capacity ${_buffer.capacity}');
     }
-    if (_buffer.isEnd()) {
-      result = utf8.decode(_buffer.getData());
-      result = result.trim();
-      _buffer.clear();
-      _queue.add(result);
+  }
+
+  /// The method accepts the result (server response) and trim's the prompt from the response
+  /// and returns the actual response.
+  String _stripPrompt(String result) {
+    var colonIndex = result.indexOf(':');
+    var responsePrefix = result.substring(0, colonIndex);
+    var response = result.substring(colonIndex);
+    if (responsePrefix.contains('@')) {
+      responsePrefix =
+          responsePrefix.substring(responsePrefix.lastIndexOf('@') + 1);
     }
+    return '$responsePrefix$response';
   }
 
   /// Reads the response sent by remote socket from the queue.

--- a/at_lookup/test/outbound_message_listener_test.dart
+++ b/at_lookup/test/outbound_message_listener_test.dart
@@ -1,0 +1,179 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockOutboundConnectionImpl extends Mock
+    implements OutboundConnectionImpl {}
+
+void main() {
+  OutboundConnection mockOutBoundConnection = MockOutboundConnectionImpl();
+
+  group('A group of tests to verify buffer of outbound message listener', () {
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(mockOutBoundConnection);
+    test('A test to validate complete data comes in single packet', () async {
+      outboundMessageListener
+          .messageHandler('data:phone@alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:phone@alice');
+    });
+
+    test(
+        'A test to validate complete data comes in packet and prompt in different packet',
+        () async {
+      outboundMessageListener
+          .messageHandler('data:@bob:phone@alice\n'.codeUnits);
+      outboundMessageListener.messageHandler('@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:@bob:phone@alice');
+    });
+
+    test('A test to validate data two complete data comes in single packets',
+        () async {
+      outboundMessageListener
+          .messageHandler('data:@bob:phone@alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:@bob:phone@alice');
+      outboundMessageListener
+          .messageHandler('data:public:phone@alice\n@alice@'.codeUnits);
+      response = await outboundMessageListener.read();
+      expect(response, 'data:public:phone@alice');
+    });
+
+    test('A test to validate data two complete data comes in multiple packets',
+        () async {
+      outboundMessageListener
+          .messageHandler('data:public:phone@alice\n@ali'.codeUnits);
+      outboundMessageListener.messageHandler('ce@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:public:phone@alice');
+      outboundMessageListener.messageHandler(
+          'data:@bob:location@alice,@bob:phone@alice\n@alice@'.codeUnits);
+      response = await outboundMessageListener.read();
+      expect(response, 'data:@bob:location@alice,@bob:phone@alice');
+    });
+
+    test('A test to validate single data comes two packets', () async {
+      outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      outboundMessageListener.messageHandler('alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:public:phone@alice');
+    });
+
+    test('A test to validate data contains @', () async {
+      outboundMessageListener
+          .messageHandler('data:phone@alice_12345675\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:phone@alice_12345675');
+    });
+
+    test(
+        'A test to validate data contains @ and partial prompt of previous data',
+        () async {
+      // partial response of previous data.
+      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      outboundMessageListener.messageHandler('alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:hello');
+      outboundMessageListener
+          .messageHandler('data:phone@alice_12345675\n@alice@'.codeUnits);
+      response = await outboundMessageListener.read();
+      expect(response, 'data:phone@alice_12345675');
+    });
+
+    test('A test to validate data contains new line character', () async {
+      outboundMessageListener.messageHandler(
+          'data:value_contains_\nin_the_value\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:value_contains_\nin_the_value');
+    });
+
+    test('A test to validate data contains new line character and @', () async {
+      outboundMessageListener.messageHandler(
+          'data:the_key_is\n@bob:phone@alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:the_key_is\n@bob:phone@alice');
+    });
+  });
+
+  group('A group of test to verify response from unauth connection', () {
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(mockOutBoundConnection);
+    test('A test to validate response from unauth connection', () async {
+      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:hello');
+    });
+
+    test('A test to validate multiple response from unauth connection',
+        () async {
+      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:hello');
+      outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
+      response = await outboundMessageListener.read();
+      expect(response, 'data:hi');
+    });
+
+    test(
+        'A test to validate response from unauth connection in multiple packets',
+        () async {
+      outboundMessageListener
+          .messageHandler('data:public:location@alice,'.codeUnits);
+      outboundMessageListener.messageHandler('public:phone@alice\n@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'data:public:location@alice,public:phone@alice');
+      outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
+      response = await outboundMessageListener.read();
+      expect(response, 'data:hi');
+    });
+  });
+
+  group('A group of test to validate buffer over flow scenarios', () {
+    test('A test to verify buffer over flow exception', () {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutBoundConnection, bufferCapacity: 10);
+      expect(
+          () => outboundMessageListener
+              .messageHandler('data:dummy_data_to_exceed_limit'.codeUnits),
+          throwsA(predicate((dynamic e) =>
+              e is BufferOverFlowException &&
+              e.message ==
+                  'data length exceeded the buffer limit. Data length : 31 and Buffer capacity 10')));
+    });
+
+    test('A test to verify buffer over flow with multiple data packets', () {
+      OutboundMessageListener outboundMessageListener =
+          OutboundMessageListener(mockOutBoundConnection, bufferCapacity: 20);
+      outboundMessageListener.messageHandler('data:dummy_data'.codeUnits);
+      expect(
+          () => outboundMessageListener
+              .messageHandler('to_exceed_limit\n@alice@'.codeUnits),
+          throwsA(predicate((dynamic e) =>
+              e is BufferOverFlowException &&
+              e.message ==
+                  'data length exceeded the buffer limit. Data length : 38 and Buffer capacity 20')));
+    });
+  });
+
+  group('A group of tests to verify error: and stream responses from server',
+      () {
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(mockOutBoundConnection);
+    test('A test to validate complete error comes in single packet', () async {
+      outboundMessageListener.messageHandler(
+          'error:AT0012: Invalid value found\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'error:AT0012: Invalid value found');
+    });
+
+    test('A test to validate complete error comes in single packet', () async {
+      outboundMessageListener
+          .messageHandler('stream:@bob:phone@alice\n@alice@'.codeUnits);
+      var response = await outboundMessageListener.read();
+      expect(response, 'stream:@bob:phone@alice');
+    });
+  });
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
With the current logic in `messageHandler`, if a partial prompt response is received, then the partial responses gets appended to subsequent responses.

**- What I did**
1. Refactor the messageHandler code as follows:
    - Add data to the buffer until we encounter a terminating character (new line character - \n)
    - Decode the data to the String format.
    - Trim the prompt the from the String format
    - Check if response as partial prompt appended from the previous responses. If yes trim it as well
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->