### PR TITLE
fix: add `await` when acquiring mutexes (otherwise the mutex will not work)

### DIFF
--- a/at_lookup/lib/src/at_lookup_impl.dart
+++ b/at_lookup/lib/src/at_lookup_impl.dart
@@ -387,7 +387,7 @@ class AtLookupImpl implements AtLookUp {
     }
     await createConnection();
     try {
-      _pkamAuthenticationMutex.acquire();
+      await _pkamAuthenticationMutex.acquire();
       if (!_connection!.getMetaData()!.isAuthenticated) {
         await _sendCommand((FromVerbBuilder()
               ..atSign = _currentAtSign
@@ -433,7 +433,7 @@ class AtLookupImpl implements AtLookUp {
     }
     await createConnection();
     try {
-      _cramAuthenticationMutex.acquire();
+      await _cramAuthenticationMutex.acquire();
       if (!_connection!.getMetaData()!.isAuthenticated) {
         await _sendCommand((FromVerbBuilder()
               ..atSign = _currentAtSign


### PR DESCRIPTION
**- What I did**
fix: add `await` when acquiring mutexes (otherwise the mutex will not work)

**- How to verify it**
Tests pass

**- Description for the changelog**
fix: add `await` when acquiring mutexes (otherwise the mutex will not work)