### PR TITLE
fix: strict atKeys file formatting for onboarding_cli; ready to publish

### DIFF
--- a/at_onboarding_cli/CHANGELOG.md
+++ b/at_onboarding_cli/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 1.1.2
 - Introducing activate_cli, a simple tool to activate atSigns from command-line
 - Introducing a close() method to safely close the OnboardingService object
-- Allow custom names for .atKeysFile when the file name is passed as atKeysFilePath when onboarding(activating)
+- Allow custom names for .atKeysFile when the file name is passed as atKeysFilePath during onboarding(activating)
 - Removed at_client dependency in onboarding process flow
 - correct example link replace @sign -> atSign
-- Upgrade dependency at_client to latest version v3.0.35
-- Upgrade dependency at_lookup to latest version v3.0.29
-- Upgrade dependency at_utils to latest version v3.0.10
+- Upgrade dependency at_client to latest version v3.0.37
+- Upgrade dependency at_lookup to latest version v3.0.30
+- Upgrade dependency at_utils to latest version v3.0.11
 - Upgrade dependency at_commons to latest version v3.0.24
 ## 1.1.1
 - Method to check and format atsign.

--- a/at_onboarding_cli/CHANGELOG.md
+++ b/at_onboarding_cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Allow custom names for .atKeysFile when the file name is passed as atKeysFilePath during onboarding(activating)
 - Removed at_client dependency in onboarding process flow
 - correct example link replace @sign -> atSign
-- Upgrade dependency at_client to latest version v3.0.37
+- Upgrade dependency at_client to latest version v3.0.38
 - Upgrade dependency at_lookup to latest version v3.0.30
 - Upgrade dependency at_utils to latest version v3.0.11
 - Upgrade dependency at_commons to latest version v3.0.24

--- a/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
+++ b/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
@@ -171,8 +171,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
       //if provided file is not of format .atKeys, append .atKeys to filename
       if (!atOnboardingPreference.atKeysFilePath!.endsWith('.atKeys')) {
-        atOnboardingPreference.atKeysFilePath =
-            atOnboardingPreference.atKeysFilePath! + '.atKeys';
+        throw AtClientException.message('atKeysFilePath provided should be of format .atKeys');
       }
     }
     //note: in case atKeysFilePath is provided instead of downloadPath;

--- a/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
+++ b/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
@@ -154,15 +154,27 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         atKeysMap[AuthKeyType.encryptionPrivateKey]!,
         atKeysMap[AuthKeyType.selfEncryptionKey]!);
 
-    //create directory at provided path if one does not exist already
-    if (atOnboardingPreference.downloadPath != null &&
-        !(await Directory(atOnboardingPreference.downloadPath!).exists())) {
-      await Directory(atOnboardingPreference.downloadPath!).create();
-    }
-    //construct download path to match standard atKeys file name convention
-    atOnboardingPreference.downloadPath = path.join(
-        atOnboardingPreference.downloadPath!, '${_atSign}_key.atKeys');
+    if (atOnboardingPreference.downloadPath != null) {
+      //create directory at provided path if one does not exist already
+      if (!(await Directory(atOnboardingPreference.downloadPath!).exists())) {
+        await Directory(atOnboardingPreference.downloadPath!).create();
+      }
+      //construct download path to match standard atKeys file name convention
+      atOnboardingPreference.downloadPath = path.join(
+          atOnboardingPreference.downloadPath!, '${_atSign}_key.atKeys');
+    } else {
+      //if atKeysFilePath points to a directory and not a file, create a file in the provided directory
+      if (await Directory(atOnboardingPreference.atKeysFilePath!).exists()) {
+        atOnboardingPreference.atKeysFilePath = path.join(
+            atOnboardingPreference.atKeysFilePath!, '${_atSign}_key.atKeys');
+      }
 
+      //if provided file is not of format .atKeys, append .atKeys to filename
+      if (!atOnboardingPreference.atKeysFilePath!.endsWith('.atKeys')) {
+        atOnboardingPreference.atKeysFilePath =
+            atOnboardingPreference.atKeysFilePath! + '.atKeys';
+      }
+    }
     //note: in case atKeysFilePath is provided instead of downloadPath;
     //file is created with whichever name provided as atKeysFilePath(even if filename does not match standary atKeys file name convention)
     IOSink atKeysFile = File(atOnboardingPreference.downloadPath ??

--- a/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
+++ b/at_onboarding_cli/lib/src/at_onboarding_service_impl.dart
@@ -107,7 +107,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         'update:$AT_PKAM_PUBLIC_KEY ${_pkamRsaKeypair.publicKey}\n';
     String? pkamUpdateResult =
         await _atLookup?.executeCommand(updateCommand, auth: false);
-    logger.finer('PkamPublicKey update result: $pkamUpdateResult');
+    logger.info('PkamPublicKey update result: $pkamUpdateResult');
     atOnboardingPreference.privateKey = _pkamRsaKeypair.privateKey.toString();
 
     //authenticate using pkam to verify insertion of pkamPublicKey
@@ -124,12 +124,12 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       String? encryptKeyUpdateResult =
           await _atLookup?.executeVerb(updateBuilder);
       logger
-          .finer('Encryption public key update result $encryptKeyUpdateResult');
+          .info('Encryption public key update result $encryptKeyUpdateResult');
       //deleting cram secret from the keystore as cram auth is complete
       DeleteVerbBuilder deleteBuilder = DeleteVerbBuilder()
         ..atKey = AT_CRAM_SECRET;
       String? deleteResponse = await _atLookup?.executeVerb(deleteBuilder);
-      logger.finer('Cram secret delete response : $deleteResponse');
+      logger.info('Cram secret delete response : $deleteResponse');
       //displays status of the atsign
       logger.finer(await getServerStatus());
       logger.info('----------atSign activated---------');

--- a/at_onboarding_cli/pubspec.yaml
+++ b/at_onboarding_cli/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 
 dependencies:
-   at_utils: ^3.0.10
-   at_client: ^3.0.35
-   at_lookup: ^3.0.29
+   at_utils: ^3.0.11
+   at_client: ^3.0.37
+   at_lookup: ^3.0.30
    zxing2: ^0.1.0
    image: ^3.1.1
    crypton: ^2.0.3

--- a/at_onboarding_cli/pubspec.yaml
+++ b/at_onboarding_cli/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
    at_utils: ^3.0.11
-   at_client: ^3.0.37
+   at_client: ^3.0.38
    at_lookup: ^3.0.30
    zxing2: ^0.1.0
    image: ^3.1.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- ensured that the keys file format is always .atKeys.
- create directories if provided paths do not exists
- now users can input directory or file path as downloadPath 

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->