### PR TITLE
feat: Log, at FINER, all requests and responses made via AtLookup

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -205,6 +205,7 @@ class AtLookupImpl implements AtLookUp {
 
   Future<void> createConnection() async {
     if (!isConnectionAvailable()) {
+      logger.info('Creating new connection');
       //1. find secondary url for atsign from lookup library
       var secondaryUrl =
           await findSecondary(_currentAtSign, _rootDomain, _rootPort);
@@ -498,6 +499,7 @@ class AtLookupImpl implements AtLookUp {
 
   Future<void> _sendCommand(String command) async {
     await createConnection();
+    logger.finer('SENDING: $command');
     await _connection!.write(command);
   }
 }

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -56,6 +56,7 @@ class OutboundMessageListener {
         List<int> temp = (_buffer.getData().toList())..removeLast();
         result = utf8.decode(temp);
         result = _stripPrompt(result);
+        logger.finer('RECEIVED $result');
         _queue.add(result);
         //clear the buffer after adding result to queue
         _buffer.clear();


### PR DESCRIPTION
**- What I did**
Log, at FINER, all requests and responses made via AtLookup

**- How I did it**
* Added `logger.finer('SENDING: $command');` to the _sendCommand method in AtLookupImpl
* Added `logger.finer('RECEIVED $result');` to messageHandler in OutboundMessageListener

**- How to verify it**
* If you set log level to FINER in your client, you should see all AtLookupImpl-originating requests and responses logged.

**- Description for the changelog**
feat: Log, at FINER, all requests and responses made via AtLookup