### PR TITLE
fix: revert to using vip tag for virtualenv

### DIFF
--- a/tests/at_onboarding_cli_functional_tests/docker-compose.yaml
+++ b/tests/at_onboarding_cli_functional_tests/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   virtualenv:
-    image: atsigncompany/virtualenv:dev_env
+    image: atsigncompany/virtualenv:vip
     ports:
       - "127.0.0.1:6379:6379"
       - "64:64"


### PR DESCRIPTION
**- What I did**

Reverted change made in #238 as the `:vip` tag will now be kept up to date by https://github.com/atsign-foundation/at_server/pull/1037

**- How to verify it**

Run tests

**- Description for the changelog**

fix: revert to using vip tag for virtualenv