### PR TITLE
feat: Improve timeout handling in OutboundMessageListener

### DIFF
--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -96,7 +96,7 @@ class OutboundMessageListener {
   /// Reads the response sent by remote socket from the queue.
   /// If there is no message in queue after [maxWaitMilliSeconds], return null. Defaults to 90 seconds.
   Future<String> read(
-      {int maxWaitMillis = 90000, int transientWaitTimeMillis = 10000}) async {
+      {int maxWaitMilliSeconds = 90000, int transientWaitTimeMillis = 10000}) async {
     String result;
     _lastReceivedTime = DateTime.now();
     var startTime = DateTime.now();

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -95,8 +95,11 @@ class OutboundMessageListener {
 
   /// Reads the response sent by remote socket from the queue.
   /// If there is no message in queue after [maxWaitMilliSeconds], return null. Defaults to 90 seconds.
+  /// Whenever data is received on client socket from server, [_lastReceivedTime] will be updated to current time.
+  /// [transientWaitTimeMillis] specifies the max duration to wait between current time and [_lastReceivedTime] before timing out.Defaults to 10 seconds.
   Future<String> read(
-      {int maxWaitMilliSeconds = 90000, int transientWaitTimeMillis = 10000}) async {
+      {int maxWaitMilliSeconds = 90000,
+      int transientWaitTimeMillis = 10000}) async {
     String result;
     _lastReceivedTime = DateTime.now();
     var startTime = DateTime.now();
@@ -115,7 +118,8 @@ class OutboundMessageListener {
       }
 
       // if currentTime - startTime  is greater than maxWaitMillis throw AtTimeoutException
-      if (DateTime.now().difference(startTime).inMilliseconds > maxWaitMilliSeconds) {
+      if (DateTime.now().difference(startTime).inMilliseconds >
+          maxWaitMilliSeconds) {
         _buffer.clear();
         _closeConnection();
         throw AtTimeoutException(
@@ -125,7 +129,6 @@ class OutboundMessageListener {
       // transientWaitTimeMillis throw AtTimeoutException
       if (DateTime.now().difference(_lastReceivedTime).inMilliseconds >
           transientWaitTimeMillis) {
-        // no message in queue even after waiting beyond maxWaitMillis
         _buffer.clear();
         _closeConnection();
         throw AtTimeoutException(

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -117,12 +117,14 @@ class OutboundMessageListener {
       throw AtLookUpException('AT0014', 'Unexpected response found');
     }
 
+    // incomplete message. Wait for 500ms and read again.
     if (_buffer.length() > 0 && !_buffer.isEnd()) {
       Future.delayed(Duration(milliseconds: transientWaitTimeMillis));
       totalWaitTime += transientWaitTimeMillis;
       if (totalWaitTime > maxWaitMillis) {
+        // no message in queue even after waiting beyond maxWaitMillis
         _buffer.clear();
-        // #TODO destroy socket
+        _closeConnection();
         throw AtTimeoutException(
             'No response after $maxWaitMillis millis from remote secondary');
       }

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -129,7 +129,7 @@ class OutboundMessageListener {
         _buffer.clear();
         _closeConnection();
         throw AtTimeoutException(
-            'Waited for $transientWaitTimeMillis. No response after $_lastReceivedTime ');
+            'Waited for $transientWaitTimeMillis millis. No response after $_lastReceivedTime ');
       }
       // wait for 10 ms before attempting to read from queue again
       await Future.delayed(Duration(milliseconds: 10));

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -97,16 +97,15 @@ class OutboundMessageListener {
     return _read(maxWaitMillis: maxWaitMilliSeconds);
   }
 
-  Future<String> _read({int maxWaitMillis = 10000, int retryCount = 1}) async {
+  Future<String> _read(
+      {int maxWaitMillis = 10000,
+      int retryCount = 1,
+      int transientWaitTimeMillis = 500}) async {
     String result;
-    var maxIterations = maxWaitMillis / 10;
-    if (retryCount == maxIterations) {
-      _buffer.clear();
-      throw AtTimeoutException(
-          'No response after $maxWaitMillis millis from remote secondary');
-    }
+    int totalWaitTime = 0;
     var queueLength = _queue.length;
     if (queueLength > 0) {
+      totalWaitTime = 0;
       result = _queue.removeFirst();
       // result from another secondary is either data or a @<atSign>@ denoting complete
       // of the handshake
@@ -117,8 +116,18 @@ class OutboundMessageListener {
       _buffer.clear();
       throw AtLookUpException('AT0014', 'Unexpected response found');
     }
-    return Future.delayed(Duration(milliseconds: 10))
-        .then((value) => _read(retryCount: ++retryCount));
+
+    if (_buffer.length() > 0 && !_buffer.isEnd()) {
+      Future.delayed(Duration(milliseconds: transientWaitTimeMillis));
+      totalWaitTime += transientWaitTimeMillis;
+      if (totalWaitTime > maxWaitMillis) {
+        _buffer.clear();
+        // #TODO destroy socket
+        throw AtTimeoutException(
+            'No response after $maxWaitMillis millis from remote secondary');
+      }
+    }
+    return Future.delayed(Duration(milliseconds: 10)).then((value) => _read());
   }
 
   bool _isValidResponse(String result) {

--- a/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -115,11 +115,11 @@ class OutboundMessageListener {
       }
 
       // if currentTime - startTime  is greater than maxWaitMillis throw AtTimeoutException
-      if (DateTime.now().difference(startTime).inMilliseconds > maxWaitMillis) {
+      if (DateTime.now().difference(startTime).inMilliseconds > maxWaitMilliSeconds) {
         _buffer.clear();
         _closeConnection();
         throw AtTimeoutException(
-            'Full response not received after $maxWaitMillis millis from remote secondary');
+            'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
       }
       // if no data is received from server and if currentTime - _lastReceivedTime is greater than
       // transientWaitTimeMillis throw AtTimeoutException

--- a/at_lookup/test/outbound_message_listener_test.dart
+++ b/at_lookup/test/outbound_message_listener_test.dart
@@ -237,5 +237,57 @@ void main() {
               e.message ==
                   'Full response not received after 2000 millis from remote secondary')));
     });
+    test(
+        'A test to verify full response received - delay between messages from server',
+        () async {
+      String? response;
+      outboundMessageListener
+          .read()
+          .whenComplete(() => {})
+          .then((value) => {response = value});
+      outboundMessageListener.messageHandler('data:'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 250));
+      outboundMessageListener.messageHandler('12'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 150));
+      outboundMessageListener.messageHandler('34'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 175));
+      outboundMessageListener.messageHandler('56'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 300));
+      outboundMessageListener.messageHandler('78'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 500));
+      outboundMessageListener.messageHandler('910\n@'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 500));
+      expect(response, isNotEmpty);
+      expect(response, 'data:12345678910');
+    });
+    test('A test to verify timeout - delay between messages from server',
+        () async {
+      String? response;
+      outboundMessageListener
+          .read(maxWaitMilliSeconds: 5000)
+          .catchError((e) {
+            return e.toString();
+          })
+          .whenComplete(() => {})
+          .then((value) => {response = value});
+      outboundMessageListener.messageHandler('data:'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 250));
+      outboundMessageListener.messageHandler('12'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 150));
+      outboundMessageListener.messageHandler('34'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 175));
+      outboundMessageListener.messageHandler('56'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 300));
+      outboundMessageListener.messageHandler('78'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 500));
+      outboundMessageListener.messageHandler('910'.codeUnits);
+      await Future.delayed(Duration(milliseconds: 5000));
+      expect(response, isNotEmpty);
+      expect(
+        response!.contains(
+            'Full response not received after 5000 millis from remote secondary'),
+        true,
+      );
+    });
   });
 }

--- a/at_lookup/test/outbound_message_listener_test.dart
+++ b/at_lookup/test/outbound_message_listener_test.dart
@@ -206,7 +206,7 @@ void main() {
       outboundMessageListener.messageHandler('56'.codeUnits);
       outboundMessageListener.messageHandler('78'.codeUnits);
       expect(
-          () async => await outboundMessageListener.read(maxWaitMillis: 2000),
+          () async => await outboundMessageListener.read(maxWaitMilliSeconds: 2000),
           throwsA(predicate((dynamic e) =>
               e is AtTimeoutException &&
               e.message ==


### PR DESCRIPTION
**- What I did**
* Replaced retries and absolute wait time with transient time out
**- How I did it**
* introduced option param transientWaitTimeMillis in read method of outbound_message_listener.dart. Added _lastReceivedTime
* when partial response is received from server and full response is not received within transientWaitTimeMillis , throw timeout exception
* when data arrives set _lastReceivedTime
* even after waiting for transientWaitTimeMillis, if full message is not received until maxWaitMillis, close connection and  throw timeoutexception
**- How to verify it**
Run the unit test group - A group of tests to verify AtTimeOutException in outbound_message_listener.dart
