### PR TITLE
chore: publish at_lookup 3.0.35

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.35
+- fix: fallback code for backward compatibility if at_chops instance is not set
 ## 3.0.34
 - feat: added new method pkamAuthenticate in at_lookup_impl which uses at_chops for pkam signing.
 ## 3.0.33

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.34
+version: 3.0.35
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -13,7 +13,7 @@ dependencies:
   crypton: ^2.0.1
   crypto: ^3.0.1
   at_utils: ^3.0.11
-  at_commons: ^3.0.26
+  at_commons: ^3.0.34
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0


### PR DESCRIPTION
**- What I did**
- publish at_lookup 3.0.35 for fallback code if at_chops is not set
**- How I did it**
- modified changelog and pubspec
**- How to verify it**
- run the unit tests
