### PR TITLE
feat: Added support for easy connection to an AtSecondaryReverseProxy

### DIFF
--- a/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -122,7 +122,16 @@ class SecondaryUrlFinder {
   SecondaryUrlFinder(this._rootDomain, this._rootPort);
 
   Future<String?> findSecondaryUrl(String atSign) async {
-    return await _findSecondary(atSign);
+    if (_rootDomain.startsWith("proxy:")) {
+      // In order to make it easy for clients to connect to a reverse proxy
+      // instead of doing a root lookup,  we adopt the convention that:
+      // if the rootDomain starts with 'proxy:'
+      // then the secondary domain name will be deemed to be the portion of rootDomain after 'proxy:'
+      // and the secondary port will be deemed to be the rootPort
+      return '${_rootDomain.substring("proxy:".length)}:$_rootPort';
+    } else {
+      return await _findSecondary(atSign);
+    }
   }
 
   Future<String?> _findSecondary(String atsign) async {

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -99,6 +99,7 @@ void main() async {
       expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
     });
 
+    // TODO Why are these tests commented out?
 //    test('test expiry time  - custom cache expiry for registeredAtSign1',
 //        () async {
 //      var atSign = 'registeredAtSign1';

--- a/at_lookup/test/secondary_address_cache_test.dart
+++ b/at_lookup/test/secondary_address_cache_test.dart
@@ -7,17 +7,6 @@ import 'package:mocktail/mocktail.dart';
 class MockSecondaryFinder extends Mock implements SecondaryUrlFinder {}
 
 void main() async {
-  String rootDomain = 'root.atsign.unit.tests';
-  int rootPort = 64;
-  SecondaryUrlFinder mockSecondaryFinder = MockSecondaryFinder();
-
-  String _addressFromAtSign(String atSign) {
-    if (atSign.startsWith('@')) {
-      atSign = atSign.replaceFirst('@', '');
-    }
-    return '$atSign.secondaries.unit.tests:1001';
-  }
-
   group('this should be moved to functional tests', () {
     test('look up @cicd1 from root.atsign.wtf:64', () async {
       var secondaryAddress =
@@ -29,7 +18,19 @@ void main() async {
     });
   });
 
-  group('some cache tests', () {
+  group('some cache tests with a MockSecondaryFinder', () {
+    String rootDomain = 'root.atsign.unit.tests';
+    int rootPort = 64;
+
+    SecondaryUrlFinder mockSecondaryFinder = MockSecondaryFinder();
+
+    String _addressFromAtSign(String atSign) {
+      if (atSign.startsWith('@')) {
+        atSign = atSign.replaceFirst('@', '');
+      }
+      return '$atSign.secondaries.unit.tests:1001';
+    }
+
     late CacheableSecondaryAddressFinder cache;
 
     setUp(() {
@@ -114,5 +115,51 @@ void main() async {
 //      await cache.findSecondary(atSign, refreshCacheNow: true);
 //      expect(cache.cacheContains(atSign), true);
 //    });
+  });
+
+  group('some cache tests with a real SecondaryUrlFinder but with rootDomain set to proxy:<something>', () {
+    String proxyHost = 'vip.ve.atsign.zone';
+    String rootDomain = 'proxy:$proxyHost';
+    int rootPort = 8443;
+
+    String _addressFromAtSign(String atSign) {
+      return '$proxyHost:$rootPort';
+    }
+
+    late CacheableSecondaryAddressFinder cache;
+
+    setUp(() {
+      cache = CacheableSecondaryAddressFinder(rootDomain, rootPort);
+    });
+
+    test('test simple lookup for @registeredAtSign1', () async {
+      var atSign = '@registeredAtSign1';
+      var secondaryAddress = await cache.findSecondary(atSign);
+      expect(secondaryAddress.port, isNotNull);
+      expect(secondaryAddress.host, isNotNull);
+      expect(secondaryAddress.toString(), _addressFromAtSign(atSign));
+    });
+    test('test simple lookup for registeredAtSign1', () async {
+      var atSign = 'registeredAtSign1';
+      var secondaryAddress = await cache.findSecondary(atSign);
+      expect(secondaryAddress.port, isNotNull);
+      expect(secondaryAddress.host, isNotNull);
+      expect(secondaryAddress.toString(), _addressFromAtSign(atSign));
+    });
+    test('test isCached for registeredAtSign1', () async {
+      var atSign = 'registeredAtSign1';
+      await cache.findSecondary(atSign);
+      expect(cache.cacheContains(atSign), true);
+    });
+
+    test('test expiry time - default cache expiry for registeredAtSign1',
+        () async {
+      var atSign = 'registeredAtSign1';
+      await cache.findSecondary(atSign);
+      final approxExpiry =
+          DateTime.now().add(Duration(hours: 1)).millisecondsSinceEpoch;
+      expect(cache.getCacheExpiryTime(atSign), isNotNull);
+      expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
+    });
   });
 }


### PR DESCRIPTION
**- What I did**
Feat: Enhanced SecondaryUrlFinder so by convention it will return a secondary address of `<proxy domain>:<'root' port> ` when rootDomain is supplied as `'proxy:<proxy domain>'` and `'rootPort'` is supplied as the port on which the reverse proxy is listening

e.g. rootDomain of 'proxy:vip.ve.atsign.zone' and rootPort of '8443' will result in all secondary lookups returning the same address, being the address of the proxy : `vip.ve.atsign.zone:8443` in this example

Test: Added tests to verify behaviour of CacheableSecondaryAddressFinder with rootDomain set to 'proxy:<something>'

**- How to verify it**
Tests should pass. For end-to-end full verification, see instructions [here](https://github.com/atsign-foundation/at_services/blob/trunk/at_secondary_proxy/README.md#usage) for setting up an AtSecondaryServer reverse proxy 

**- Description for the changelog**
Feat: Added support for easy connection to an AtSecondaryReverseProxy