### PR TITLE
build: update at_lookup version to 3.0.33 for publish

### DIFF
--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.32
+version: 3.0.33
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -16,13 +16,6 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
 
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.1


### PR DESCRIPTION
**- What I did**
release: update at_lookup version to 3.0.33 for publish

**- How I did it**
- Updated pubspec.yaml 
- CHANGELOG was already up to date

**- How to verify it**
- Tests pass

