### PR TITLE
fix: Pub points badges and pubspec links

### DIFF
--- a/packages/at_contact/README.md
+++ b/packages/at_contact/README.md
@@ -10,7 +10,7 @@ Add a badge bar for your package by replacing at_contact below with
 your package name below and at_libraries with the name of the repo
 -->
 
-[![pub package](https://img.shields.io/pub/v/at_contact)](https://pub.dev/packages/at_contact) [![pub points](https://badges.bar/at_contact/pub%20points)](https://pub.dev/packages/at_contact/score) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
+[![pub package](https://img.shields.io/pub/v/at_contact)](https://pub.dev/packages/at_contact) [![pub points](https://img.shields.io/pub/points/at_contact?logo=dart)](https://pub.dev/packages/at_contact/score) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 
 <!--- this is a table version
 | [![pub package](https://img.shields.io/pub/v/at_contact)](https://pub.dev/packages/at_contact) | [![pub points](https://badges.bar/at_contact/pub%20points)](https://pub.dev/packages/at_contact/score) | [![build status](https://github.com/atsign-foundation/at_libraries/actions/workflows/at_libraries.yaml/badge.svg?branch=trunk)](https://github.com/atsign-foundation/at_libraries/actions/workflows/at_libraries.yaml) | [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)

--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -1,10 +1,10 @@
 name: at_contact
 description: A Dart library for managing contact data that developers can use
   for their applications.
-documentation: https://atsign.dev/docs/
+documentation: https://docs.atsign.com/
 version: 3.0.7
 repository: https://github.com/atsign-foundation/at_libraries
-homepage: https://atsign.dev
+homepage: https://atsign.com
 environment:
   sdk: '>=2.12.0 <3.0.0'
 

--- a/packages/at_lookup/README.md
+++ b/packages/at_lookup/README.md
@@ -1,5 +1,7 @@
 <img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
 
+[![pub package](https://img.shields.io/pub/v/at_lookup)](https://pub.dev/packages/at_lookup) [![pub points](https://img.shields.io/pub/points/at_lookup?logo=dart)](https://pub.dev/packages/at_lookup/score) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
+
 # at_lookup library
 
 ## Overview:

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -2,7 +2,8 @@ name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
 version: 3.0.33
 repository: https://github.com/atsign-foundation/at_libraries
-homepage: https://atsign.dev
+homepage: https://atsign.com
+documentation: https://docs.atsign.com/
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/at_onboarding_cli/README.md
+++ b/packages/at_onboarding_cli/README.md
@@ -1,5 +1,7 @@
 <img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
 
+[![pub package](https://img.shields.io/pub/v/at_onboarding_cli)](https://pub.dev/packages/at_onboarding_cli) [![pub points](https://img.shields.io/pub/points/at_onboarding_cli?logo=dart)](https://pub.dev/packages/at_onboarding_cli/score) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
+
 # at_onboarding_cli
 
 ## Introduction

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -2,6 +2,8 @@ name: at_onboarding_cli
 description: Dart tool to authenticate, onboard and perform complex operations on atSign seccondaries from command-line-interface.
 version: 1.2.1
 repository: https://github.com/atsign-foundation/at_libraries/tree/trunk/packages/at_onboarding_cli
+homepage: https://atsign.com
+documentation: https://docs.atsign.com/
 
 environment:
   sdk: '>=2.15.1 <3.0.0'

--- a/packages/at_server_status/README.md
+++ b/packages/at_server_status/README.md
@@ -1,5 +1,7 @@
 <img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
 
+[![pub package](https://img.shields.io/pub/v/at_server_status)](https://pub.dev/packages/at_server_status) [![pub points](https://img.shields.io/pub/points/at_server_status?logo=dart)](https://pub.dev/packages/at_server_status/score) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
+
 # at_server_status
 The at_server_status library provides an easy means to check on the status
 of the atRoot server as well as the atServer for a particular atSign.

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -1,8 +1,8 @@
 name: at_server_status
 description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
-documentation: https://atsign.dev/apidocs
 repository: https://github.com/atsign-foundation/at_libraries
-homepage: https://atsign.dev
+homepage: https://atsign.com
+documentation: https://docs.atsign.com/
 version: 1.0.3
 
 environment:


### PR DESCRIPTION
Part of https://github.com/atsign-foundation/.github/issues/46

**- What I did**

* Pub Points badges moved to shields.io from badges.bar
* Added badge strip where missing
* Updated homepage and documentation links in pubspecs

**- How to verify it**

Immediate change in GitHub on merge.

Packages will need to be bumped and published to pub.dev.

**- Description for the changelog**

fix: Pub points badges and pubspec links