### PR TITLE
test: Added a test to verify core mutex behaviour

### DIFF
--- a/at_lookup/test/mutex_test.dart
+++ b/at_lookup/test/mutex_test.dart
@@ -1,0 +1,42 @@
+import 'package:mutex/mutex.dart';
+import 'package:test/test.dart';
+
+void main() {
+  List<String> criticalSectionEvents = [];
+  Future<void> criticalSection(String eventName, Mutex m, int delayInMillis) async {
+    print ('criticalSection $eventName starting');
+    try {
+      await m.acquire();
+      criticalSectionEvents.add("$eventName acquired mutex");
+
+      print("criticalSection $eventName acquired mutex");
+      await Future.delayed(Duration(milliseconds: 10));
+
+      print("criticalSection $eventName delaying for $delayInMillis milliseconds");
+      await Future.delayed(Duration(milliseconds: delayInMillis));
+
+      criticalSectionEvents.add("$eventName criticalSection completed");
+
+    } finally {
+      print ("criticalSection $eventName released mutex");
+      m.release();
+      criticalSectionEvents.add("$eventName released mutex");
+    }
+  }
+  test('Verify mutex core behaviour', () async {
+    Mutex m = Mutex();
+    criticalSection("One", m, 100); // delay for 100 milliseconds so next 'criticalSection' gets a chance to run
+    criticalSection("Two", m, 10);
+
+    await Future.delayed(Duration(milliseconds: 200));
+
+    expect(criticalSectionEvents.length, 6);
+    expect(criticalSectionEvents[0], "One acquired mutex");
+    expect(criticalSectionEvents[1], "One criticalSection completed");
+    expect(criticalSectionEvents[2], "One released mutex");
+    expect(criticalSectionEvents[3], "Two acquired mutex");
+    expect(criticalSectionEvents[4], "Two criticalSection completed");
+    expect(criticalSectionEvents[5], "Two released mutex");
+  });
+
+}

--- a/at_lookup/test/outbound_message_listener_test.dart
+++ b/at_lookup/test/outbound_message_listener_test.dart
@@ -11,43 +11,6 @@ class MockOutboundConnectionImpl extends Mock
 void main() {
   OutboundConnection mockOutBoundConnection = MockOutboundConnectionImpl();
 
-  List<String> criticalSectionEvents = [];
-  Future<void> criticalSection(String eventName, Mutex m, int delayInMillis) async {
-    print ('criticalSection $eventName starting');
-    try {
-      await m.acquire();
-      criticalSectionEvents.add("$eventName acquired mutex");
-
-      print("criticalSection $eventName acquired mutex");
-      await Future.delayed(Duration(milliseconds: 10));
-
-      print("criticalSection $eventName delaying for $delayInMillis milliseconds");
-      await Future.delayed(Duration(milliseconds: delayInMillis));
-
-      criticalSectionEvents.add("$eventName criticalSection completed");
-
-    } finally {
-      print ("criticalSection $eventName released mutex");
-      m.release();
-      criticalSectionEvents.add("$eventName released mutex");
-    }
-  }
-  test('Verify mutex core behaviour', () async {
-    Mutex m = Mutex();
-    criticalSection("One", m, 100); // delay for 100 milliseconds so next 'criticalSection' gets a chance to run
-    criticalSection("Two", m, 10);
-
-    await Future.delayed(Duration(milliseconds: 200));
-
-    expect(criticalSectionEvents.length, 6);
-    expect(criticalSectionEvents[0], "One acquired mutex");
-    expect(criticalSectionEvents[1], "One criticalSection completed");
-    expect(criticalSectionEvents[2], "One released mutex");
-    expect(criticalSectionEvents[3], "Two acquired mutex");
-    expect(criticalSectionEvents[4], "Two criticalSection completed");
-    expect(criticalSectionEvents[5], "Two released mutex");
-  });
-
   group('A group of tests to verify buffer of outbound message listener', () {
     OutboundMessageListener outboundMessageListener =
         OutboundMessageListener(mockOutBoundConnection);


### PR DESCRIPTION
**- What I did**
Added a test to verify core mutex behaviour

**- How I did it**
Added a test case which asserts that appropriate use of `await mutex.acquired()` and `mutex.release()` wrapping critical sections code does indeed result in expected behaviour with critical sections executing sequentially not concurrently.

**- How to verify it**
Test passes

**- Description for the changelog**
Added a test to verify core mutex behaviour

