### PR TITLE
build: change at_chops ref in pubspec to published version

### DIFF
--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -16,13 +16,13 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
-
-dependency_overrides:
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_chops
-      ref: at_chops
+  at_chops: ^1.0.0
+#dependency_overrides:
+#  at_chops:
+#    git:
+#      url: https://github.com/atsign-foundation/at_libraries.git
+#      path: packages/at_chops
+#      ref: at_chops
 #    path: ../at_chops
 
 dev_dependencies:


### PR DESCRIPTION
**- What I did**
- added at_chops published version to at_lookup pubspec.yaml
