### PR TITLE
fix: make the request-response mutex apply to all AtLookupImpl instances

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -436,11 +436,13 @@ class AtLookupImpl implements AtLookUp {
     );
   }
 
-  Mutex requestResponseMutex = Mutex();
+  /// Making this mutex static (thus global) because we are suspicious of SecureSocket multiplexing
+  /// within Dart.
+  static Mutex globalRequestResponseMutex = Mutex();
 
   Future<String> _process(String command, {bool auth = false}) async {
     try {
-      await requestResponseMutex.acquire();
+      await globalRequestResponseMutex.acquire();
 
       if (auth && _isAuthRequired()) {
         if (privateKey != null) {
@@ -461,7 +463,7 @@ class AtLookupImpl implements AtLookUp {
         rethrow;
       }
     } finally {
-      requestResponseMutex.release();
+      globalRequestResponseMutex.release();
     }
   }
 


### PR DESCRIPTION
**- What I did**
fix: make the mutex around request-response apply to all AtLookupImpl instances, not just a single instance 

**Note:** This is a workaround for a problem we suspect might exist in SecureSocket multiplexing

**- How I did it**
Made the `requestResponseMutex` variable static; and renamed it to `globalRequestResponseMutex`

**- How to verify it**
Should have no unexpected side-effects in application

**- Description for the changelog**
fix: make the mutex around request-response apply to all AtLookupImpl instances, not just a single instance 
