### PR TITLE
feat: Add isAuthenticated to AtConnectionMetadata

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -19,10 +19,6 @@ class AtLookupImpl implements AtLookUp {
   /// Listener for reading verb responses from the remote server
   late OutboundMessageListener messageListener;
 
-  bool _isPkamAuthenticated = false;
-
-  bool _isCramAuthenticated = false;
-
   OutboundConnection? _connection;
 
   OutboundConnection? get connection => _connection;
@@ -358,9 +354,10 @@ class AtLookupImpl implements AtLookUp {
     if (privateKey == null) {
       throw UnAuthenticatedException('Private key not passed');
     }
+    await createConnection();
     try {
       _pkamAuthenticationMutex.acquire();
-      if (!_isPkamAuthenticated) {
+      if (!_connection!.getMetaData()!.isAuthenticated) {
         await _sendCommand('from:$_currentAtSign\n');
         var fromResponse = await (messageListener.read());
         logger.finer('from result:$fromResponse');
@@ -378,13 +375,13 @@ class AtLookupImpl implements AtLookUp {
         var pkamResponse = await messageListener.read();
         if (pkamResponse == 'data:success') {
           logger.info('auth success');
-          _isPkamAuthenticated = true;
+          _connection!.getMetaData()!.isAuthenticated = true;
         } else {
           throw UnAuthenticatedException(
               'Failed connecting to $_currentAtSign. $pkamResponse');
         }
       }
-      return _isPkamAuthenticated;
+      return _connection!.getMetaData()!.isAuthenticated;
     } finally {
       _pkamAuthenticationMutex.release();
     }
@@ -399,9 +396,10 @@ class AtLookupImpl implements AtLookUp {
     if (secret == null) {
       throw UnAuthenticatedException('Cram secret not passed');
     }
+    await createConnection();
     try {
       _cramAuthenticationMutex.acquire();
-      if (!_isCramAuthenticated) {
+      if (!_connection!.getMetaData()!.isAuthenticated) {
         await _sendCommand('from:$_currentAtSign\n');
         var fromResponse = await messageListener.read();
         logger.info('from result:$fromResponse');
@@ -416,12 +414,12 @@ class AtLookupImpl implements AtLookUp {
         var cramResponse = await messageListener.read();
         if (cramResponse == 'data:success') {
           logger.info('auth success');
-          _isCramAuthenticated = true;
+          _connection!.getMetaData()!.isAuthenticated = true;
         } else {
           throw UnAuthenticatedException('Auth failed');
         }
       }
-      return _isCramAuthenticated;
+      return _connection!.getMetaData()!.isAuthenticated;
     } finally {
       _cramAuthenticationMutex.release();
     }
@@ -481,7 +479,7 @@ class AtLookupImpl implements AtLookUp {
 
   bool _isAuthRequired() {
     return !isConnectionAvailable() ||
-        !(_isPkamAuthenticated || _isCramAuthenticated);
+        !(_connection!.getMetaData()!.isAuthenticated);
   }
 
   Future<bool> createOutBoundConnection(host, port, toAtSign) async {

--- a/at_lookup/lib/src/connection/at_connection.dart
+++ b/at_lookup/lib/src/connection/at_connection.dart
@@ -20,6 +20,7 @@ abstract class AtConnection {
 }
 
 abstract class AtConnectionMetaData {
+  bool isAuthenticated = false;
   DateTime? lastAccessed;
   DateTime? created;
   bool isClosed = false;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replaced the `_isPKAMAuthenticated` and `isCramAuthenticated` in AtLookupImpl with `isAuthenticated` in AtConnectionMetadata to indicate If the connection is authenticated or not.

**- How I did it**
Add a new field - isAuthenticated into AtConnectionMetadata which is false by default. When authenticated will be set to true.

@gkc : The connection gets created inside the `authenticate` and `authenticate_cram` (authenticate -> sendCommand -> createConnection). So for the first time, since the connection does not exist, the IF condition to check connection authentication fails with NULL pointer exception. Hence called createConnection method inside the authenticate and authenticate_cram methods. To avoid duplicate creation of connection, we already have a check in createConnection to verify if connection already exists; If yes it does nothing.

Please let me know if this is fine or needs an alternative approach to deal with this.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->