### PR TITLE
chore: publish at_lookup

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.34
+- feat: added new method pkamAuthenticate in at_lookup_impl which uses at_chops for pkam signing.
 ## 3.0.33
 - fix: Removed race condition (related to management of outbound connection state after timeouts) which
 could in very rare circumstances cause unnecessary long delays

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.33
+version: 3.0.34
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
- changes for publishing at_lookup which contains at_chops related changes. Change has to be published before at_client is published with at_chops changes.

**- How I did it**
- modified change log and pubspec
