### PR TITLE
fix: accomodate for delay in secondary creation after registering a free atsign

### DIFF
--- a/at_onboarding_cli/CHANGELOG.md
+++ b/at_onboarding_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.3
 - Introducing register_cli that fetches a free atsign and registers it to provided email
+- Introduced a check to ensure secondary is created before trying to activate it
 ## 1.1.2
 - Introducing activate_cli, a simple tool to activate atSigns from command-line
 - Introducing a close() method to safely close the OnboardingService object


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/232
**- What I did**
- introduced a method to check if secondary belonging to the atsign at hand exists or waits until the secondary is created in case it does not.

**- How I did it**
- Introduced a method called waitUntilSecondaryExists() which checks if secondary exists.
- When the secondary does not exist, try for 50 iterations to fetch the secondary address.
- Tries to connect to the secondary address fetched.
- Retries for 50 iteration if the connection to secondary was not established
- Resume normal onboarding process after abovementioned checks
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- fix: accomodate for delay in secondary creation after registering a free atsign