### PR TITLE
fix: make sure all tls connections dump keys and other minor fixes

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -51,7 +51,6 @@ class AtLookupImpl implements AtLookUp {
     this.cramSecret = cramSecret;
     this.secondaryAddressFinder = secondaryAddressFinder ?? CacheableSecondaryAddressFinder(rootDomain, rootPort);
     _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
-    // ..decryptPackets = false;
   }
 
   @Deprecated('use CacheableSecondaryAddressFinder')

--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -49,25 +49,20 @@ class AtLookupImpl implements AtLookUp {
     _rootPort = rootPort;
     this.privateKey = privateKey;
     this.cramSecret = cramSecret;
-    this.secondaryAddressFinder = secondaryAddressFinder ??
-        CacheableSecondaryAddressFinder(rootDomain, rootPort);
-    _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig()
-      ..decryptPackets = false;
+    this.secondaryAddressFinder = secondaryAddressFinder ?? CacheableSecondaryAddressFinder(rootDomain, rootPort);
+    _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
+    // ..decryptPackets = false;
   }
 
   @Deprecated('use CacheableSecondaryAddressFinder')
-  static Future<String?> findSecondary(
-      String atsign, String? rootDomain, int rootPort) async {
+  static Future<String?> findSecondary(String atsign, String? rootDomain, int rootPort) async {
     // temporary change to preserve backward compatibility and change the callers later on to use
     // SecondaryAddressFinder.findSecondary
-    return (await CacheableSecondaryAddressFinder(rootDomain!, rootPort)
-            .findSecondary(atsign))
-        .toString();
+    return (await CacheableSecondaryAddressFinder(rootDomain!, rootPort).findSecondary(atsign)).toString();
   }
 
   @override
-  Future<bool> delete(String key,
-      {String? sharedWith, bool isPublic = false}) async {
+  Future<bool> delete(String key, {String? sharedWith, bool isPublic = false}) async {
     var builder = DeleteVerbBuilder()
       ..isPublic = isPublic
       ..sharedWith = sharedWith
@@ -78,8 +73,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @override
-  Future<String> llookup(String key,
-      {String? sharedBy, String? sharedWith, bool isPublic = false}) async {
+  Future<String> llookup(String key, {String? sharedBy, String? sharedWith, bool isPublic = false}) async {
     LLookupVerbBuilder builder;
     if (sharedWith != null) {
       builder = LLookupVerbBuilder()
@@ -103,9 +97,7 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   Future<String> lookup(String key, String sharedBy,
-      {bool auth = true,
-      bool verifyData = false,
-      bool metadata = false}) async {
+      {bool auth = true, bool verifyData = false, bool metadata = false}) async {
     var builder = LookupVerbBuilder()
       ..atKey = key
       ..sharedBy = sharedBy
@@ -145,13 +137,11 @@ class AtLookupImpl implements AtLookUp {
       var value = resultJson['data'];
       value = VerbUtil.getFormattedValue(value);
       logger.finer('value: $value dataSignature:$dataSignature');
-      var isDataValid = publicKey.verifySHA256Signature(
-          utf8.encode(value) as Uint8List, base64Decode(dataSignature));
+      var isDataValid = publicKey.verifySHA256Signature(utf8.encode(value) as Uint8List, base64Decode(dataSignature));
       logger.finer('atlookup data verify result: $isDataValid');
       return 'data:$value';
     } on Exception catch (e) {
-      logger.severe(
-          'Error while verify public data for key: $key sharedBy: $sharedBy exception:${e.toString()}');
+      logger.severe('Error while verify public data for key: $key sharedBy: $sharedBy exception:${e.toString()}');
       return 'data:null';
     }
   }
@@ -167,11 +157,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @override
-  Future<List<String>> scan(
-      {String? regex,
-      String? sharedBy,
-      bool auth = true,
-      bool showHiddenKeys = false}) async {
+  Future<List<String>> scan({String? regex, String? sharedBy, bool auth = true, bool showHiddenKeys = false}) async {
     var builder = ScanVerbBuilder()
       ..sharedBy = sharedBy
       ..regex = regex
@@ -185,8 +171,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @override
-  Future<bool> update(String key, String value,
-      {String? sharedWith, Metadata? metadata}) async {
+  Future<bool> update(String key, String value, {String? sharedWith, Metadata? metadata}) async {
     var builder = UpdateVerbBuilder()
       ..atKey = key
       ..sharedBy = _currentAtSign
@@ -209,13 +194,11 @@ class AtLookupImpl implements AtLookUp {
     if (!isConnectionAvailable()) {
       logger.info('Creating new connection');
       //1. find secondary url for atsign from lookup library
-      SecondaryAddress secondaryAddress =
-          await secondaryAddressFinder.findSecondary(_currentAtSign);
+      SecondaryAddress secondaryAddress = await secondaryAddressFinder.findSecondary(_currentAtSign);
       var host = secondaryAddress.host;
       var port = secondaryAddress.port;
       //2. create a connection to secondary server
-      await createOutBoundConnection(
-          host, port.toString(), _currentAtSign, _secureSocketConfig);
+      await createOutBoundConnection(host, port.toString(), _currentAtSign, _secureSocketConfig);
       //3. listen to server response
       messageListener = OutboundMessageListener(_connection);
       messageListener.listen();
@@ -375,8 +358,7 @@ class AtLookupImpl implements AtLookUp {
         fromResponse = fromResponse.trim().replaceAll('data:', '');
         logger.finer('fromResponse $fromResponse');
         var key = RSAPrivateKey.fromString(privateKey);
-        var sha256signature =
-            key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);
+        var sha256signature = key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);
         var signature = base64Encode(sha256signature);
         logger.finer('Sending command pkam:$signature');
         await _sendCommand('pkam:$signature\n');
@@ -385,8 +367,7 @@ class AtLookupImpl implements AtLookUp {
           logger.info('auth success');
           _connection!.getMetaData()!.isAuthenticated = true;
         } else {
-          throw UnAuthenticatedException(
-              'Failed connecting to $_currentAtSign. $pkamResponse');
+          throw UnAuthenticatedException('Failed connecting to $_currentAtSign. $pkamResponse');
         }
       }
       return _connection!.getMetaData()!.isAuthenticated;
@@ -468,8 +449,7 @@ class AtLookupImpl implements AtLookUp {
         } else if (cramSecret != null) {
           await authenticate_cram(cramSecret);
         } else {
-          throw UnAuthenticatedException(
-              'Unable to perform atlookup auth. Private key/cram secret is not set');
+          throw UnAuthenticatedException('Unable to perform atlookup auth. Private key/cram secret is not set');
         }
       }
       try {
@@ -486,22 +466,19 @@ class AtLookupImpl implements AtLookUp {
   }
 
   bool _isAuthRequired() {
-    return !isConnectionAvailable() ||
-        !(_connection!.getMetaData()!.isAuthenticated);
+    return !isConnectionAvailable() || !(_connection!.getMetaData()!.isAuthenticated);
   }
 
-  Future<bool> createOutBoundConnection(String host, String port,
-      String toAtSign, SecureSocketConfig secureSocketConfig) async {
+  Future<bool> createOutBoundConnection(
+      String host, String port, String toAtSign, SecureSocketConfig secureSocketConfig) async {
     try {
-      SecureSocket secureSocket = await SecureSocketUtil.createSecureSocket(
-          host, port, secureSocketConfig);
+      SecureSocket secureSocket = await SecureSocketUtil.createSecureSocket(host, port, secureSocketConfig);
       _connection = OutboundConnectionImpl(secureSocket);
       if (outboundConnectionTimeout != null) {
         _connection!.setIdleTime(outboundConnectionTimeout);
       }
     } on SocketException {
-      throw SecondaryConnectException(
-          'unable to connect to secondary $toAtSign on $host:$port');
+      throw SecondaryConnectException('unable to connect to secondary $toAtSign on $host:$port');
     }
     return true;
   }

--- a/at_lookup/lib/src/util/secure_socket_util.dart
+++ b/at_lookup/lib/src/util/secure_socket_util.dart
@@ -11,7 +11,7 @@ class SecureSocketUtil {
       SecurityContext securityContext = SecurityContext();
       try {
         File keysFile = File(secureSocketConfig.tlsKeysSavePath!);
-        if (secureSocketConfig.pathToCerts != null) {
+        if (secureSocketConfig.pathToCerts != null && await File(secureSocketConfig.pathToCerts!).exists()) {
           securityContext
               .setTrustedCertificates(secureSocketConfig.pathToCerts!);
         } else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
closes https://github.com/atsign-foundation/at_libraries/issues/189
Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/189
**- What I did**
- removed a redundant piece of code that obstructed some tls_connections from dumping keys [colin] 
- added a check to ensure that rootcerts exist at the provided location [srie]
- minor refactoring/dart format

**- How I did it**
- removed a snippet that defaults param decryptPackets to false

**- How to verify it**
- the tls keys file at the save path now has multiple sets of tls key dumps belonging to multiple connections. previously only one connection dumped keys.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->