### PR TITLE
fix: Removed race condition related to management of outbound connection state after timeouts

### DIFF
--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -44,9 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - at_contact
-          - at_server_status
-          - at_onboarding_cli
+          - at_lookup
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -21,7 +21,30 @@ jobs:
       matrix:
         package:
           - at_contact
-          - at_lookup
+          - at_server_status
+          - at_onboarding_cli
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies in ${{ matrix.package }}
+        working-directory: packages/${{ matrix.package }}
+        run: dart pub get
+
+      - name: Analyze project source in ${{ matrix.package }}
+        working-directory: packages/${{ matrix.package }}
+        run: dart analyze
+
+  at_lookup_build_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - at_contact
           - at_server_status
           - at_onboarding_cli
     steps:
@@ -41,7 +64,6 @@ jobs:
 
       - name: run tests
         run: dart test --concurrency=1
-
 
   functional_tests_at_onboarding_cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -39,6 +39,10 @@ jobs:
         working-directory: packages/${{ matrix.package }}
         run: dart analyze
 
+      - name: run tests
+        run: dart test --concurrency=1
+
+
   functional_tests_at_onboarding_cli:
     runs-on: ubuntu-latest
     env:
@@ -51,7 +55,7 @@ jobs:
         with:
           sdk: stable
 
-      #functional tests for at_onbaording_cli
+      #functional tests for at_onboarding_cli
       - name: add entry to hosts file
         run: echo "127.0.0.1    vip.ve.atsign.zone" | sudo tee -a /etc/hosts
 

--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -61,6 +61,7 @@ jobs:
         run: dart analyze
 
       - name: run tests
+        working-directory: packages/${{ matrix.package }}
         run: dart test --concurrency=1
 
   functional_tests_at_onboarding_cli:

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.33
+- fix: Removed race condition (related to management of outbound connection state after timeouts) which
+could in very rare circumstances cause unnecessary long delays
 ## 3.0.32
 - feat: Upgrade at_commons for notifyFetch verb
 ## 3.0.31

--- a/packages/at_lookup/analysis_options.yaml
+++ b/packages/at_lookup/analysis_options.yaml
@@ -10,6 +10,7 @@ linter:
     - camel_case_types
     - unnecessary_string_interpolations
     - await_only_futures
+    - unawaited_futures
 
 analyzer:
 #   exclude:

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -439,7 +439,7 @@ class AtLookupImpl implements AtLookUp {
               ..atSign = _currentAtSign
               ..clientConfig = _clientConfig)
             .buildCommand());
