### PR TITLE
fix: ignore initial server response.

### DIFF
--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -34,7 +34,10 @@ class OutboundMessageListener {
     var offset;
     // check buffer overflow
     _checkBufferOverFlow(data);
-
+    // When a new connection is established server returns `@` prompt.Skip it
+    if (data.length == 1 && data.first == atCharCodeUnit) {
+      return;
+    }
     // If the data contains a new line character, add until the new line char to buffer
     if (data.contains(newLineCodeUnit)) {
       offset = data.lastIndexOf(newLineCodeUnit);

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -34,10 +34,6 @@ class OutboundMessageListener {
     var offset;
     // check buffer overflow
     _checkBufferOverFlow(data);
-    // When a new connection is established server returns `@` prompt.Skip it
-    if (data.length == 1 && data.first == atCharCodeUnit) {
-      return;
-    }
     // If the data contains a new line character, add until the new line char to buffer
     if (data.contains(newLineCodeUnit)) {
       offset = data.lastIndexOf(newLineCodeUnit);
@@ -54,7 +50,7 @@ class OutboundMessageListener {
       // If element is @ character and lastCharacter in the buffer is \n,
       // then complete data is received. process it.
       if (data[element] == atCharCodeUnit &&
-          _buffer.getData().last == newLineCodeUnit) {
+          (_buffer.length() > 0 && _buffer.getData().last == newLineCodeUnit)) {
         // remove the terminating character (last \n) from the server response.
         // preserve other new line characters.
         List<int> temp = (_buffer.getData().toList())..removeLast();

--- a/at_onboarding_cli/functional_tests/pubspec.yaml
+++ b/at_onboarding_cli/functional_tests/pubspec.yaml
@@ -13,10 +13,7 @@ dependencies:
 
 dependency_overrides:
   at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: trunk
+    path: ../../at_lookup
   at_client:
     git:
       url: https://github.com/atsign-foundation/at_client_sdk.git


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. When new connection is established, ignore the initial server response - `@`
2. Edit the pubspec.yaml of onboarding functional test to pick the at_lookup from the path. So that the current branch at_lookup package is picked up.

**- How I did it**
1. Added an IF condition that ignores, the `@` prompt.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->