### PR TITLE
feat: add clientConfig to from verb

### DIFF
--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -16,12 +16,12 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
 
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: add_clientConfig_to_from_verb
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_onboarding_cli/functional_tests/pubspec.yaml
+++ b/at_onboarding_cli/functional_tests/pubspec.yaml
@@ -10,20 +10,23 @@ environment:
 dependencies:
   at_onboarding_cli:
     path: ../
+  at_client: ^3.0.35
+  at_lookup: ^3.0.29
+  at_commons: ^3.0.24
 
-dependency_overrides:
-  at_lookup:
-    path: ../../at_lookup
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: at_client
-      ref: trunk
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
+#dependency_overrides:
+#  at_lookup:
+#    path: ../../at_lookup
+#  at_client:
+#    git:
+#      url: https://github.com/atsign-foundation/at_client_sdk.git
+#      path: at_client
+#      ref: trunk
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 
 
 dev_dependencies:

--- a/at_onboarding_cli/pubspec.yaml
+++ b/at_onboarding_cli/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 
 dependencies:
-   at_utils: ^3.0.4
-   at_client: ^3.0.32
-   at_lookup: ^3.0.28
+   at_utils: ^3.0.10
+   at_client: ^3.0.35
+   at_lookup: ^3.0.29
    zxing2: ^0.1.0
    image: ^3.1.1
    crypton: ^2.0.3
-   at_commons: ^3.0.21
+   at_commons: ^3.0.24
    encrypt: ^5.0.1
    at_server_status: ^1.0.3
    path: ^1.8.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- add clientConfig to AtLookup to store and pass the client infomation to the secondary server

**- How I did it**
- Add clientConfig to the AtLookupImpl and populate the data via the constructor.
- Pass the clientConfig to authenticate and authenticate_cram methods.

**- How to verify it**
- When clientConfig is populated, the client version information should be passed to the cloud secondary.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->