-        var fromResponse = await messageListener.read();
+        var fromResponse = await messageListener.read(transientWaitTimeMillis: 4000, maxWaitMilliSeconds: 10000);
         logger.info('from result:$fromResponse');
         if (fromResponse.isEmpty) {
           return false;

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -449,7 +449,7 @@ class AtLookupImpl implements AtLookUp {
         var bytes = utf8.encode(digestInput);
         var digest = sha512.convert(bytes);
         await _sendCommand('cram:$digest\n');
-        var cramResponse = await messageListener.read();
+        var cramResponse = await messageListener.read(transientWaitTimeMillis: 4000, maxWaitMilliSeconds: 10000);
         if (cramResponse == 'data:success') {
           logger.info('auth success');
           _connection!.getMetaData()!.isAuthenticated = true;

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -229,6 +229,7 @@ class AtLookupImpl implements AtLookUp {
       //3. listen to server response
       messageListener = OutboundMessageListener(_connection!);
       messageListener.listen();
+      logger.info('New connection created OK');
     }
   }
 

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -382,7 +382,7 @@ class AtLookupImpl implements AtLookUp {
 
   /// Generates digest using from verb response and [privateKey] and performs a PKAM authentication to
   /// secondary server. This method is executed for all verbs that requires authentication.
-  Future<bool> authenticatePKAM(String? privateKey) async {
+  Future<bool> authenticate(String? privateKey) async {
     if (privateKey == null) {
       throw UnAuthenticatedException('Private key not passed');
     }
@@ -425,7 +425,7 @@ class AtLookupImpl implements AtLookUp {
   /// Generates digest using from verb response and [secret] and performs a CRAM authentication to
   /// secondary server
   // ignore: non_constant_identifier_names
-  Future<bool> authenticateCRAM(var secret) async {
+  Future<bool> authenticate_cram(var secret) async {
     secret ??= cramSecret;
     if (secret == null) {
       throw UnAuthenticatedException('Cram secret not passed');
@@ -491,12 +491,12 @@ class AtLookupImpl implements AtLookUp {
 
       if (auth && _isAuthRequired()) {
         if (privateKey != null) {
-          await authenticatePKAM(privateKey);
+          await authenticate(privateKey);
         } else if (cramSecret != null) {
-          await authenticateCRAM(cramSecret);
+          await authenticate_cram(cramSecret);
         } else {
           throw UnAuthenticatedException(
-              'Unable to perform atLookup auth. Private key/cram secret is not set');
+              'Unable to perform atlookup auth. Private key/cram secret is not set');
         }
       }
       try {

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -49,16 +49,14 @@ class AtLookupImpl implements AtLookUp {
   Mutex requestResponseMutex = Mutex();
 
   AtLookupImpl(String atSign, String rootDomain, int rootPort,
-      {String? privateKey,
-      String? cramSecret,
+      {this.privateKey,
+      this.cramSecret,
       SecondaryAddressFinder? secondaryAddressFinder,
       SecureSocketConfig? secureSocketConfig,
       Map<String, dynamic>? clientConfig}) {
     _currentAtSign = atSign;
     _rootDomain = rootDomain;
     _rootPort = rootPort;
-    this.privateKey = privateKey;
-    this.cramSecret = cramSecret;
     this.secondaryAddressFinder = secondaryAddressFinder ??
         CacheableSecondaryAddressFinder(rootDomain, rootPort);
     _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
@@ -497,7 +495,7 @@ class AtLookupImpl implements AtLookUp {
           await authenticateCRAM(cramSecret);
         } else {
           throw UnAuthenticatedException(
-              'Unable to perform atlookup auth. Private key/cram secret is not set');
+              'Unable to perform atLookup auth. Private key/cram secret is not set');
         }
       }
       try {

--- a/packages/at_lookup/lib/src/connection/base_connection.dart
+++ b/packages/at_lookup/lib/src/connection/base_connection.dart
@@ -24,13 +24,14 @@ abstract class BaseConnection extends AtConnection {
   Future<void> close() async {
     try {
       _socket.destroy();
-      getMetaData()!.isClosed = true;
     } on Exception {
       getMetaData()!.isStale = true;
       // Ignore exception on a connection close
     } on Error {
       getMetaData()!.isStale = true;
       // Ignore error on a connection close
+    } finally {
+      getMetaData()!.isClosed = true;
     }
   }
 

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -5,6 +5,7 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/connection/at_connection.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:meta/meta.dart';
 
 ///Listener class for messages received by [RemoteSecondary]
 class OutboundMessageListener {
@@ -159,8 +160,15 @@ class OutboundMessageListener {
     await _closeConnection();
   }
 
+  @visibleForTesting
+  Duration? delayBeforeClose;
+
   Future<void> _closeConnection() async {
+    logger.info("_closeConnection() called : isInValid currently ${_connection.isInValid()}");
     if (!_connection.isInValid()) {
+      if (delayBeforeClose != null) {
+        await Future.delayed(delayBeforeClose!);
+      }
       await _connection.close();
     }
   }

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -124,7 +124,7 @@ class OutboundMessageListener {
       if (DateTime.now().difference(startTime).inMilliseconds >
           maxWaitMilliSeconds) {
         _buffer.clear();
-        _closeConnection();
+        await _closeConnection();
         throw AtTimeoutException(
             'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
       }
@@ -133,7 +133,7 @@ class OutboundMessageListener {
       if (DateTime.now().difference(_lastReceivedTime).inMilliseconds >
           transientWaitTimeMillis) {
         _buffer.clear();
-        _closeConnection();
+        await _closeConnection();
         throw AtTimeoutException(
             'Waited for $transientWaitTimeMillis millis. No response after $_lastReceivedTime ');
       }
@@ -164,7 +164,6 @@ class OutboundMessageListener {
   Duration? delayBeforeClose;
 
   Future<void> _closeConnection() async {
-    logger.info("_closeConnection() called : isInValid currently ${_connection.isInValid()}");
     if (!_connection.isInValid()) {
       if (delayBeforeClose != null) {
         await Future.delayed(delayBeforeClose!);

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockOutboundConnectionImpl extends Mock implements OutboundConnectionImpl {}
+class MockSocket extends Mock implements Socket {}
+
+void main() {
+  // In order to reduce duplicated test code, creating test functions which will be used in two ways. See test groups below.
+  testOne(Duration? delayBeforeClose) async {
+    Socket mockSocket = MockSocket();
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    OutboundConnection connection = OutboundConnectionImpl(mockSocket);
+    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+
+    // We want to set up a connection, then call read() and have it time out.
+    // When read() times out, the connection should be closed BEFORE the exception is thrown
+    // This test is to guard against race conditions if we're not using `await` somewhere that we should be
+
+    // This variable enables us to introduce a delay before closing the connection
+    // The introduction of this delay enables the race condition (if it exists) to occur in this test
+    if (delayBeforeClose != null) {
+      outboundMessageListener.delayBeforeClose = delayBeforeClose;
+    }
+    int transientWaitTimeMillis = 50;
+    try {
+      await outboundMessageListener.read(transientWaitTimeMillis: transientWaitTimeMillis);
+    } on AtTimeoutException catch (expected) {
+      expect(expected.message, startsWith('Waited for $transientWaitTimeMillis millis. No response after'));
+      expect(connection.isInValid(), true);
+    }
+  }
+  testTwo(Duration? delayBeforeClose) async {
+    Socket mockSocket = MockSocket();
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    OutboundConnection connection = OutboundConnectionImpl(mockSocket);
+    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+
+    // We want to set up a connection, then call read() and have it time out.
+    // When read() times out, the connection should be closed BEFORE the exception is thrown
+    // This test is to guard against race conditions if we're not using `await` somewhere that we should be
+
+    // This variable enables us to introduce a delay before closing the connection
+    // The introduction of this delay enables the race condition (if it exists) to occur in this test
+    if (delayBeforeClose != null) {
+      outboundMessageListener.delayBeforeClose = delayBeforeClose;
+    }
+    int maxWaitMilliSeconds = 50;
+    try {
+      await outboundMessageListener.read(maxWaitMilliSeconds: maxWaitMilliSeconds);
+      expect(false, true, reason: 'Test should not have reached this point');
+    } on AtTimeoutException catch (expected) {
+      expect(expected.message, 'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
+      expect(connection.isInValid(), true);
+    }
+  }
+
+  testThree(Duration? delayBeforeClose) async {
+    Socket mockSocket = MockSocket();
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    OutboundConnection connection = OutboundConnectionImpl(mockSocket);
+    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+
+    // We want to set up a connection, then call read() and have it time out.
+    // When read() times out, the connection should be closed BEFORE the exception is thrown
+    // This test is to guard against race conditions if we're not using `await` somewhere that we should be
+
+    // This variable enables us to introduce a delay before closing the connection
+    // The introduction of this delay enables the race condition (if it exists) to occur in this test
+    if (delayBeforeClose != null) {
+      outboundMessageListener.delayBeforeClose = delayBeforeClose;
+    }
+    int maxWaitMilliSeconds = 50;
+    try {
+      await outboundMessageListener.read(maxWaitMilliSeconds: maxWaitMilliSeconds);
+      expect(false, true, reason: 'Test should not have reached this point');
+    } on AtTimeoutException catch (expected) {
+      expect(expected.message, 'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
+      expect(() async =>
+      await connection.write("hello\n"),
+          throwsA(predicate((dynamic e) =>
+          e is ConnectionInvalidException)));
+    }
+  }
+
+  group('A group of tests to detect race condition in connection management', ()
+  {
+    test(
+        'Test that isInvalid is set on the OutboundConnection after transientWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+        () async {
+      await testOne(Duration(milliseconds: 100));
+    });
+
+    test('Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+        () async {
+      await testTwo(Duration(milliseconds: 100));
+    });
+
+    test('Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException', () async {
+      await testThree(Duration(milliseconds: 100));
+    });
+  });
+
+  /// These tests will pass even when the race condition exists because of complications in the event loop from testing
+  /// The tests are here to verify that we haven't caused another problem from the introduction
+  /// of `@visibleForTesting Duration? delayBeforeClose` into OutboundMessageListener
+  group('Same race condition tests without the artificial delay', () {
+    test(
+        'Test that isInvalid is set on the OutboundConnection after transientWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+            () async {
+          await testOne(null);
+        });
+
+    test('Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+            () async {
+          await testTwo(null);
+        });
+
+    test('Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException', () async {
+      await testThree(null);
+    });
+  });
+}

--- a/packages/at_lookup/test/mutex_test.dart
+++ b/packages/at_lookup/test/mutex_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:mutex/mutex.dart';
 import 'package:test/test.dart';
 
@@ -27,9 +29,9 @@ void main() {
 
   test('Verify mutex core behaviour', () async {
     Mutex m = Mutex();
-    criticalSection("One", m,
-        100); // delay for 100 milliseconds so next 'criticalSection' gets a chance to run
-    criticalSection("Two", m, 10);
+    unawaited(criticalSection("One", m,
+        100)); // delay for 100 milliseconds so next 'criticalSection' gets a chance to run
+    unawaited(criticalSection("Two", m, 10));
 
     await Future.delayed(Duration(milliseconds: 200));
 

--- a/packages/at_lookup/test/mutex_test.dart
+++ b/packages/at_lookup/test/mutex_test.dart
@@ -5,8 +5,8 @@ void main() {
   List<String> criticalSectionEvents = [];
   Future<void> criticalSection(
       String eventName, Mutex m, int delayInMillis) async {
-    print('criticalSection $eventName starting');
     try {
+      print('criticalSection $eventName trying to acquire mutex');
       await m.acquire();
       criticalSectionEvents.add("$eventName acquired mutex");
 

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -98,16 +98,16 @@ void main() {
     });
   });
 
-  group('A group of test to verify response from unauth connection', () {
+  group('A group of test to verify response from unauthorized connection', () {
     OutboundMessageListener outboundMessageListener =
         OutboundMessageListener(mockOutBoundConnection);
-    test('A test to validate response from unauth connection', () async {
+    test('A test to validate response from unauthorized connection', () async {
       outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:hello');
     });
 
-    test('A test to validate multiple response from unauth connection',
+    test('A test to validate multiple response from unauthorized connection',
         () async {
       outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
       var response = await outboundMessageListener.read();
@@ -118,7 +118,7 @@ void main() {
     });
 
     test(
-        'A test to validate response from unauth connection in multiple packets',
+        'A test to validate response from unauthorized connection in multiple packets',
         () async {
       outboundMessageListener
           .messageHandler('data:public:location@alice,'.codeUnits);
@@ -262,7 +262,7 @@ void main() {
       expect(response, 'data:12345678910');
     });
     test(
-        'A test to verify maxwait timeout - delay between messages from server',
+        'A test to verify max wait timeout - delay between messages from server',
         () async {
       String? response;
       outboundMessageListener

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/connection/outbound_message_listener.dart';
@@ -14,7 +16,7 @@ void main() {
     OutboundMessageListener outboundMessageListener =
         OutboundMessageListener(mockOutBoundConnection);
     test('A test to validate complete data comes in single packet', () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:phone@alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:phone@alice');
@@ -23,20 +25,20 @@ void main() {
     test(
         'A test to validate complete data comes in packet and prompt in different packet',
         () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:@bob:phone@alice\n'.codeUnits);
-      outboundMessageListener.messageHandler('@alice@'.codeUnits);
+      await outboundMessageListener.messageHandler('@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:@bob:phone@alice');
     });
 
     test('A test to validate data two complete data comes in single packets',
         () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:@bob:phone@alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:@bob:phone@alice');
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:public:phone@alice\n@alice@'.codeUnits);
       response = await outboundMessageListener.read();
       expect(response, 'data:public:phone@alice');
@@ -44,26 +46,26 @@ void main() {
 
     test('A test to validate data two complete data comes in multiple packets',
         () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:public:phone@alice\n@ali'.codeUnits);
-      outboundMessageListener.messageHandler('ce@'.codeUnits);
+      await outboundMessageListener.messageHandler('ce@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:public:phone@alice');
-      outboundMessageListener.messageHandler(
+      await outboundMessageListener.messageHandler(
           'data:@bob:location@alice,@bob:phone@alice\n@alice@'.codeUnits);
       response = await outboundMessageListener.read();
       expect(response, 'data:@bob:location@alice,@bob:phone@alice');
     });
 
     test('A test to validate single data comes two packets', () async {
-      outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
-      outboundMessageListener.messageHandler('alice\n@alice@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener.messageHandler('alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:public:phone@alice');
     });
 
     test('A test to validate data contains @', () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:phone@alice_12345675\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:phone@alice_12345675');
@@ -73,25 +75,25 @@ void main() {
         'A test to validate data contains @ and partial prompt of previous data',
         () async {
       // partial response of previous data.
-      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
-      outboundMessageListener.messageHandler('alice@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:hello');
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:phone@alice_12345675\n@alice@'.codeUnits);
       response = await outboundMessageListener.read();
       expect(response, 'data:phone@alice_12345675');
     });
 
     test('A test to validate data contains new line character', () async {
-      outboundMessageListener.messageHandler(
+      await outboundMessageListener.messageHandler(
           'data:value_contains_\nin_the_value\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:value_contains_\nin_the_value');
     });
 
     test('A test to validate data contains new line character and @', () async {
-      outboundMessageListener.messageHandler(
+      await outboundMessageListener.messageHandler(
           'data:the_key_is\n@bob:phone@alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:the_key_is\n@bob:phone@alice');
@@ -102,17 +104,17 @@ void main() {
     OutboundMessageListener outboundMessageListener =
         OutboundMessageListener(mockOutBoundConnection);
     test('A test to validate response from unauthorized connection', () async {
-      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:hello');
     });
 
     test('A test to validate multiple response from unauthorized connection',
         () async {
-      outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:hello\n@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:hello');
-      outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
       response = await outboundMessageListener.read();
       expect(response, 'data:hi');
     });
@@ -120,12 +122,12 @@ void main() {
     test(
         'A test to validate response from unauthorized connection in multiple packets',
         () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('data:public:location@alice,'.codeUnits);
-      outboundMessageListener.messageHandler('public:phone@alice\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('public:phone@alice\n@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:public:location@alice,public:phone@alice');
-      outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
       response = await outboundMessageListener.read();
       expect(response, 'data:hi');
     });
@@ -163,14 +165,14 @@ void main() {
     OutboundMessageListener outboundMessageListener =
         OutboundMessageListener(mockOutBoundConnection);
     test('A test to validate complete error comes in single packet', () async {
-      outboundMessageListener.messageHandler(
+      await outboundMessageListener.messageHandler(
           'error:AT0012: Invalid value found\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'error:AT0012: Invalid value found');
     });
 
     test('A test to validate complete error comes in single packet', () async {
-      outboundMessageListener
+      await outboundMessageListener
           .messageHandler('stream:@bob:phone@alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'stream:@bob:phone@alice');
@@ -211,8 +213,8 @@ void main() {
     test(
         'A test to verify partial response - wait time greater than transientWaitTimeMillis',
         () async {
-      outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
-      outboundMessageListener.messageHandler('12'.codeUnits);
+      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener.messageHandler('12'.codeUnits);
       expect(
           () async =>
               await outboundMessageListener.read(transientWaitTimeMillis: 50),
@@ -224,11 +226,11 @@ void main() {
     test(
         'A test to verify partial response - wait time greater than maxWaitMillis',
         () async {
-      outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
-      outboundMessageListener.messageHandler('12'.codeUnits);
-      outboundMessageListener.messageHandler('34'.codeUnits);
-      outboundMessageListener.messageHandler('56'.codeUnits);
-      outboundMessageListener.messageHandler('78'.codeUnits);
+      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener.messageHandler('12'.codeUnits);
+      await outboundMessageListener.messageHandler('34'.codeUnits);
+      await outboundMessageListener.messageHandler('56'.codeUnits);
+      await outboundMessageListener.messageHandler('78'.codeUnits);
       expect(
           () async =>
           // we want to trigger the maxWaitMilliSeconds exception, so setting transient to a higher value
@@ -242,21 +244,21 @@ void main() {
         'A test to verify full response received - delay between messages from server',
         () async {
       String? response;
-      outboundMessageListener
+      unawaited(outboundMessageListener
           .read(transientWaitTimeMillis: 50)
           .whenComplete(() => {})
-          .then((value) => {response = value});
-      outboundMessageListener.messageHandler('data:'.codeUnits);
+          .then((value) => {response = value}));
+      await outboundMessageListener.messageHandler('data:'.codeUnits);
       await Future.delayed(Duration(milliseconds: 25));
-      outboundMessageListener.messageHandler('12'.codeUnits);
+      await outboundMessageListener.messageHandler('12'.codeUnits);
       await Future.delayed(Duration(milliseconds: 15));
-      outboundMessageListener.messageHandler('34'.codeUnits);
+      await outboundMessageListener.messageHandler('34'.codeUnits);
       await Future.delayed(Duration(milliseconds: 17));
-      outboundMessageListener.messageHandler('56'.codeUnits);
+      await outboundMessageListener.messageHandler('56'.codeUnits);
       await Future.delayed(Duration(milliseconds: 30));
-      outboundMessageListener.messageHandler('78'.codeUnits);
+      await outboundMessageListener.messageHandler('78'.codeUnits);
       await Future.delayed(Duration(milliseconds: 45));
-      outboundMessageListener.messageHandler('910\n@'.codeUnits);
+      await outboundMessageListener.messageHandler('910\n@'.codeUnits);
       await Future.delayed(Duration(milliseconds: 25));
       expect(response, isNotEmpty);
       expect(response, 'data:12345678910');
@@ -265,24 +267,24 @@ void main() {
         'A test to verify max wait timeout - delay between messages from server',
         () async {
       String? response;
-      outboundMessageListener
+      await outboundMessageListener
           .read(maxWaitMilliSeconds: 100)
           .catchError((e) {
             return e.toString();
           })
           .whenComplete(() => {})
           .then((value) => {response = value});
-      outboundMessageListener.messageHandler('data:'.codeUnits);
+      await outboundMessageListener.messageHandler('data:'.codeUnits);
       await Future.delayed(Duration(milliseconds: 15));
-      outboundMessageListener.messageHandler('12'.codeUnits);
+      await outboundMessageListener.messageHandler('12'.codeUnits);
       await Future.delayed(Duration(milliseconds: 10));
-      outboundMessageListener.messageHandler('34'.codeUnits);
+      await outboundMessageListener.messageHandler('34'.codeUnits);
       await Future.delayed(Duration(milliseconds: 12));
-      outboundMessageListener.messageHandler('56'.codeUnits);
+      await outboundMessageListener.messageHandler('56'.codeUnits);
       await Future.delayed(Duration(milliseconds: 13));
-      outboundMessageListener.messageHandler('78'.codeUnits);
+      await outboundMessageListener.messageHandler('78'.codeUnits);
       await Future.delayed(Duration(milliseconds: 20));
-      outboundMessageListener.messageHandler('910'.codeUnits);
+      await outboundMessageListener.messageHandler('910'.codeUnits);
       await Future.delayed(Duration(milliseconds: 50));
       expect(response, isNotEmpty);
       expect(
@@ -295,24 +297,24 @@ void main() {
         'A test to verify transient timeout - delay between messages from server',
         () async {
       String? response;
-      outboundMessageListener
+      await outboundMessageListener
           .read(transientWaitTimeMillis: 50)
           .catchError((e) {
             return e.toString();
           })
           .whenComplete(() => {})
           .then((value) => {response = value});
-      outboundMessageListener.messageHandler('data:'.codeUnits);
+      await outboundMessageListener.messageHandler('data:'.codeUnits);
       await Future.delayed(Duration(milliseconds: 10));
-      outboundMessageListener.messageHandler('12'.codeUnits);
+      await outboundMessageListener.messageHandler('12'.codeUnits);
       await Future.delayed(Duration(milliseconds: 15));
-      outboundMessageListener.messageHandler('34'.codeUnits);
+      await outboundMessageListener.messageHandler('34'.codeUnits);
       await Future.delayed(Duration(milliseconds: 17));
-      outboundMessageListener.messageHandler('56'.codeUnits);
+      await outboundMessageListener.messageHandler('56'.codeUnits);
       await Future.delayed(Duration(milliseconds: 20));
-      outboundMessageListener.messageHandler('78'.codeUnits);
+      await outboundMessageListener.messageHandler('78'.codeUnits);
       await Future.delayed(Duration(milliseconds: 10));
-      outboundMessageListener.messageHandler('910'.codeUnits);
+      await outboundMessageListener.messageHandler('910'.codeUnits);
       await Future.delayed(Duration(milliseconds: 60));
       expect(response, isNotEmpty);
       expect(


### PR DESCRIPTION
fixes #250 

**- What I did**
* fix: Removed race condition related to management of OutboundConnection state after timeouts
* style: a few miscellaneous style / readability / maintainability changes
* fix: add the `unawaited_futures` lint rule to detect where we are not using `await` (usually accidentally). **Note:** This rule would have flagged the missing 'awaits' which triggered the bug 
* test: Added a new job to the github action config to run the at_lookup unit tests. Have opened a separate ticket to clean this up properly ( #252 ) - first by making the unit tests pass, then by consolidating back to single matrix job which does build and test for each package

**- How I did it**
* fix: (The fix itself) : Added missing `await`s to `OutboundMessageListener.read` which prevent problems caused (very rarely) by race condition where the OutboundConnection should have been closed but hasn't yet been closed, therefore making a rapidly-subsequent `write()` believe that the connection is still valid, and other weirdnesses to ensue
* test: Add a bunch of tests to verify
  * that isInvalid is set on the OutboundConnection after transientWaitTime timeout BEFORE the OutboundMessageListener.read() returns
  * that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns
  * that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException
* test: Add a `@visibleForTesting Duration? delayBeforeClose;` variable to OutboundMessageListener to allow us to inject a pause before actually closing a connection. In turn makes it possible to reliably reproduce race conditions (if they exist) related to program code trying to write to a connection which should be closed but has not yet been marked as closed for whatever reason.


* fix: New lint rule flagged lots of warnings about missing awaits in test code. Added missing awaits to eliminate the warnings.
* fix: add the `unawaited_futures` lint rule to detect where we are not using `await` (usually accidentally). 
* fix: use finally block in close() to set isClosed to true on the connection metadata
* feat: log an INFO message when a new connection has been created (we already log an INFO message when we are about to try to create a new connection)
* style: remove lint warnings for spelling in test descriptions
* fix: eliminated two lint warnings by making privateKey and cramSecret initializing formal parameters in AtLookupImpl constructorImpl constructor
* fix: set transient wait time to 4 seconds and max wait time to 10 seconds for response to 'cram' verb
* fix: set transient wait time to 4 seconds and max wait time to 10 seconds for response to 'from' verb
* test: Reworded to improve clarity of mutex_test.dart output
* test: Speed up the outbound_message_listener_test unit tests by setting transientWaitTime and maxWaitTime parameters when calling `OutboundMessageListener.read()`

**- How to verify it**
* All tests pass. If you're curious and want to prove that the tests will fail without the fix, then you can remove the `await`s in outbound_message_listener.dart at lines 127 and 136 and re-run the unit tests, at which point three of them will fail.

**- Description for the changelog**
fix: Removed race condition related to management of outbound connection state after timeouts