### PR TITLE
fix: handle cases of authentication in non-optimal network conditions

### DIFF
--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -386,9 +386,10 @@ class AtLookupImpl implements AtLookUp {
     if (privateKey == null) {
       throw UnAuthenticatedException('Private key not passed');
     }
-    await createConnection();
+
     try {
       await _pkamAuthenticationMutex.acquire();
+      await createConnection();
       if (!_connection!.getMetaData()!.isAuthenticated) {
         await _sendCommand((FromVerbBuilder()
               ..atSign = _currentAtSign
@@ -417,6 +418,12 @@ class AtLookupImpl implements AtLookUp {
         }
       }
       return _connection!.getMetaData()!.isAuthenticated;
+    } on Exception catch (e) {
+      logger.severe(e.toString());
+      return false;
+    } catch (e) {
+      logger.severe(e.toString());
+      return false;
     } finally {
       _pkamAuthenticationMutex.release();
     }
@@ -586,7 +593,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   Future<void> close() async {
-    await _connection!.close();
+    await _connection?.close();
   }
 
   Future<void> _sendCommand(String command) async {

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -421,9 +421,6 @@ class AtLookupImpl implements AtLookUp {
     } on Exception catch (e) {
       logger.severe(e.toString());
       return false;
-    } catch (e) {
-      logger.severe(e.toString());
-      return false;
     } finally {
       _pkamAuthenticationMutex.release();
     }

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -147,7 +147,8 @@ class SecondaryUrlFinder {
       var prompt = false;
       var once = true;
       // ignore: omit_local_variable_types
-      socket = await SecureSocket.connect(_rootDomain, _rootPort);
+      socket = await SecureSocket.connect(_rootDomain, _rootPort,
+          timeout: Duration(seconds: 30));
       // listen to the received data event stream
       socket.listen((List<int> event) async {
         answer = utf8.decode(event);

--- a/packages/at_lookup/lib/src/util/secure_socket_util.dart
+++ b/packages/at_lookup/lib/src/util/secure_socket_util.dart
@@ -7,7 +7,8 @@ class SecureSocketUtil {
       String host, String port, SecureSocketConfig secureSocketConfig) async {
     SecureSocket? _secureSocket;
     if (!secureSocketConfig.decryptPackets) {
-      _secureSocket = await SecureSocket.connect(host, int.parse(port));
+      _secureSocket = await SecureSocket.connect(host, int.parse(port),
+          timeout: Duration(seconds: 30));
       _secureSocket.setOption(SocketOption.tcpNoDelay, true);
       return _secureSocket;
     } else {
@@ -25,7 +26,8 @@ class SecureSocketUtil {
         _secureSocket = await SecureSocket.connect(host, int.parse(port),
             context: securityContext,
             keyLog: (line) =>
-                keysFile.writeAsStringSync(line, mode: FileMode.append));
+                keysFile.writeAsStringSync(line, mode: FileMode.append),
+            timeout: Duration(seconds: 30));
         _secureSocket.setOption(SocketOption.tcpNoDelay, true);
         return _secureSocket;
       } catch (e) {

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:at_client/at_client.dart';
+import 'package:at_onboarding_cli/src/util/network_util.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
@@ -11,7 +12,6 @@ import 'package:encrypt/encrypt.dart';
 import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
-import 'package:at_client/src/util/network_util.dart';
 
 ///class containing service that can onboard/activate/authenticate @signs
 class AtOnboardingServiceImpl implements AtOnboardingService {
@@ -22,13 +22,11 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   AtClient? _atClient;
   AtSignLogger logger = AtSignLogger('OnboardingCli');
   AtOnboardingPreference atOnboardingPreference;
-  late NetworkUtil networkUtil;
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
     _atSign = AtUtils.formatAtSign(atsign)!;
     //performs atSign format checks on the atSign
     _atSign = AtUtils.fixAtSign(atsign);
-    networkUtil = NetworkUtil();
   }
 
   @override
@@ -242,7 +240,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
           'Either of private key or .atKeys file not provided in preferences',
           exceptionScenario: ExceptionScenario.invalidValueProvided);
     }
-    if (!(await networkUtil.isNetworkAvailable())) {
+    if (!(await NetworkUtil.isNetworkAvailable())) {
       return false;
     }
     _atClient ??= await getAtClient();
@@ -369,7 +367,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       stdout.writeln('Connecting to secondary ...');
       try {
         secureSocket = await SecureSocket.connect(
-            _secondaryAddress!.host, _secondaryAddress.port);
+            _secondaryAddress.host, _secondaryAddress.port);
       } on Exception catch (e) {
         logger.finer(e);
       }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -11,6 +11,7 @@ import 'package:encrypt/encrypt.dart';
 import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
+import 'package:at_client/src/util/network_util.dart';
 
 ///class containing service that can onboard/activate/authenticate @signs
 class AtOnboardingServiceImpl implements AtOnboardingService {
@@ -21,23 +22,23 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   AtClient? _atClient;
   AtSignLogger logger = AtSignLogger('OnboardingCli');
   AtOnboardingPreference atOnboardingPreference;
+  late NetworkUtil networkUtil;
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
-    _atSign = AtUtils.formatAtSign(atsign)!;
+    atsign = AtUtils.formatAtSign(atsign)!;
     //performs atSign format checks on the atSign
-    AtUtils.fixAtSign(_atSign);
+    _atSign = AtUtils.fixAtSign(atsign);
+    networkUtil = NetworkUtil();
   }
 
   @override
   Future<AtClient?> getAtClient() async {
     if (_atClient == null) {
-      AtClientManager _atClientManager = AtClientManager.getInstance();
-      await _atClientManager.setCurrentAtSign(
+      AtClientManager atClientManager = AtClientManager.getInstance();
+      await atClientManager.setCurrentAtSign(
           _atSign, atOnboardingPreference.namespace, atOnboardingPreference);
-      _atLookup = _atClientManager.atClient
-          .getRemoteSecondary()
-          ?.atLookUp;
-      return _atClientManager.atClient;
+      _atLookup = atClientManager.atClient.getRemoteSecondary()?.atLookUp;
+      return atClientManager.atClient;
     }
     return _atClient;
   }
@@ -46,7 +47,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<bool> onboard() async {
     //get cram_secret from either from AtOnboardingConfig or decode it from qr code whichever available
     atOnboardingPreference.cramSecret ??=
-        _getSecretFromQr(atOnboardingPreference.qrCodePath);
+        getSecretFromQr(atOnboardingPreference.qrCodePath);
 
     if (atOnboardingPreference.cramSecret == null) {
       throw AtClientException.message(
@@ -77,33 +78,33 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to generate/update encryption key-pairs to activate an atsign
   Future<void> _activateAtsign() async {
-    RSAKeypair _pkamRsaKeypair;
-    RSAKeypair _encryptionKeyPair;
-    String _selfEncryptionKey;
+    RSAKeypair pkamRsaKeypair;
+    RSAKeypair encryptionKeyPair;
+    String selfEncryptionKey;
     Map<String, String> atKeysMap;
 
     //generating pkamKeyPair
     logger.info('Generating pkam keypair');
-    _pkamRsaKeypair = generateRsaKeypair();
+    pkamRsaKeypair = generateRsaKeypair();
 
     //generate user encryption keypair
     logger.info('Generating encryption keypair');
-    _encryptionKeyPair = generateRsaKeypair();
+    encryptionKeyPair = generateRsaKeypair();
 
     //generate selfEncryptionKey
-    _selfEncryptionKey = generateAESKey();
+    selfEncryptionKey = generateAESKey();
 
     stdout.writeln(
-        '[Information] Generating you encryption keys and .atKeys file\n');
+        '[Information] Generating your encryption keys and .atKeys file');
     //mapping encryption keys pairs to their names
     atKeysMap = <String, String>{
-      AuthKeyType.pkamPublicKey: _pkamRsaKeypair.publicKey.toString(),
-      AuthKeyType.pkamPrivateKey: _pkamRsaKeypair.privateKey.toString(),
-      AuthKeyType.encryptionPublicKey: _encryptionKeyPair.publicKey.toString(),
+      AuthKeyType.pkamPublicKey: pkamRsaKeypair.publicKey.toString(),
+      AuthKeyType.pkamPrivateKey: pkamRsaKeypair.privateKey.toString(),
+      AuthKeyType.encryptionPublicKey: encryptionKeyPair.publicKey.toString(),
       AuthKeyType.encryptionPrivateKey:
-      _encryptionKeyPair.privateKey.toString(),
-      AuthKeyType.selfEncryptionKey: _selfEncryptionKey,
-      _atSign: _selfEncryptionKey,
+          encryptionKeyPair.privateKey.toString(),
+      AuthKeyType.selfEncryptionKey: selfEncryptionKey,
+      _atSign: selfEncryptionKey,
     };
     //generate .atKeys file
     await _generateAtKeysFile(atKeysMap);
@@ -111,25 +112,25 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     //updating pkamPublicKey to remote secondary
     logger.finer('Updating PkamPublicKey to remote secondary');
     String updateCommand =
-        'update:$AT_PKAM_PUBLIC_KEY ${_pkamRsaKeypair.publicKey}\n';
+        'update:$AT_PKAM_PUBLIC_KEY ${pkamRsaKeypair.publicKey}\n';
     String? pkamUpdateResult =
-    await _atLookup?.executeCommand(updateCommand, auth: false);
+        await _atLookup?.executeCommand(updateCommand, auth: false);
     logger.info('PkamPublicKey update result: $pkamUpdateResult');
-    atOnboardingPreference.privateKey = _pkamRsaKeypair.privateKey.toString();
+    atOnboardingPreference.privateKey = pkamRsaKeypair.privateKey.toString();
 
     //authenticate using pkam to verify insertion of pkamPublicKey
     _isPkamAuthenticated =
-    (await _atLookup?.authenticate(atOnboardingPreference.privateKey))!;
+        (await _atLookup?.authenticate(atOnboardingPreference.privateKey))!;
 
     if (_isPkamAuthenticated) {
       //update user encryption public key to remote secondary
       UpdateVerbBuilder updateBuilder = UpdateVerbBuilder()
         ..atKey = 'publickey'
         ..isPublic = true
-        ..value = _encryptionKeyPair.publicKey.toString()
+        ..value = encryptionKeyPair.publicKey.toString()
         ..sharedBy = _atSign;
       String? encryptKeyUpdateResult =
-      await _atLookup?.executeVerb(updateBuilder);
+          await _atLookup?.executeVerb(updateBuilder);
       logger
           .info('Encryption public key update result $encryptKeyUpdateResult');
       //deleting cram secret from the keystore as cram auth is complete
@@ -183,9 +184,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       }
     }
     //note: in case atKeysFilePath is provided instead of downloadPath;
-    //file is created with whichever name provided as atKeysFilePath(even if filename does not match standary atKeys file name convention)
+    //file is created with whichever name provided as atKeysFilePath(even if filename does not match standard atKeys file name convention)
     IOSink atKeysFile = File(atOnboardingPreference.downloadPath ??
-        atOnboardingPreference.atKeysFilePath!)
+            atOnboardingPreference.atKeysFilePath!)
         .openWrite();
 
     //generating .atKeys file at path provided in onboardingConfig
@@ -193,38 +194,35 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     await atKeysFile.flush();
     await atKeysFile.close();
     logger.info(
-        'atKeys file saved at ${atOnboardingPreference.downloadPath ??
-            atOnboardingPreference.atKeysFilePath}');
-    stdout.writeln(
-        '[Success] Your .atKeys file saved at ${atOnboardingPreference
-            .downloadPath ?? atOnboardingPreference.atKeysFilePath}\n');
+        'atKeys file saved at ${atOnboardingPreference.downloadPath ?? atOnboardingPreference.atKeysFilePath}');
   }
 
   ///back-up encryption keys to local secondary
   Future<void> _persistKeysLocalSecondary() async {
     //when authenticating keys need to be fetched from atKeys file
-    Map<String, String> _atKeysMap = await _decryptAtKeysFile(
+    Map<String, String> atKeysMap = await _decryptAtKeysFile(
         (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath))!);
     //backup keys into local secondary
     bool? response = await _atClient
         ?.getLocalSecondary()
-        ?.putValue(AT_PKAM_PUBLIC_KEY, _atKeysMap[AuthKeyType.pkamPublicKey]!);
+        ?.putValue(AT_PKAM_PUBLIC_KEY, atKeysMap[AuthKeyType.pkamPublicKey]!);
     logger.finer('PkamPublicKey persist to localSecondary: status $response');
-    response = await _atClient?.getLocalSecondary()?.putValue(
-        AT_PKAM_PRIVATE_KEY, _atKeysMap[AuthKeyType.pkamPrivateKey]!);
+    response = await _atClient
+        ?.getLocalSecondary()
+        ?.putValue(AT_PKAM_PRIVATE_KEY, atKeysMap[AuthKeyType.pkamPrivateKey]!);
     logger.finer('PkamPrivateKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
         '$AT_ENCRYPTION_PUBLIC_KEY$_atSign',
-        _atKeysMap[AuthKeyType.encryptionPublicKey]!);
+        atKeysMap[AuthKeyType.encryptionPublicKey]!);
     logger.finer(
         'EncryptionPublicKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
         AT_ENCRYPTION_PRIVATE_KEY,
-        _atKeysMap[AuthKeyType.encryptionPrivateKey]!);
+        atKeysMap[AuthKeyType.encryptionPrivateKey]!);
     logger.finer(
         'EncryptionPrivateKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
-        AT_ENCRYPTION_SELF_KEY, _atKeysMap[AuthKeyType.selfEncryptionKey]!);
+        AT_ENCRYPTION_SELF_KEY, atKeysMap[AuthKeyType.selfEncryptionKey]!);
     logger.finer(
         'Self encryption key persist to localSecondary: status $response');
   }
@@ -238,17 +236,18 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       throw AtPrivateKeyNotFoundException(
           'Either of private key or .atKeys file not provided in preferences',
           exceptionScenario: ExceptionScenario.invalidValueProvided);
-    } else {
-      _atClient ??= await getAtClient();
-      _isPkamAuthenticated =
-          await _atLookup?.authenticate(atOnboardingPreference.privateKey) ??
-              false;
-      if (!_isAtsignOnboarded &&
-          atOnboardingPreference.atKeysFilePath != null) {
-        await _persistKeysLocalSecondary();
-      }
-      return _isPkamAuthenticated;
     }
+    if (!(await networkUtil.isNetworkAvailable())) {
+      return false;
+    }
+    _atClient ??= await getAtClient();
+    _isPkamAuthenticated =
+        await _atLookup?.authenticate(atOnboardingPreference.privateKey) ??
+            false;
+    if (!_isAtsignOnboarded && atOnboardingPreference.atKeysFilePath != null) {
+      await _persistKeysLocalSecondary();
+    }
+    return _isPkamAuthenticated;
   }
 
   ///method to read and return data from .atKeysFile
@@ -268,10 +267,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to extract and decrypt pkamPrivateKey from atKeysData
   ///returns pkam_private_key
-  String? _getPkamPrivateKey(Map<String, String>? jsonData) =>
-      jsonData == null
-          ? null
-          : EncryptionUtil.decryptValue(
+  String? _getPkamPrivateKey(Map<String, String>? jsonData) => jsonData == null
+      ? null
+      : EncryptionUtil.decryptValue(
           jsonData[AuthKeyType.pkamPrivateKey]!, _getDecryptionKey(jsonData));
 
   ///method to extract decryption key from atKeysData
@@ -285,7 +283,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<Map<String, String>> _decryptAtKeysFile(
       Map<String, String> jsonData) async {
     String decryptionKey = _getDecryptionKey(jsonData);
-    Map<String, String> _atKeysMap = <String, String>{
+    Map<String, String> atKeysMap = <String, String>{
       AuthKeyType.pkamPublicKey: EncryptionUtil.decryptValue(
           jsonData[AuthKeyType.pkamPublicKey]!, decryptionKey),
       AuthKeyType.pkamPrivateKey: EncryptionUtil.decryptValue(
@@ -296,7 +294,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
           jsonData[AuthKeyType.encryptionPrivateKey]!, decryptionKey),
       AuthKeyType.selfEncryptionKey: decryptionKey,
     };
-    return _atKeysMap;
+    return atKeysMap;
   }
 
   ///generates random RSA keypair
@@ -318,14 +316,11 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   ///extracts cram secret from qrCode
-  String? _getSecretFromQr(String? path) {
+  static String? getSecretFromQr(String? path) {
     if (path != null) {
       Image? image = decodePng(File(path).readAsBytesSync());
       LuminanceSource source = RGBLuminanceSource(image!.width, image.height,
-          image
-              .getBytes(format: Format.abgr)
-              .buffer
-              .asInt32List());
+          image.getBytes(format: Format.abgr).buffer.asInt32List());
       BinaryBitmap bitmap = BinaryBitmap(HybridBinarizer(source));
       Result result = QRCodeReader().decode(bitmap);
       String secret = result.text.split(':')[1];
@@ -339,40 +334,50 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   ///If not, wait until secondary is created
   Future<void> _waitUntilSecondaryCreated() async {
     final maxRetries = 50;
-    int _retryCount = 0;
-    SecondaryAddress? _secondaryAddress;
+    int retryCount = 1;
+    SecondaryAddress? secondaryAddress;
     SecureSocket? secureSocket;
 
-    while (_retryCount < maxRetries && _secondaryAddress == null) {
-      logger.finer('retrying find secondary.......$_retryCount/$maxRetries');
+    while (retryCount <= maxRetries && secondaryAddress == null) {
+      await Future.delayed(Duration(seconds: 3));
+      logger.finer('retrying find secondary.......$retryCount/$maxRetries');
       try {
-        _secondaryAddress =
-        await _atLookup?.secondaryAddressFinder.findSecondary(_atSign);
+        secondaryAddress =
+            await _atLookup?.secondaryAddressFinder.findSecondary(_atSign);
       } on Exception catch (e) {
         logger.finer(e);
       }
-      _retryCount++;
+      retryCount++;
+    }
+
+    if (secondaryAddress == null) {
+      logger.severe('Could not find secondary address for $_atSign');
+      exit(1);
     }
     //resetting retry counter to be used for different operation
-    _retryCount = 0;
-    while (secureSocket == null && _retryCount < maxRetries) {
-      logger.finer('retrying connect secondary.......$_retryCount/$maxRetries');
-      stdout.writeln('Connecting to secondary ...');
+    retryCount = 1;
+    while (secureSocket == null && retryCount <= maxRetries) {
+      await Future.delayed(Duration(seconds: 3));
+      logger.finer('retrying connect secondary.......$retryCount/$maxRetries');
+      stdout.writeln('Connecting to secondary ...$retryCount/$maxRetries');
       try {
         secureSocket = await SecureSocket.connect(
-            _secondaryAddress!.host, _secondaryAddress.port);
+            secondaryAddress.host, secondaryAddress.port,
+            timeout: Duration(
+                seconds:
+                    30)); // 30-second timeout should be enough even for slow networks
       } on Exception catch (e) {
         logger.finer(e);
       }
+      retryCount++;
     }
-    stdout.writeln('\n');
   }
 
   @override
   Future<void> close() async {
     await _atLookup?.close();
     _atClient = null;
-    logger.severe('Killing current instance of at_onboarding_cli');
+    logger.info('Closing current instance of at_onboarding_cli');
     exit(0);
   }
 

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -24,9 +24,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   AtOnboardingPreference atOnboardingPreference;
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
-    _atSign = AtUtils.formatAtSign(atsign)!;
     //performs atSign format checks on the atSign
-    _atSign = AtUtils.fixAtSign(atsign);
+    _atSign = AtUtils.fixAtSign(AtUtils.formatAtSign(atsign)!);
   }
 
   @override

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -11,7 +11,6 @@ import 'package:encrypt/encrypt.dart';
 import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
-import 'package:at_client/src/util/network_util.dart';
 
 ///class containing service that can onboard/activate/authenticate @signs
 class AtOnboardingServiceImpl implements AtOnboardingService {
@@ -22,23 +21,23 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   AtClient? _atClient;
   AtSignLogger logger = AtSignLogger('OnboardingCli');
   AtOnboardingPreference atOnboardingPreference;
-  late NetworkUtil networkUtil;
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
-    atsign = AtUtils.formatAtSign(atsign)!;
+    _atSign = AtUtils.formatAtSign(atsign)!;
     //performs atSign format checks on the atSign
-    _atSign = AtUtils.fixAtSign(atsign);
-    networkUtil = NetworkUtil();
+    AtUtils.fixAtSign(_atSign);
   }
 
   @override
   Future<AtClient?> getAtClient() async {
     if (_atClient == null) {
-      AtClientManager atClientManager = AtClientManager.getInstance();
-      await atClientManager.setCurrentAtSign(
+      AtClientManager _atClientManager = AtClientManager.getInstance();
+      await _atClientManager.setCurrentAtSign(
           _atSign, atOnboardingPreference.namespace, atOnboardingPreference);
-      _atLookup = atClientManager.atClient.getRemoteSecondary()?.atLookUp;
-      return atClientManager.atClient;
+      _atLookup = _atClientManager.atClient
+          .getRemoteSecondary()
+          ?.atLookUp;
+      return _atClientManager.atClient;
     }
     return _atClient;
   }
@@ -47,7 +46,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<bool> onboard() async {
     //get cram_secret from either from AtOnboardingConfig or decode it from qr code whichever available
     atOnboardingPreference.cramSecret ??=
-        getSecretFromQr(atOnboardingPreference.qrCodePath);
+        _getSecretFromQr(atOnboardingPreference.qrCodePath);
 
     if (atOnboardingPreference.cramSecret == null) {
       throw AtClientException.message(
@@ -78,33 +77,33 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to generate/update encryption key-pairs to activate an atsign
   Future<void> _activateAtsign() async {
-    RSAKeypair pkamRsaKeypair;
-    RSAKeypair encryptionKeyPair;
-    String selfEncryptionKey;
+    RSAKeypair _pkamRsaKeypair;
+    RSAKeypair _encryptionKeyPair;
+    String _selfEncryptionKey;
     Map<String, String> atKeysMap;
 
     //generating pkamKeyPair
     logger.info('Generating pkam keypair');
-    pkamRsaKeypair = generateRsaKeypair();
+    _pkamRsaKeypair = generateRsaKeypair();
 
     //generate user encryption keypair
     logger.info('Generating encryption keypair');
-    encryptionKeyPair = generateRsaKeypair();
+    _encryptionKeyPair = generateRsaKeypair();
 
     //generate selfEncryptionKey
-    selfEncryptionKey = generateAESKey();
+    _selfEncryptionKey = generateAESKey();
 
     stdout.writeln(
-        '[Information] Generating your encryption keys and .atKeys file');
+        '[Information] Generating you encryption keys and .atKeys file\n');
     //mapping encryption keys pairs to their names
     atKeysMap = <String, String>{
-      AuthKeyType.pkamPublicKey: pkamRsaKeypair.publicKey.toString(),
-      AuthKeyType.pkamPrivateKey: pkamRsaKeypair.privateKey.toString(),
-      AuthKeyType.encryptionPublicKey: encryptionKeyPair.publicKey.toString(),
+      AuthKeyType.pkamPublicKey: _pkamRsaKeypair.publicKey.toString(),
+      AuthKeyType.pkamPrivateKey: _pkamRsaKeypair.privateKey.toString(),
+      AuthKeyType.encryptionPublicKey: _encryptionKeyPair.publicKey.toString(),
       AuthKeyType.encryptionPrivateKey:
-          encryptionKeyPair.privateKey.toString(),
-      AuthKeyType.selfEncryptionKey: selfEncryptionKey,
-      _atSign: selfEncryptionKey,
+      _encryptionKeyPair.privateKey.toString(),
+      AuthKeyType.selfEncryptionKey: _selfEncryptionKey,
+      _atSign: _selfEncryptionKey,
     };
     //generate .atKeys file
     await _generateAtKeysFile(atKeysMap);
@@ -112,25 +111,25 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     //updating pkamPublicKey to remote secondary
     logger.finer('Updating PkamPublicKey to remote secondary');
     String updateCommand =
-        'update:$AT_PKAM_PUBLIC_KEY ${pkamRsaKeypair.publicKey}\n';
+        'update:$AT_PKAM_PUBLIC_KEY ${_pkamRsaKeypair.publicKey}\n';
     String? pkamUpdateResult =
-        await _atLookup?.executeCommand(updateCommand, auth: false);
+    await _atLookup?.executeCommand(updateCommand, auth: false);
     logger.info('PkamPublicKey update result: $pkamUpdateResult');
-    atOnboardingPreference.privateKey = pkamRsaKeypair.privateKey.toString();
+    atOnboardingPreference.privateKey = _pkamRsaKeypair.privateKey.toString();
 
     //authenticate using pkam to verify insertion of pkamPublicKey
     _isPkamAuthenticated =
-        (await _atLookup?.authenticate(atOnboardingPreference.privateKey))!;
+    (await _atLookup?.authenticate(atOnboardingPreference.privateKey))!;
 
     if (_isPkamAuthenticated) {
       //update user encryption public key to remote secondary
       UpdateVerbBuilder updateBuilder = UpdateVerbBuilder()
         ..atKey = 'publickey'
         ..isPublic = true
-        ..value = encryptionKeyPair.publicKey.toString()
+        ..value = _encryptionKeyPair.publicKey.toString()
         ..sharedBy = _atSign;
       String? encryptKeyUpdateResult =
-          await _atLookup?.executeVerb(updateBuilder);
+      await _atLookup?.executeVerb(updateBuilder);
       logger
           .info('Encryption public key update result $encryptKeyUpdateResult');
       //deleting cram secret from the keystore as cram auth is complete
@@ -184,9 +183,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       }
     }
     //note: in case atKeysFilePath is provided instead of downloadPath;
-    //file is created with whichever name provided as atKeysFilePath(even if filename does not match standard atKeys file name convention)
+    //file is created with whichever name provided as atKeysFilePath(even if filename does not match standary atKeys file name convention)
     IOSink atKeysFile = File(atOnboardingPreference.downloadPath ??
-            atOnboardingPreference.atKeysFilePath!)
+        atOnboardingPreference.atKeysFilePath!)
         .openWrite();
 
     //generating .atKeys file at path provided in onboardingConfig
@@ -194,35 +193,38 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     await atKeysFile.flush();
     await atKeysFile.close();
     logger.info(
-        'atKeys file saved at ${atOnboardingPreference.downloadPath ?? atOnboardingPreference.atKeysFilePath}');
+        'atKeys file saved at ${atOnboardingPreference.downloadPath ??
+            atOnboardingPreference.atKeysFilePath}');
+    stdout.writeln(
+        '[Success] Your .atKeys file saved at ${atOnboardingPreference
+            .downloadPath ?? atOnboardingPreference.atKeysFilePath}\n');
   }
 
   ///back-up encryption keys to local secondary
   Future<void> _persistKeysLocalSecondary() async {
     //when authenticating keys need to be fetched from atKeys file
-    Map<String, String> atKeysMap = await _decryptAtKeysFile(
+    Map<String, String> _atKeysMap = await _decryptAtKeysFile(
         (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath))!);
     //backup keys into local secondary
     bool? response = await _atClient
         ?.getLocalSecondary()
-        ?.putValue(AT_PKAM_PUBLIC_KEY, atKeysMap[AuthKeyType.pkamPublicKey]!);
+        ?.putValue(AT_PKAM_PUBLIC_KEY, _atKeysMap[AuthKeyType.pkamPublicKey]!);
     logger.finer('PkamPublicKey persist to localSecondary: status $response');
-    response = await _atClient
-        ?.getLocalSecondary()
-        ?.putValue(AT_PKAM_PRIVATE_KEY, atKeysMap[AuthKeyType.pkamPrivateKey]!);
+    response = await _atClient?.getLocalSecondary()?.putValue(
+        AT_PKAM_PRIVATE_KEY, _atKeysMap[AuthKeyType.pkamPrivateKey]!);
     logger.finer('PkamPrivateKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
         '$AT_ENCRYPTION_PUBLIC_KEY$_atSign',
-        atKeysMap[AuthKeyType.encryptionPublicKey]!);
+        _atKeysMap[AuthKeyType.encryptionPublicKey]!);
     logger.finer(
         'EncryptionPublicKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
         AT_ENCRYPTION_PRIVATE_KEY,
-        atKeysMap[AuthKeyType.encryptionPrivateKey]!);
+        _atKeysMap[AuthKeyType.encryptionPrivateKey]!);
     logger.finer(
         'EncryptionPrivateKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
-        AT_ENCRYPTION_SELF_KEY, atKeysMap[AuthKeyType.selfEncryptionKey]!);
+        AT_ENCRYPTION_SELF_KEY, _atKeysMap[AuthKeyType.selfEncryptionKey]!);
     logger.finer(
         'Self encryption key persist to localSecondary: status $response');
   }
@@ -236,18 +238,17 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       throw AtPrivateKeyNotFoundException(
           'Either of private key or .atKeys file not provided in preferences',
           exceptionScenario: ExceptionScenario.invalidValueProvided);
+    } else {
+      _atClient ??= await getAtClient();
+      _isPkamAuthenticated =
+          await _atLookup?.authenticate(atOnboardingPreference.privateKey) ??
+              false;
+      if (!_isAtsignOnboarded &&
+          atOnboardingPreference.atKeysFilePath != null) {
+        await _persistKeysLocalSecondary();
+      }
+      return _isPkamAuthenticated;
     }
-    if (!(await networkUtil.isNetworkAvailable())) {
-      return false;
-    }
-    _atClient ??= await getAtClient();
-    _isPkamAuthenticated =
-        await _atLookup?.authenticate(atOnboardingPreference.privateKey) ??
-            false;
-    if (!_isAtsignOnboarded && atOnboardingPreference.atKeysFilePath != null) {
-      await _persistKeysLocalSecondary();
-    }
-    return _isPkamAuthenticated;
   }
 
   ///method to read and return data from .atKeysFile
@@ -267,9 +268,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to extract and decrypt pkamPrivateKey from atKeysData
   ///returns pkam_private_key
-  String? _getPkamPrivateKey(Map<String, String>? jsonData) => jsonData == null
-      ? null
-      : EncryptionUtil.decryptValue(
+  String? _getPkamPrivateKey(Map<String, String>? jsonData) =>
+      jsonData == null
+          ? null
+          : EncryptionUtil.decryptValue(
           jsonData[AuthKeyType.pkamPrivateKey]!, _getDecryptionKey(jsonData));
 
   ///method to extract decryption key from atKeysData
@@ -283,7 +285,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<Map<String, String>> _decryptAtKeysFile(
       Map<String, String> jsonData) async {
     String decryptionKey = _getDecryptionKey(jsonData);
-    Map<String, String> atKeysMap = <String, String>{
+    Map<String, String> _atKeysMap = <String, String>{
       AuthKeyType.pkamPublicKey: EncryptionUtil.decryptValue(
           jsonData[AuthKeyType.pkamPublicKey]!, decryptionKey),
       AuthKeyType.pkamPrivateKey: EncryptionUtil.decryptValue(
@@ -294,7 +296,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
           jsonData[AuthKeyType.encryptionPrivateKey]!, decryptionKey),
       AuthKeyType.selfEncryptionKey: decryptionKey,
     };
-    return atKeysMap;
+    return _atKeysMap;
   }
 
   ///generates random RSA keypair
@@ -316,11 +318,14 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   ///extracts cram secret from qrCode
-  static String? getSecretFromQr(String? path) {
+  String? _getSecretFromQr(String? path) {
     if (path != null) {
       Image? image = decodePng(File(path).readAsBytesSync());
       LuminanceSource source = RGBLuminanceSource(image!.width, image.height,
-          image.getBytes(format: Format.abgr).buffer.asInt32List());
+          image
+              .getBytes(format: Format.abgr)
+              .buffer
+              .asInt32List());
       BinaryBitmap bitmap = BinaryBitmap(HybridBinarizer(source));
       Result result = QRCodeReader().decode(bitmap);
       String secret = result.text.split(':')[1];
@@ -334,50 +339,40 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   ///If not, wait until secondary is created
   Future<void> _waitUntilSecondaryCreated() async {
     final maxRetries = 50;
-    int retryCount = 1;
-    SecondaryAddress? secondaryAddress;
+    int _retryCount = 0;
+    SecondaryAddress? _secondaryAddress;
     SecureSocket? secureSocket;
 
-    while (retryCount <= maxRetries && secondaryAddress == null) {
-      await Future.delayed(Duration(seconds: 3));
-      logger.finer('retrying find secondary.......$retryCount/$maxRetries');
+    while (_retryCount < maxRetries && _secondaryAddress == null) {
+      logger.finer('retrying find secondary.......$_retryCount/$maxRetries');
       try {
-        secondaryAddress =
-            await _atLookup?.secondaryAddressFinder.findSecondary(_atSign);
+        _secondaryAddress =
+        await _atLookup?.secondaryAddressFinder.findSecondary(_atSign);
       } on Exception catch (e) {
         logger.finer(e);
       }
-      retryCount++;
-    }
-
-    if (secondaryAddress == null) {
-      logger.severe('Could not find secondary address for $_atSign');
-      exit(1);
+      _retryCount++;
     }
     //resetting retry counter to be used for different operation
-    retryCount = 1;
-    while (secureSocket == null && retryCount <= maxRetries) {
-      await Future.delayed(Duration(seconds: 3));
-      logger.finer('retrying connect secondary.......$retryCount/$maxRetries');
-      stdout.writeln('Connecting to secondary ...$retryCount/$maxRetries');
+    _retryCount = 0;
+    while (secureSocket == null && _retryCount < maxRetries) {
+      logger.finer('retrying connect secondary.......$_retryCount/$maxRetries');
+      stdout.writeln('Connecting to secondary ...');
       try {
         secureSocket = await SecureSocket.connect(
-            secondaryAddress.host, secondaryAddress.port,
-            timeout: Duration(
-                seconds:
-                    30)); // 30-second timeout should be enough even for slow networks
+            _secondaryAddress!.host, _secondaryAddress.port);
       } on Exception catch (e) {
         logger.finer(e);
       }
-      retryCount++;
     }
+    stdout.writeln('\n');
   }
 
   @override
   Future<void> close() async {
     await _atLookup?.close();
     _atClient = null;
-    logger.info('Closing current instance of at_onboarding_cli');
+    logger.severe('Killing current instance of at_onboarding_cli');
     exit(0);
   }
 

--- a/packages/at_onboarding_cli/lib/src/util/network_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/network_util.dart
@@ -1,0 +1,15 @@
+import 'package:at_utils/at_logger.dart';
+import 'package:internet_connection_checker/internet_connection_checker.dart';
+
+class NetworkUtil {
+
+  static AtSignLogger logger = AtSignLogger('NetworkUtil');
+
+  static Future<bool> isNetworkAvailable() async {
+    var result = await InternetConnectionChecker().hasConnection;
+    if (!result) {
+      logger.finer('Unable to connect to internet');
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/271

**- What I did**
- At the moment there is no timeout for socket.connect() calls in AtLookup. As a result of which async calls try to connect to the secondary indefinitely when the network is unavailable. By introducing a 30-sec timeout for each of these calls, when the network is unavailable the whole process times out in 1 minute and then the authenticate method returns false if the connection could not be established.

**- How I did it**
- added 30-sec timeout for socket.connect() in secondadyAddressFinder.findSecondary()
- added 30-sec timeout for socket.connect() in SecureSocketUtil.createSecureSocket()
- handle the exceptions that above-mentioned changes in case of a time-out will throw. Also, return 'false' when AtLookupImpl.authenticate() encounters an exception.
- add a network availability check in onboardingService.authenticate() that will terminate in case of network unavailability

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: added timeouts for socket.connect() calls