### PR TITLE
chore: reverting back code-snippet accidentally added while resolving merge conflict

### DIFF
--- a/at_lookup/CHANGELOG.md
+++ b/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.31
+- fix: tls keys are being dumped only by some secure socket connections when decryptPackets is set to true
 ## 3.0.30
 - Introduce clientConfig which can be used to send client configurations to server.
 ## 3.0.29

--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -54,8 +54,7 @@ class AtLookupImpl implements AtLookUp {
     this.cramSecret = cramSecret;
     this.secondaryAddressFinder = secondaryAddressFinder ??
         CacheableSecondaryAddressFinder(rootDomain, rootPort);
-    _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig()
-      ..decryptPackets = false;
+    _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
     // Stores the client configurations.
     // If client configurations are not available, defaults to empty map
     _clientConfig = clientConfig ?? {};

--- a/at_lookup/pubspec.yaml
+++ b/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.30
+version: 3.0.31
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
There was a code snipped that was supposed to be removed as part of https://github.com/atsign-foundation/at_libraries/pull/217. But this was somehow reverted back, the possibility being a merge-conflict resolution sneaked it back into the trunk. This PR is to make sure that the correct code is present in the trunk

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->