### PR TITLE
feat: Enhance executeVerb to decode error responses in JSON.

### DIFF
--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -16,12 +16,12 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
 
-# dependency_overrides:
-#  at_commons:
-#      git:
-#        url: https://github.com/atsign-foundation/at_tools.git
-#        path: at_commons
-#        ref: trunk
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Decode the JSON responses from the server. This is in-line with the following [PR:841](https://github.com/atsign-foundation/at_server/pull/841)

**- How I did it**
- When server returns the error responses in JSON encoding, decode the response. To provide backward compatibility, on FormatException, fall back to existing implementation.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->