### PR TITLE
feat: at_chops signing algorithms new implementation and refactoring

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,2 +1,4 @@
+## 1.0.1
+- feat: Added implementation for different signing algorithms.
 ## 1.0.0
 - Initial version.

--- a/packages/at_chops/example/at_chops_example.dart
+++ b/packages/at_chops/example/at_chops_example.dart
@@ -23,7 +23,8 @@ void main() {
   // 2 - Signing and data verification using asymmetric key pair
   final digest = 'sample pkam digest';
   //2.1 sign the digest using [atPkamKeyPair.privateKey]
-  final signingResult = atChops.signString(digest, SigningKeyType.signingSha256);
+  final signingResult =
+      atChops.signString(digest, SigningKeyType.signingSha256);
   //2.2 verify the signature using [atPkamKeyPair.publicKey]
   final verificationResult = atChops.verifySignatureString(
       digest, signingResult.result, SigningKeyType.signingSha256);

--- a/packages/at_chops/example/at_chops_example.dart
+++ b/packages/at_chops/example/at_chops_example.dart
@@ -1,4 +1,6 @@
 import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 
 void main() {
   final atEncryptionKeyPair = AtChopsUtil
@@ -15,18 +17,42 @@ void main() {
   //1.1 encrypt the data using [atEncryptionKeyPair.publicKey]
   final encryptionResult =
       atChops.encryptString(data, EncryptionKeyType.rsa2048);
+
   //1.2 decrypt the data using [atEncryptionKeyPair.privateKey]
   final decryptionResult =
       atChops.decryptString(encryptionResult.result, EncryptionKeyType.rsa2048);
   assert(data == decryptionResult.result, true);
 
   // 2 - Signing and data verification using asymmetric key pair
+  // Using signString() and verifyString()
   final digest = 'sample pkam digest';
   //2.1 sign the digest using [atPkamKeyPair.privateKey]
   final signingResult =
       atChops.signString(digest, SigningKeyType.signingSha256);
+
   //2.2 verify the signature using [atPkamKeyPair.publicKey]
   final verificationResult = atChops.verifySignatureString(
       digest, signingResult.result, SigningKeyType.signingSha256);
   assert(verificationResult.result, true);
+
+  // 3 - Signing and data verification using asymmetric key pair
+  // Using sign() and verify()
+  String plainText = 'some demo data';
+  //3.1.1 Create a valid instance of AtSigningInput
+  AtSigningInput signingInput = AtSigningInput(plainText);
+  AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
+      atEncryptionKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
+  signingInput.signingAlgorithm = signingAlgorithm;
+  //3.1.2 Use the instance of AtSigningInput to generate a signature
+  final signResult = atChops.sign(signingInput);
+
+  //3.2.1 Create a valid instance of AtSigningVerificationInput
+  AtSigningVerificationInput? verificationInput = AtSigningVerificationInput(
+      plainText, signResult.result, atEncryptionKeyPair.atPublicKey.publicKey);
+  AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
+      atEncryptionKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
+  verificationInput.signingAlgorithm = verifyAlgorithm;
+  //3.2.2 Use the instance of AtSigningVerificationInput to verify the signature
+  AtSigningResult verifyResult = atChops.verify(verificationInput);
+  assert(verifyResult.result == true);
 }

--- a/packages/at_chops/example/at_chops_example.dart
+++ b/packages/at_chops/example/at_chops_example.dart
@@ -28,10 +28,12 @@ void main() {
   final digest = 'sample pkam digest';
   //2.1 sign the digest using [atPkamKeyPair.privateKey]
   final signingResult =
+  // ignore: deprecated_member_use_from_same_package
       atChops.signString(digest, SigningKeyType.signingSha256);
 
   //2.2 verify the signature using [atPkamKeyPair.publicKey]
   final verificationResult = atChops.verifySignatureString(
+    // ignore: deprecated_member_use_from_same_package
       digest, signingResult.result, SigningKeyType.signingSha256);
   assert(verificationResult.result, true);
 
@@ -41,7 +43,7 @@ void main() {
   //3.1.1 Create a valid instance of AtSigningInput
   AtSigningInput signingInput = AtSigningInput(plainText);
   AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
-      atEncryptionKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
+      atEncryptionKeyPair, HashingAlgoType.sha512);
   signingInput.signingAlgorithm = signingAlgorithm;
   //3.1.2 Use the instance of AtSigningInput to generate a signature
   final signResult = atChops.sign(signingInput);
@@ -50,7 +52,7 @@ void main() {
   AtSigningVerificationInput? verificationInput = AtSigningVerificationInput(
       plainText, signResult.result, atEncryptionKeyPair.atPublicKey.publicKey);
   AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
-      atEncryptionKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
+      atEncryptionKeyPair, HashingAlgoType.sha512);
   verificationInput.signingAlgorithm = verifyAlgorithm;
   //3.2.2 Use the instance of AtSigningVerificationInput to verify the signature
   AtSigningResult verifyResult = atChops.verify(verificationInput);

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -12,5 +12,3 @@ export 'src/metadata/encryption_result.dart';
 export 'src/metadata/signing_metadata.dart';
 export 'src/metadata/signing_result.dart';
 export 'src/util/at_chops_util.dart';
-export 'src/util/at_data_signing_exception.dart';
-export 'src/util/at_signature_verification_result.dart';

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -2,12 +2,15 @@ library at_chops;
 
 export 'src/at_chops_base.dart';
 export 'src/at_chops_impl.dart';
-export 'src/util/at_chops_util.dart';
-export 'src/key/key_type.dart';
 export 'src/key/impl/at_chops_keys.dart';
 export 'src/key/impl/at_encryption_key_pair.dart';
 export 'src/key/impl/at_pkam_key_pair.dart';
+export 'src/key/key_type.dart';
+export 'src/metadata/at_signing_input.dart';
 export 'src/metadata/encryption_metadata.dart';
 export 'src/metadata/encryption_result.dart';
 export 'src/metadata/signing_metadata.dart';
 export 'src/metadata/signing_result.dart';
+export 'src/util/at_chops_util.dart';
+export 'src/util/at_data_signing_exception.dart';
+export 'src/util/at_signature_verification_result.dart';

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -12,3 +12,4 @@ export 'src/metadata/encryption_result.dart';
 export 'src/metadata/signing_metadata.dart';
 export 'src/metadata/signing_result.dart';
 export 'src/util/at_chops_util.dart';
+export 'src/algorithm/algo_type.dart';

--- a/packages/at_chops/lib/src/algorithm/algo_type.dart
+++ b/packages/at_chops/lib/src/algorithm/algo_type.dart
@@ -1,3 +1,3 @@
-enum SigningAlgoType { ecc_secp256r1, rsa2048 }
+enum SigningAlgoType { ecc_secp256r1, rsa2048, rsa4096 }
 
 enum HashingAlgoType { sha256, sha512, md5 }

--- a/packages/at_chops/lib/src/algorithm/algo_type.dart
+++ b/packages/at_chops/lib/src/algorithm/algo_type.dart
@@ -1,0 +1,3 @@
+enum SigningAlgoType { ecc_secp256r1, rsa2048 }
+
+enum HashingAlgoType { sha256, sha512, md5 }

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/at_private_key.dart';
@@ -27,10 +28,14 @@ abstract class SymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
 /// Signed data signature is verified with public key of the key pair.
 abstract class AtSigningAlgorithm {
   /// Signs the data using [AtPrivateKey] of [AsymmetricKeyPair]
-  Uint8List sign(Uint8List data, int digestLength);
+  Uint8List sign(Uint8List data);
 
   /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair]
-  bool verify(Uint8List signedData, Uint8List signature, int digestLength);
+  bool verify(Uint8List signedData, Uint8List signature);
+
+  void setHashingAlgoType(HashingAlgoType? hashingAlgoType);
+
+  void setSigningAlgoType(SigningAlgoType? signingAlgoType);
 }
 
 /// Interface for hashing data. Refer [DefaultHash] for sample implementation.

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/at_private_key.dart';

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -32,14 +32,6 @@ abstract class AtSigningAlgorithm {
 
   /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair] or the passed [publicKey]
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey});
-
-  HashingAlgoType? getHashingAlgo();
-
-  void setHashingAlgoType(HashingAlgoType? hashingAlgoType);
-
-  SigningAlgoType? getSigningAlgo();
-
-  void setSigningAlgoType(SigningAlgoType? signingAlgoType);
 }
 
 /// Interface for hashing data. Refer [DefaultHash] for sample implementation.

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -30,8 +30,8 @@ abstract class AtSigningAlgorithm {
   /// Signs the data using [AtPrivateKey] of [AsymmetricKeyPair]
   Uint8List sign(Uint8List data);
 
-  /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair]
-  bool verify(Uint8List signedData, Uint8List signature);
+  /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair] or the passed [publicKey]
+  bool verify(Uint8List signedData, Uint8List signature, {String? publicKey});
 
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType);
 

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -27,10 +27,10 @@ abstract class SymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
 /// Signed data signature is verified with public key of the key pair.
 abstract class AtSigningAlgorithm {
   /// Signs the data using [AtPrivateKey] of [AsymmetricKeyPair]
-  Uint8List sign(Uint8List data);
+  Uint8List sign(Uint8List data, int digestLength);
 
   /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair]
-  bool verify(Uint8List signedData, Uint8List signature);
+  bool verify(Uint8List signedData, Uint8List signature, int digestLength);
 }
 
 /// Interface for hashing data. Refer [DefaultHash] for sample implementation.

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -33,7 +33,11 @@ abstract class AtSigningAlgorithm {
   /// Verifies the data signature using [AtPublicKey] of [AsymmetricKeyPair] or the passed [publicKey]
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey});
 
+  HashingAlgoType? getHashingAlgo();
+
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType);
+
+  SigningAlgoType? getSigningAlgo();
 
   void setSigningAlgoType(SigningAlgoType? signingAlgoType);
 }

--- a/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
@@ -3,14 +3,12 @@ import 'dart:typed_data';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
-import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 class DefaultEncryptionAlgo implements AtEncryptionAlgorithm {
   final AtEncryptionKeyPair _encryptionKeypair;
-  final EncryptionKeyType _encryptionKeyType;
-  DefaultEncryptionAlgo(this._encryptionKeypair, this._encryptionKeyType);
+  DefaultEncryptionAlgo(this._encryptionKeypair);
 
   @override
   Uint8List encrypt(Uint8List plainData, {InitialisationVector? iv}) {

--- a/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
@@ -2,10 +2,10 @@ import 'dart:typed_data';
 
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
-import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
-import 'package:crypton/crypton.dart';
+import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_commons/at_commons.dart';
+import 'package:crypton/crypton.dart';
 
 class DefaultEncryptionAlgo implements AtEncryptionAlgorithm {
   final AtEncryptionKeyPair _encryptionKeypair;

--- a/packages/at_chops/lib/src/algorithm/default_hashing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_hashing_algo.dart
@@ -1,6 +1,5 @@
-import 'package:crypto/crypto.dart';
-
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:crypto/crypto.dart';
 
 class DefaultHash implements AtHashingAlgorithm {
   @override

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -6,11 +6,16 @@ import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
-/// Data signing and verification using sha256 hash and atsign encryption keypair
+/// Data signing and verification using atsign encryption keypair
+/// [_signingAlgoType] and [_hashingAlgoType] need to be specified
+/// Allowed specifications are listed in [SigningAlgoType] and [HashingAlgoType]
+/// Default [_signingAlgoType] is [SigningAlgoType.rsa2048]
+/// Default [_hashingAlgoType] is [HashingAlgoType.sha256]
 class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair? _encryptionKeyPair;
   SigningAlgoType? _signingAlgoType;
   HashingAlgoType? _hashingAlgoType;
+
   DefaultSigningAlgo(this._encryptionKeyPair);
 
   @override
@@ -55,9 +60,15 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
   }
 
   @override
+  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
+
+  @override
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
     _hashingAlgoType = hashingAlgoType;
   }
+
+  @override
+  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
 
   @override
   void setSigningAlgoType(SigningAlgoType? signingAlgoType) {

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -3,25 +3,37 @@ import 'dart:typed_data';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
 import 'package:at_chops/src/key/key_type.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair _encryptionKeyPair;
   final SigningKeyType _signingKeyType;
-  DefaultSigningAlgo(this._encryptionKeyPair, this._signingKeyType);
+  final String? verificationPublicKey;
+  DefaultSigningAlgo(this._encryptionKeyPair, this._signingKeyType, {this.verificationPublicKey});
 
   @override
-  Uint8List sign(Uint8List data) {
+  Uint8List sign(Uint8List data, int digestLength) {
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_encryptionKeyPair.atPrivateKey.privateKey);
     return rsaPrivateKey.createSHA256Signature(data);
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature) {
-    final rsaPublicKey =
-        RSAPublicKey.fromString(_encryptionKeyPair.atPublicKey.publicKey);
+  bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
+    if(verificationPublicKey == null){
+      throw AtException('PublicKey is required to verify a digital signature');
+    }
+    final rsaPublicKey = RSAPublicKey.fromString(verificationPublicKey!);
     return rsaPublicKey.verifySHA256Signature(signedData, signature);
+  }
+
+  static int parseDigestLength(String signatureSpec){
+    return signatureSpec.split('/')[1] as int;
+  }
+
+  static String generateDigestSpec(int digestLength){
+    return 'SHA-2/$digestLength';
   }
 }

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -10,11 +10,10 @@ import 'package:crypton/crypton.dart';
 /// Allowed algorithms are listed in [SigningAlgoType] and [HashingAlgoType]
 class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair? _encryptionKeyPair;
-  SigningAlgoType _signingAlgoType;
-  HashingAlgoType _hashingAlgoType;
+  final HashingAlgoType _hashingAlgoType;
 
   DefaultSigningAlgo(
-      this._encryptionKeyPair, this._signingAlgoType, this._hashingAlgoType);
+      this._encryptionKeyPair, this._hashingAlgoType);
 
   @override
   Uint8List sign(Uint8List data) {

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -1,42 +1,55 @@
 import 'dart:typed_data';
 
+import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
-import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
-/// Data signing and verification for Public Key Authentication Mechanism - Pkam
+/// Data signing and verification using sha256 hash and atsign encryption keypair
 class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair _encryptionKeyPair;
-  final SigningKeyType _signingKeyType;
-  final String? verificationPublicKey;
-  DefaultSigningAlgo(this._encryptionKeyPair, this._signingKeyType,
-      {this.verificationPublicKey});
+  SigningAlgoType? _signingAlgoType;
+  HashingAlgoType? _hashingAlgoType;
+  DefaultSigningAlgo(this._encryptionKeyPair);
 
   @override
-  Uint8List sign(Uint8List data, int digestLength) {
+  Uint8List sign(Uint8List data) {
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_encryptionKeyPair.atPrivateKey.privateKey);
-    return rsaPrivateKey.createSHA256Signature(data);
+    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
+    switch (_hashingAlgoType) {
+      case HashingAlgoType.sha256:
+        return rsaPrivateKey.createSHA256Signature(data);
+      case HashingAlgoType.sha512:
+        return rsaPrivateKey.createSHA512Signature(data);
+      default:
+        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
+    }
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
-    if (verificationPublicKey == null) {
-      throw AtException('PublicKey is required to verify a digital signature');
+  bool verify(Uint8List signedData, Uint8List signature) {
+    final rsaPublicKey =
+        RSAPublicKey.fromString(_encryptionKeyPair.atPublicKey.publicKey);
+    _hashingAlgoType ??= HashingAlgoType.sha256;
+    switch (_hashingAlgoType) {
+      case HashingAlgoType.sha256:
+        return rsaPublicKey.verifySHA256Signature(signedData, signature);
+      case HashingAlgoType.sha512:
+        return rsaPublicKey.verifySHA512Signature(signedData, signature);
+      default:
+        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
     }
-    final rsaPublicKey = RSAPublicKey.fromString(verificationPublicKey!);
-    return rsaPublicKey.verifySHA256Signature(signedData, signature);
   }
 
-  static int parseDigestLength(String signatureSpec) {
-    return signatureSpec.split('/')[1] as int;
+  @override
+  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
+    _hashingAlgoType = hashingAlgoType;
   }
 
-  static String generateDigestSpec(int digestLength) {
-    return 'SHA-2/$digestLength';
+  @override
+  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
+    _signingAlgoType = signingAlgoType;
   }
 }
-
-//TODO enum that contains signing algorithms to choose from

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -33,7 +33,7 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
 
   @override
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
-    var rsaPublicKey;
+    RSAPublicKey? rsaPublicKey;
     if (publicKey != null) {
       rsaPublicKey = RSAPublicKey.fromString(publicKey);
     } else if (_encryptionKeyPair != null) {

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -38,3 +38,5 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
     return 'SHA-2/$digestLength';
   }
 }
+
+//TODO enum that contains signing algorithms to choose from

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -12,13 +12,13 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair? _encryptionKeyPair;
   final HashingAlgoType _hashingAlgoType;
 
-  DefaultSigningAlgo(
-      this._encryptionKeyPair, this._hashingAlgoType);
+  DefaultSigningAlgo(this._encryptionKeyPair, this._hashingAlgoType);
 
   @override
   Uint8List sign(Uint8List data) {
     if (_encryptionKeyPair == null) {
-      throw AtException('encryption key pair not set for default signing algo');
+      throw AtSigningException(
+          'encryption key pair not set for default signing algo');
     }
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_encryptionKeyPair!.atPrivateKey.privateKey);
@@ -28,7 +28,7 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException(
+        throw AtSigningException(
             'Hashing algo $_hashingAlgoType is invalid/not supported');
     }
   }
@@ -42,7 +42,7 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       rsaPublicKey =
           RSAPublicKey.fromString(_encryptionKeyPair!.atPublicKey.publicKey);
     } else {
-      throw AtException(
+      throw AtSigningVerificationException(
           'Encryption key pair or public key not set for default signing algo');
     }
     switch (_hashingAlgoType) {
@@ -51,7 +51,8 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPublicKey.verifySHA512Signature(signedData, signature);
       default:
-        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
+        throw AtSigningVerificationException(
+            'Invalid hashing algo $_hashingAlgoType provided');
     }
   }
 }

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -11,7 +11,8 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair _encryptionKeyPair;
   final SigningKeyType _signingKeyType;
   final String? verificationPublicKey;
-  DefaultSigningAlgo(this._encryptionKeyPair, this._signingKeyType, {this.verificationPublicKey});
+  DefaultSigningAlgo(this._encryptionKeyPair, this._signingKeyType,
+      {this.verificationPublicKey});
 
   @override
   Uint8List sign(Uint8List data, int digestLength) {
@@ -22,18 +23,18 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
 
   @override
   bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
-    if(verificationPublicKey == null){
+    if (verificationPublicKey == null) {
       throw AtException('PublicKey is required to verify a digital signature');
     }
     final rsaPublicKey = RSAPublicKey.fromString(verificationPublicKey!);
     return rsaPublicKey.verifySHA256Signature(signedData, signature);
   }
 
-  static int parseDigestLength(String signatureSpec){
+  static int parseDigestLength(String signatureSpec) {
     return signatureSpec.split('/')[1] as int;
   }
 
-  static String generateDigestSpec(int digestLength){
+  static String generateDigestSpec(int digestLength) {
     return 'SHA-2/$digestLength';
   }
 }

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -32,7 +32,7 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
+        throw AtException('Hashing algo $_hashingAlgoType is invalid/not supported');
     }
   }
 

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -7,16 +7,14 @@ import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 /// Data signing and verification using atsign encryption keypair
-/// [_signingAlgoType] and [_hashingAlgoType] need to be specified
-/// Allowed specifications are listed in [SigningAlgoType] and [HashingAlgoType]
-/// Default [_signingAlgoType] is [SigningAlgoType.rsa2048]
-/// Default [_hashingAlgoType] is [HashingAlgoType.sha256]
+/// Allowed algorithms are listed in [SigningAlgoType] and [HashingAlgoType]
 class DefaultSigningAlgo implements AtSigningAlgorithm {
   final AtEncryptionKeyPair? _encryptionKeyPair;
-  SigningAlgoType? _signingAlgoType;
-  HashingAlgoType? _hashingAlgoType;
+  SigningAlgoType _signingAlgoType;
+  HashingAlgoType _hashingAlgoType;
 
-  DefaultSigningAlgo(this._encryptionKeyPair);
+  DefaultSigningAlgo(
+      this._encryptionKeyPair, this._signingAlgoType, this._hashingAlgoType);
 
   @override
   Uint8List sign(Uint8List data) {
@@ -25,14 +23,14 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
     }
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_encryptionKeyPair!.atPrivateKey.privateKey);
-    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
         return rsaPrivateKey.createSHA256Signature(data);
       case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException('Hashing algo $_hashingAlgoType is invalid/not supported');
+        throw AtException(
+            'Hashing algo $_hashingAlgoType is invalid/not supported');
     }
   }
 
@@ -48,7 +46,6 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       throw AtException(
           'Encryption key pair or public key not set for default signing algo');
     }
-    _hashingAlgoType ??= HashingAlgoType.sha256;
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
         return rsaPublicKey.verifySHA256Signature(signedData, signature);
@@ -57,21 +54,5 @@ class DefaultSigningAlgo implements AtSigningAlgorithm {
       default:
         throw AtException('Invalid hashing algo $_hashingAlgoType provided');
     }
-  }
-
-  @override
-  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
-
-  @override
-  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
-    _hashingAlgoType = hashingAlgoType;
-  }
-
-  @override
-  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
-
-  @override
-  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
-    _signingAlgoType = signingAlgoType;
   }
 }

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -6,11 +6,9 @@ import 'package:crypto/crypto.dart';
 import 'package:ecdsa/ecdsa.dart' as ecdsa;
 import 'package:elliptic/elliptic.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/key/key_type.dart';
 
 /// Data signing and verification for ECDSA - elliptic curve
 class EccSigningAlgo implements AtSigningAlgorithm {
-  String? publicKey;
   SigningAlgoType? _signingAlgoType;
   HashingAlgoType? _hashingAlgoType;
   EccSigningAlgo();
@@ -21,7 +19,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature) {
+  bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
     if (publicKey == null) {
       throw AtException('public key not set not ecc verification');
     }
@@ -29,7 +27,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
     var hashHex = sha256.convert(signedData).toString();
     var hash = List<int>.generate(hashHex.length ~/ 2,
         (i) => int.parse(hashHex.substring(i * 2, i * 2 + 2), radix: 16));
-    var pubKey = ec.hexToPublicKey(publicKey!);
+    var pubKey = ec.hexToPublicKey(publicKey);
     var eccSignature =
         ecdsa.Signature.fromCompactHex(String.fromCharCodes(signature));
     return ecdsa.verify(pubKey, hash, eccSignature);

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -16,7 +16,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   @override
   Uint8List sign(Uint8List data) {
     if (_privateKey == null) {
-      throw AtException(
+      throw AtSigningException(
           'elliptic private key has to be set for signing operation');
     }
     var hashHex = sha256.convert(data).toString();
@@ -29,7 +29,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   @override
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
     if (publicKey == null && _privateKey == null) {
-      throw AtException('public key not set not ecc verification');
+      throw AtSigningVerificationException('public key not set not ecc verification');
     }
     var ec = elliptic.getSecp256r1();
     var hashHex = sha256.convert(signedData).toString();

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -5,29 +5,45 @@ import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypto/crypto.dart';
 import 'package:ecdsa/ecdsa.dart' as ecdsa;
-import 'package:elliptic/elliptic.dart';
+import 'package:elliptic/elliptic.dart' as elliptic;
 
 /// Data signing and verification for ECDSA - elliptic curve
+/// Currently uses sha256 hashing for data. #TODO implement using _hashingAlgoType in the future.
 class EccSigningAlgo implements AtSigningAlgorithm {
   SigningAlgoType? _signingAlgoType;
   HashingAlgoType? _hashingAlgoType;
+  elliptic.PrivateKey? _privateKey;
+
   EccSigningAlgo();
 
   @override
-  Uint8List sign(Uint8List dataHash) {
-    throw UnimplementedError('not implemented');
+  Uint8List sign(Uint8List data) {
+    if (_privateKey == null) {
+      throw AtException(
+          'elliptic private key has to be set for signing operation');
+    }
+    var hashHex = sha256.convert(data).toString();
+    var hash = List<int>.generate(hashHex.length ~/ 2,
+        (i) => int.parse(hashHex.substring(i * 2, i * 2 + 2), radix: 16));
+    return Uint8List.fromList(
+        ecdsa.signature(_privateKey!, hash).toCompactHex().codeUnits);
   }
 
   @override
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
-    if (publicKey == null) {
+    if (publicKey == null && _privateKey == null) {
       throw AtException('public key not set not ecc verification');
     }
-    var ec = getSecp256r1();
+    var ec = elliptic.getSecp256r1();
     var hashHex = sha256.convert(signedData).toString();
     var hash = List<int>.generate(hashHex.length ~/ 2,
         (i) => int.parse(hashHex.substring(i * 2, i * 2 + 2), radix: 16));
-    var pubKey = ec.hexToPublicKey(publicKey);
+    var pubKey;
+    if (publicKey != null) {
+      pubKey = ec.hexToPublicKey(publicKey);
+    } else {
+      pubKey = _privateKey!.publicKey;
+    }
     var eccSignature =
         ecdsa.Signature.fromCompactHex(String.fromCharCodes(signature));
     return ecdsa.verify(pubKey, hash, eccSignature);
@@ -38,7 +54,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
 
   @override
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
-    // TODO: implement setHashingAlgoType
+    _hashingAlgoType = hashingAlgoType;
   }
 
   @override
@@ -46,6 +62,12 @@ class EccSigningAlgo implements AtSigningAlgorithm {
 
   @override
   void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
-    // TODO: implement setSigningAlgoType
+    _signingAlgoType = signingAlgoType;
+  }
+
+  elliptic.PrivateKey? get privateKey => _privateKey;
+
+  set privateKey(elliptic.PrivateKey? value) {
+    _privateKey = value;
   }
 }

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+
+import 'package:at_chops/src/algorithm/algo_type.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:crypto/crypto.dart';
+import 'package:ecdsa/ecdsa.dart' as ecdsa;
+import 'package:elliptic/elliptic.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_chops/src/key/key_type.dart';
+
+/// Data signing and verification for ECDSA - elliptic curve
+class EccSigningAlgo implements AtSigningAlgorithm {
+  String? publicKey;
+  SigningAlgoType? _signingAlgoType;
+  HashingAlgoType? _hashingAlgoType;
+  EccSigningAlgo();
+
+  @override
+  Uint8List sign(Uint8List dataHash) {
+    throw UnimplementedError('not implemented');
+  }
+
+  @override
+  bool verify(Uint8List signedData, Uint8List signature) {
+    if (publicKey == null) {
+      throw AtException('public key not set not ecc verification');
+    }
+    var ec = getSecp256r1();
+    var hashHex = sha256.convert(signedData).toString();
+    var hash = List<int>.generate(hashHex.length ~/ 2,
+        (i) => int.parse(hashHex.substring(i * 2, i * 2 + 2), radix: 16));
+    var pubKey = ec.hexToPublicKey(publicKey!);
+    var eccSignature =
+        ecdsa.Signature.fromCompactHex(String.fromCharCodes(signature));
+    return ecdsa.verify(pubKey, hash, eccSignature);
+  }
+
+  @override
+  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
+    // TODO: implement setHashingAlgoType
+  }
+
+  @override
+  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
+    // TODO: implement setSigningAlgoType
+  }
+}

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -8,10 +8,8 @@ import 'package:ecdsa/ecdsa.dart' as ecdsa;
 import 'package:elliptic/elliptic.dart' as elliptic;
 
 /// Data signing and verification for ECDSA - elliptic curve
-/// Currently uses sha256 hashing for data. #TODO implement using _hashingAlgoType in the future.
+/// Uses sha256 hashing for data. Extend implementation for other hashing algorithm in the future.
 class EccSigningAlgo implements AtSigningAlgorithm {
-  SigningAlgoType? _signingAlgoType;
-  HashingAlgoType? _hashingAlgoType;
   elliptic.PrivateKey? _privateKey;
 
   EccSigningAlgo();
@@ -47,22 +45,6 @@ class EccSigningAlgo implements AtSigningAlgorithm {
     var eccSignature =
         ecdsa.Signature.fromCompactHex(String.fromCharCodes(signature));
     return ecdsa.verify(pubKey, hash, eccSignature);
-  }
-
-  @override
-  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
-
-  @override
-  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
-    _hashingAlgoType = hashingAlgoType;
-  }
-
-  @override
-  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
-
-  @override
-  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
-    _signingAlgoType = signingAlgoType;
   }
 
   elliptic.PrivateKey? get privateKey => _privateKey;

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypto/crypto.dart';
@@ -36,7 +35,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
     var hashHex = sha256.convert(signedData).toString();
     var hash = List<int>.generate(hashHex.length ~/ 2,
         (i) => int.parse(hashHex.substring(i * 2, i * 2 + 2), radix: 16));
-    var pubKey;
+    elliptic.PublicKey pubKey;
     if (publicKey != null) {
       pubKey = ec.hexToPublicKey(publicKey);
     } else {

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -1,11 +1,11 @@
 import 'dart:typed_data';
 
 import 'package:at_chops/src/algorithm/algo_type.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypto/crypto.dart';
 import 'package:ecdsa/ecdsa.dart' as ecdsa;
 import 'package:elliptic/elliptic.dart';
-import 'package:at_chops/src/algorithm/at_algorithm.dart';
 
 /// Data signing and verification for ECDSA - elliptic curve
 class EccSigningAlgo implements AtSigningAlgorithm {
@@ -34,9 +34,15 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   }
 
   @override
+  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
+
+  @override
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
     // TODO: implement setHashingAlgoType
   }
+
+  @override
+  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
 
   @override
   void setSigningAlgoType(SigningAlgoType? signingAlgoType) {

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -9,10 +9,8 @@ import 'package:crypton/crypton.dart';
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 class PkamSigningAlgo implements AtSigningAlgorithm {
   final AtPkamKeyPair? _pkamKeyPair;
-  SigningAlgoType _signingAlgoType;
-  HashingAlgoType _hashingAlgoType;
-  PkamSigningAlgo(
-      this._pkamKeyPair, this._signingAlgoType, this._hashingAlgoType);
+  final HashingAlgoType _hashingAlgoType;
+  PkamSigningAlgo(this._pkamKeyPair, this._hashingAlgoType);
 
   @override
   Uint8List sign(Uint8List data) {
@@ -34,7 +32,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
 
   @override
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
-    var rsaPublicKey;
+    RSAPublicKey rsaPublicKey;
     if (publicKey != null) {
       rsaPublicKey = RSAPublicKey.fromString(publicKey);
     } else if (_pkamKeyPair != null) {
@@ -54,8 +52,4 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
         throw AtException('Invalid hashing algo $_hashingAlgoType provided');
     }
   }
-
-  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
-
-  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
 }

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -56,9 +56,15 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   }
 
   @override
+  HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
+
+  @override
   void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
     _hashingAlgoType = hashingAlgoType;
   }
+
+  @override
+  SigningAlgoType? getSigningAlgo() => _signingAlgoType;
 
   @override
   void setSigningAlgoType(SigningAlgoType? signingAlgoType) {

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -1,42 +1,55 @@
 import 'dart:typed_data';
 
+import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/key/impl/at_pkam_key_pair.dart';
-import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 class PkamSigningAlgo implements AtSigningAlgorithm {
   final AtPkamKeyPair _pkamKeyPair;
-  final SigningKeyType _signingKeyType;
-  PkamSigningAlgo(this._pkamKeyPair, this._signingKeyType);
+  SigningAlgoType? _signingAlgoType;
+  HashingAlgoType? _hashingAlgoType;
+  PkamSigningAlgo(this._pkamKeyPair);
 
   @override
-  Uint8List sign(Uint8List data, int digestLength) {
+  Uint8List sign(Uint8List data) {
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair.atPrivateKey.privateKey);
-    switch (digestLength) {
-      case 256:
+    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
+    switch (_hashingAlgoType) {
+      case HashingAlgoType.sha256:
         return rsaPrivateKey.createSHA256Signature(data);
-      case 512:
+      case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException('Invalid digestLength provided');
+        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
     }
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
+  bool verify(Uint8List signedData, Uint8List signature) {
     final rsaPublicKey =
         RSAPublicKey.fromString(_pkamKeyPair.atPublicKey.publicKey);
-    switch (digestLength) {
-      case 256:
+    _hashingAlgoType ??= HashingAlgoType.sha256;
+    switch (_hashingAlgoType) {
+      case HashingAlgoType.sha256:
         return rsaPublicKey.verifySHA256Signature(signedData, signature);
-      case 512:
+      case HashingAlgoType.sha512:
         return rsaPublicKey.verifySHA512Signature(signedData, signature);
       default:
-        throw AtException('Invalid digestLength provided');
+        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
     }
+  }
+
+  @override
+  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
+    _hashingAlgoType = hashingAlgoType;
+  }
+
+  @override
+  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
+    _signingAlgoType = signingAlgoType;
   }
 }

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -16,7 +16,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   @override
   Uint8List sign(Uint8List data) {
     if (_pkamKeyPair == null) {
-      throw Exception('pkam key pair is null. cannot sign data');
+      throw AtException('pkam key pair is null. cannot sign data');
     }
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair!.atPrivateKey.privateKey);
@@ -27,7 +27,8 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
+        throw AtException(
+            'Hashing algo $_hashingAlgoType is invalid/not supported');
     }
   }
 

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/key/impl/at_pkam_key_pair.dart';
 import 'package:at_chops/src/key/key_type.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
@@ -12,16 +13,31 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   PkamSigningAlgo(this._pkamKeyPair, this._signingKeyType);
 
   @override
-  Uint8List sign(Uint8List data) {
+  Uint8List sign(Uint8List data, int digestLength) {
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair.atPrivateKey.privateKey);
-    return rsaPrivateKey.createSHA256Signature(data);
+    switch(digestLength){
+      case 256:
+        return rsaPrivateKey.createSHA256Signature(data);
+      case 512:
+        return rsaPrivateKey.createSHA512Signature(data);
+      default:
+        throw AtException('Invalid digestLength provided');
+    }
+
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature) {
+  bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
     final rsaPublicKey =
         RSAPublicKey.fromString(_pkamKeyPair.atPublicKey.publicKey);
-    return rsaPublicKey.verifySHA256Signature(signedData, signature);
+    switch(digestLength){
+      case 256:
+        return rsaPublicKey.verifySHA256Signature(signedData, signature);
+      case 512:
+        return rsaPublicKey.verifySHA512Signature(signedData, signature);
+      default:
+        throw AtException('Invalid digestLength provided');
+    }
   }
 }

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -16,7 +16,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   Uint8List sign(Uint8List data, int digestLength) {
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair.atPrivateKey.privateKey);
-    switch(digestLength){
+    switch (digestLength) {
       case 256:
         return rsaPrivateKey.createSHA256Signature(data);
       case 512:
@@ -24,14 +24,13 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       default:
         throw AtException('Invalid digestLength provided');
     }
-
   }
 
   @override
   bool verify(Uint8List signedData, Uint8List signature, int digestLength) {
     final rsaPublicKey =
         RSAPublicKey.fromString(_pkamKeyPair.atPublicKey.publicKey);
-    switch(digestLength){
+    switch (digestLength) {
       case 256:
         return rsaPublicKey.verifySHA256Signature(signedData, signature);
       case 512:

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -9,9 +9,10 @@ import 'package:crypton/crypton.dart';
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 class PkamSigningAlgo implements AtSigningAlgorithm {
   final AtPkamKeyPair? _pkamKeyPair;
-  SigningAlgoType? _signingAlgoType;
-  HashingAlgoType? _hashingAlgoType;
-  PkamSigningAlgo(this._pkamKeyPair);
+  SigningAlgoType _signingAlgoType;
+  HashingAlgoType _hashingAlgoType;
+  PkamSigningAlgo(
+      this._pkamKeyPair, this._signingAlgoType, this._hashingAlgoType);
 
   @override
   Uint8List sign(Uint8List data) {
@@ -20,7 +21,6 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
     }
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair!.atPrivateKey.privateKey);
-    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
         return rsaPrivateKey.createSHA256Signature(data);
@@ -45,7 +45,6 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
           'Pkam key pair or public key not set for pkam verification');
     }
 
-    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
         return rsaPublicKey.verifySHA256Signature(signedData, signature);
@@ -56,19 +55,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
     }
   }
 
-  @override
   HashingAlgoType? getHashingAlgo() => _hashingAlgoType;
 
-  @override
-  void setHashingAlgoType(HashingAlgoType? hashingAlgoType) {
-    _hashingAlgoType = hashingAlgoType;
-  }
-
-  @override
   SigningAlgoType? getSigningAlgo() => _signingAlgoType;
-
-  @override
-  void setSigningAlgoType(SigningAlgoType? signingAlgoType) {
-    _signingAlgoType = signingAlgoType;
-  }
 }

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -15,7 +15,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   @override
   Uint8List sign(Uint8List data) {
     if (_pkamKeyPair == null) {
-      throw AtException('pkam key pair is null. cannot sign data');
+      throw AtSigningException('pkam key pair is null. cannot sign data');
     }
     final rsaPrivateKey =
         RSAPrivateKey.fromString(_pkamKeyPair!.atPrivateKey.privateKey);
@@ -25,7 +25,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPrivateKey.createSHA512Signature(data);
       default:
-        throw AtException(
+        throw AtSigningException(
             'Hashing algo $_hashingAlgoType is invalid/not supported');
     }
   }
@@ -39,7 +39,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       rsaPublicKey =
           RSAPublicKey.fromString(_pkamKeyPair!.atPublicKey.publicKey);
     } else {
-      throw AtException(
+      throw AtSigningVerificationException(
           'Pkam key pair or public key not set for pkam verification');
     }
 
@@ -49,7 +49,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPublicKey.verifySHA512Signature(signedData, signature);
       default:
-        throw AtException('Invalid hashing algo $_hashingAlgoType provided');
+        throw AtSigningVerificationException('Invalid hashing algo $_hashingAlgoType provided');
     }
   }
 }

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -32,7 +32,7 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   bool verify(Uint8List signedData, Uint8List signature) {
     final rsaPublicKey =
         RSAPublicKey.fromString(_pkamKeyPair.atPublicKey.publicKey);
-    _hashingAlgoType ??= HashingAlgoType.sha256;
+    _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
         return rsaPublicKey.verifySHA256Signature(signedData, signature);

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -8,15 +8,18 @@ import 'package:crypton/crypton.dart';
 
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 class PkamSigningAlgo implements AtSigningAlgorithm {
-  final AtPkamKeyPair _pkamKeyPair;
+  final AtPkamKeyPair? _pkamKeyPair;
   SigningAlgoType? _signingAlgoType;
   HashingAlgoType? _hashingAlgoType;
   PkamSigningAlgo(this._pkamKeyPair);
 
   @override
   Uint8List sign(Uint8List data) {
+    if (_pkamKeyPair == null) {
+      throw Exception('pkam key pair is null. cannot sign data');
+    }
     final rsaPrivateKey =
-        RSAPrivateKey.fromString(_pkamKeyPair.atPrivateKey.privateKey);
+        RSAPrivateKey.fromString(_pkamKeyPair!.atPrivateKey.privateKey);
     _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:
@@ -29,9 +32,18 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
   }
 
   @override
-  bool verify(Uint8List signedData, Uint8List signature) {
-    final rsaPublicKey =
-        RSAPublicKey.fromString(_pkamKeyPair.atPublicKey.publicKey);
+  bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
+    var rsaPublicKey;
+    if (publicKey != null) {
+      rsaPublicKey = RSAPublicKey.fromString(publicKey);
+    } else if (_pkamKeyPair != null) {
+      rsaPublicKey =
+          RSAPublicKey.fromString(_pkamKeyPair!.atPublicKey.publicKey);
+    } else {
+      throw AtException(
+          'Pkam key pair or public key not set for pkam verification');
+    }
+
     _hashingAlgoType ??= HashingAlgoType.sha256; //default to sha256
     switch (_hashingAlgoType) {
       case HashingAlgoType.sha256:

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -89,10 +89,14 @@ abstract class AtChops {
       String data, String signature, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 
-  ///TODO needs documentation
+  ///Generate data signature
+  ///Inputs need to passed through [AtSigningInput]
+  ///Please refer to [AtSigningInput] docs to create a valid input instance
   AtSigningResult sign(AtSigningInput signingInput);
 
-  ///TODO needs documentation
+  ///Verifies data with a valid signature
+  ///Inputs need to passed through [AtSigningVerificationInput]
+  ///Please refer to [AtSigningVerificationInput] docs to create a valid input instance
   AtSigningResult verify(AtSigningVerificationInput verifyInput);
 
   /// Create a string hash of input [signedData] using a [hashingAlgorithm].

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -11,7 +11,6 @@ import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_chops/src/metadata/at_signing_input.dart';
 import 'package:at_chops/src/metadata/encryption_result.dart';
 import 'package:at_chops/src/metadata/signing_result.dart';
-import 'package:at_chops/src/util/at_signature_verification_result.dart';
 
 /// Base class for all Cryptographic and Hashing Operations. Callers have to either implement
 /// specific encryption, signing or hashing algorithms. Otherwise default implementation of specific algorithms will be used.
@@ -75,42 +74,26 @@ abstract class AtChops {
       Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm, int digestLength});
 
-  ///Method that generates dataSignature for String [data] using an [RSAPrivateKey]
-  ///Required Inputs:
-  /// 1) String data that needs to be signed
-  /// 2) Preferred length of signature
-  ///Output: base64Encoded signature generated using [algorithm] and [digestLength]
+  /// Sign the input string [data] using a [signingAlgorithm].
+  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
+  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   @Deprecated('Use sign() instead')
   AtSigningResult signString(String data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? atSingingAlgorithm});
+      {AtSigningAlgorithm? signingAlgorithm});
 
-  ///Verifies dataSignature in [data] to [signature] using [publicKey]
-  ///Required inputs:
-  ///1) data that needs to be verified using [signature]
-  ///2) signature to be verified in base64Encoded String format
-  ///3) DigestLength used to generate [signature]
-  ///Output:
-  ///Case verified - Returns [AtSignatureVerificationResult] object with [AtSignatureVerificationResult.isVerified] set to true
-  ///case NotVerified - Returns [AtSignatureVerificationResult] object with [AtSignatureVerificationResult.isVerified] set to false
-  ///and the exception is stored in [AtSignatureVerificationResult.exception]
+  /// Verify the [signature] of string [data] using a [signingAlgorithm]
+  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
+  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   @Deprecated('Use verify() instead')
-  AtSigningResult verifyStringSignature(
+  AtSigningResult verifySignatureString(
       String data, String signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? atSigningAlgorithm});
+      {AtSigningAlgorithm? signingAlgorithm});
 
-  ///Method that generates dataSignature for type[AtSignatureInput] using an [RSAPrivateKey]
-  ///Required Inputs:
-  /// 1) [AtSigningInput] object with all parameters specified
-  ///Output:
-  ///[AtSignature] object containing [signature], [signatureTimestamp] and [signedBy]
-  ///signature is a base64Encoded String generated using algorithm and digestLength specified in [AtSigningInput]
+  ///TODO needs documentation
   AtSigningResult sign(AtSigningInput signingInput);
 
-  ///Method that verifies dataSignature of object type [AtSignature] using [RSAPublicKey]
-  ///Required inputs:
-  ///1) [AtSignature] object containing all required parameters
-  ///Verifies signature in [AtSignature.signature] to [AtSignature.actualText]
-  AtSigningResult verify(AtSigningInput signingInput);
+  ///TODO needs documentation
+  AtSigningResult verify(AtSigningInput verifyInput);
 
   /// Create a string hash of input [signedData] using a [hashingAlgorithm].
   /// Refer to [DefaultHash] for default implementation of hashing.

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -81,8 +81,7 @@ abstract class AtChops {
   /// 2) Preferred length of signature
   ///Output: base64Encoded signature generated using [algorithm] and [digestLength]
   @Deprecated('Use sign() instead')
-  AtSigningResult signString(
-      String data, SigningKeyType signingKeyType,
+  AtSigningResult signString(String data, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? atSingingAlgorithm});
 
   ///Verifies dataSignature in [data] to [signature] using [publicKey]
@@ -95,7 +94,8 @@ abstract class AtChops {
   ///case NotVerified - Returns [AtSignatureVerificationResult] object with [AtSignatureVerificationResult.isVerified] set to false
   ///and the exception is stored in [AtSignatureVerificationResult.exception]
   @Deprecated('Use verify() instead')
-  AtSigningResult verifyStringSignature(String data, String signature, SigningKeyType signingKeyType,
+  AtSigningResult verifyStringSignature(
+      String data, String signature, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? atSigningAlgorithm});
 
   ///Method that generates dataSignature for type[AtSignatureInput] using an [RSAPrivateKey]

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -62,15 +62,21 @@ abstract class AtChops {
       InitialisationVector? iv});
 
   /// Sign the input bytes [data] using a [signingAlgorithm].
+  // ignore: deprecated_member_use_from_same_package
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
+  // ignore: deprecated_member_use_from_same_package
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
+  // ignore: deprecated_member_use_from_same_package
   AtSigningResult signBytes(Uint8List data, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 
   /// Verify the [signature] of bytes [data] using a [signingAlgorithm]
+  // ignore: deprecated_member_use_from_same_package
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
+  // ignore: deprecated_member_use_from_same_package
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult verifySignatureBytes(
+      // ignore: deprecated_member_use_from_same_package
       Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -89,17 +89,17 @@ abstract class AtChops {
       String data, String signature, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 
-  ///Generate data signature
-  ///Inputs need to passed through [AtSigningInput]
-  ///Please refer to [AtSigningInput] docs to create a valid input instance
+  /// Compute data signature using the private key from a key pair
+  /// Input has to be set using [AtSigningInput] object
+  /// Please refer to [AtSigningInput] to create a valid input instance
   AtSigningResult sign(AtSigningInput signingInput);
 
-  ///Verifies data with a valid signature
-  ///Inputs need to passed through [AtSigningVerificationInput]
-  ///Please refer to [AtSigningVerificationInput] docs to create a valid input instance
+  /// Verifies the signature computed for input data using the public key from a key pair
+  /// Input has to set using [AtSigningVerificationInput] obect
+  /// Please refer to [AtSigningVerificationInput] docs to create a valid input instance
   AtSigningResult verify(AtSigningVerificationInput verifyInput);
 
-  /// Create a string hash of input [signedData] using a [hashingAlgorithm].
+  /// Create a hash of input [signedData] using a [hashingAlgorithm].
   /// Refer to [DefaultHash] for default implementation of hashing.
   String hash(Uint8List signedData, AtHashingAlgorithm hashingAlgorithm);
 }

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -65,14 +65,14 @@ abstract class AtChops {
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult signBytes(Uint8List data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm, int digestLength});
+      {AtSigningAlgorithm? signingAlgorithm});
 
   /// Verify the [signature] of bytes [data] using a [signingAlgorithm]
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult verifySignatureBytes(
       Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm, int digestLength});
+      {AtSigningAlgorithm? signingAlgorithm});
 
   /// Sign the input string [data] using a [signingAlgorithm].
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
@@ -93,7 +93,7 @@ abstract class AtChops {
   AtSigningResult sign(AtSigningInput signingInput);
 
   ///TODO needs documentation
-  AtSigningResult verify(AtSigningInput verifyInput);
+  AtSigningResult verify(AtSigningVerificationInput verifyInput);
 
   /// Create a string hash of input [signedData] using a [hashingAlgorithm].
   /// Refer to [DefaultHash] for default implementation of hashing.

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -8,8 +8,10 @@ import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_chops/src/key/impl/at_chops_keys.dart';
 import 'package:at_chops/src/key/key_type.dart';
+import 'package:at_chops/src/metadata/at_signing_input.dart';
 import 'package:at_chops/src/metadata/encryption_result.dart';
 import 'package:at_chops/src/metadata/signing_result.dart';
+import 'package:at_chops/src/util/at_signature_verification_result.dart';
 
 /// Base class for all Cryptographic and Hashing Operations. Callers have to either implement
 /// specific encryption, signing or hashing algorithms. Otherwise default implementation of specific algorithms will be used.
@@ -64,27 +66,51 @@ abstract class AtChops {
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult signBytes(Uint8List data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
+      {AtSigningAlgorithm? signingAlgorithm, int digestLength});
 
   /// Verify the [signature] of bytes [data] using a [signingAlgorithm]
   /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult verifySignatureBytes(
       Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
+      {AtSigningAlgorithm? signingAlgorithm, int digestLength});
 
-  /// Sign the input string [data] using a [signingAlgorithm].
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  AtSigningResult signString(String data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
+  ///Method that generates dataSignature for String [data] using an [RSAPrivateKey]
+  ///Required Inputs:
+  /// 1) String data that needs to be signed
+  /// 2) Preferred length of signature
+  ///Output: base64Encoded signature generated using [algorithm] and [digestLength]
+  @Deprecated('Use sign() instead')
+  AtSigningResult signString(
+      String data, SigningKeyType signingKeyType,
+      {AtSigningAlgorithm? atSingingAlgorithm});
 
-  /// Verify the [signature] of string [data] using a [signingAlgorithm]
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  AtSigningResult verifySignatureString(
-      String data, String signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
+  ///Verifies dataSignature in [data] to [signature] using [publicKey]
+  ///Required inputs:
+  ///1) data that needs to be verified using [signature]
+  ///2) signature to be verified in base64Encoded String format
+  ///3) DigestLength used to generate [signature]
+  ///Output:
+  ///Case verified - Returns [AtSignatureVerificationResult] object with [AtSignatureVerificationResult.isVerified] set to true
+  ///case NotVerified - Returns [AtSignatureVerificationResult] object with [AtSignatureVerificationResult.isVerified] set to false
+  ///and the exception is stored in [AtSignatureVerificationResult.exception]
+  @Deprecated('Use verify() instead')
+  AtSigningResult verifyStringSignature(String data, String signature, SigningKeyType signingKeyType,
+      {AtSigningAlgorithm? atSigningAlgorithm});
+
+  ///Method that generates dataSignature for type[AtSignatureInput] using an [RSAPrivateKey]
+  ///Required Inputs:
+  /// 1) [AtSigningInput] object with all parameters specified
+  ///Output:
+  ///[AtSignature] object containing [signature], [signatureTimestamp] and [signedBy]
+  ///signature is a base64Encoded String generated using algorithm and digestLength specified in [AtSigningInput]
+  AtSigningResult sign(AtSigningInput signingInput);
+
+  ///Method that verifies dataSignature of object type [AtSignature] using [RSAPublicKey]
+  ///Required inputs:
+  ///1) [AtSignature] object containing all required parameters
+  ///Verifies signature in [AtSignature.signature] to [AtSignature.actualText]
+  AtSigningResult verify(AtSigningInput signingInput);
 
   /// Create a string hash of input [signedData] using a [hashingAlgorithm].
   /// Refer to [DefaultHash] for default implementation of hashing.

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -140,6 +140,7 @@ class AtChopsImpl extends AtChops {
   }
 
   @override
+  // ignore: deprecated_member_use_from_same_package
   AtSigningResult signBytes(Uint8List data, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm}) {
     signingAlgorithm ??= _getSigningAlgorithm(signingKeyType)!;
@@ -156,7 +157,10 @@ class AtChopsImpl extends AtChops {
 
   @override
   AtSigningResult verifySignatureBytes(
-      Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
+      Uint8List data,
+      Uint8List signature,
+      // ignore: deprecated_member_use_from_same_package
+      SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm}) {
     signingAlgorithm ??= _getSigningAlgorithm(signingKeyType)!;
     // hard coding signing and hashing algo since this method is deprecated
@@ -170,6 +174,7 @@ class AtChopsImpl extends AtChops {
   }
 
   @override
+  // ignore: deprecated_member_use_from_same_package
   AtSigningResult signString(String data, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm}) {
     final signingResult = signBytes(
@@ -185,7 +190,11 @@ class AtChopsImpl extends AtChops {
 
   @override
   AtSigningResult verifySignatureString(
-      String data, String signature, SigningKeyType signingKeyType,
+      // ignore: deprecated_member_use_from_same_package
+      String data,
+      String signature,
+      // ignore: deprecated_member_use_from_same_package
+      SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm}) {
     final signingResult = verifySignatureBytes(
         utf8.encode(data) as Uint8List, base64Decode(signature), signingKeyType,
@@ -219,11 +228,11 @@ class AtChopsImpl extends AtChops {
   }
 
   @override
-  AtSigningResult verify(AtSigningVerificationInput verificationInput) {
-    _logger.finer('Calling verify for input : $verificationInput ');
-    final dataBytes = _getBytes(verificationInput.data);
-    final signatureBytes = _getBytes(verificationInput.signature);
-    return _verifySignatureBytes(dataBytes, signatureBytes, verificationInput);
+  AtSigningResult verify(AtSigningVerificationInput verifyInput) {
+    _logger.finer('Calling verify for input : $verifyInput ');
+    final dataBytes = _getBytes(verifyInput.data);
+    final signatureBytes = _getBytes(verifyInput.signature);
+    return _verifySignatureBytes(dataBytes, signatureBytes, verifyInput);
   }
 
   AtSigningResult _verifySignatureBytes(Uint8List data, Uint8List signature,
@@ -249,8 +258,7 @@ class AtChopsImpl extends AtChops {
       EncryptionKeyType encryptionKeyType, String? keyName) {
     switch (encryptionKeyType) {
       case EncryptionKeyType.rsa2048:
-        return DefaultEncryptionAlgo(
-            _getEncryptionKeyPair(keyName)!, encryptionKeyType);
+        return DefaultEncryptionAlgo(_getEncryptionKeyPair(keyName)!);
       case EncryptionKeyType.rsa4096:
         // TODO: Handle this case.
         break;
@@ -275,14 +283,18 @@ class AtChopsImpl extends AtChops {
     return null;
   }
 
+  // ignore: deprecated_member_use_from_same_package
   AtSigningAlgorithm? _getSigningAlgorithm(SigningKeyType signingKeyType) {
     switch (signingKeyType) {
+      // ignore: deprecated_member_use_from_same_package
       case SigningKeyType.pkamSha256:
-        return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
-            SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+        return PkamSigningAlgo(
+            atChopsKeys.atPkamKeyPair!, HashingAlgoType.sha256);
+
+      // ignore: deprecated_member_use_from_same_package
       case SigningKeyType.signingSha256:
-        return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
-            SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+        return DefaultSigningAlgo(
+            atChopsKeys.atEncryptionKeyPair!, HashingAlgoType.sha256);
       default:
         throw Exception(
             'Cannot find signing algorithm for signing key type $signingKeyType');
@@ -294,12 +306,12 @@ class AtChopsImpl extends AtChops {
       return signingInput.signingAlgorithm;
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.pkam) {
-      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      return PkamSigningAlgo(
+          atChopsKeys.atPkamKeyPair!, signingInput.hashingAlgoType);
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.data) {
-      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      return DefaultSigningAlgo(
+          atChopsKeys.atEncryptionKeyPair!, signingInput.hashingAlgoType);
     } else {
       throw Exception(
           'Cannot find signing algorithm for signing input  $signingInput');
@@ -317,18 +329,15 @@ class AtChopsImpl extends AtChops {
         verificationInput.signingMode == AtSigningMode.pkam) {
       if (atChopsKeys.atPkamKeyPair != null) {
         return PkamSigningAlgo(
-            atChopsKeys.atPkamKeyPair,
-            verificationInput.signingAlgoType,
-            verificationInput.hashingAlgoType);
+            atChopsKeys.atPkamKeyPair, verificationInput.hashingAlgoType);
       } else {
-        return PkamSigningAlgo(null, verificationInput.signingAlgoType,
-            verificationInput.hashingAlgoType);
+        return PkamSigningAlgo(null, verificationInput.hashingAlgoType);
       }
     } else if (verificationInput.signingMode != null &&
         verificationInput.signingMode == AtSigningMode.data &&
         atChopsKeys.atEncryptionKeyPair != null) {
-      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      return DefaultSigningAlgo(
+          atChopsKeys.atEncryptionKeyPair, verificationInput.hashingAlgoType);
     } else {
       throw Exception(
           'Cannot find signing algorithm for signing input  $verificationInput');

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -209,8 +209,14 @@ class AtChopsImpl extends AtChops {
   AtSigningResult _signBytes(Uint8List data, AtSigningInput signingInput,
       {AtSigningAlgorithm? signingAlgorithm}) {
     signingAlgorithm ??= _getSigningAlgorithmV2(signingInput)!;
-    final atSigningMetadata = AtSigningMetaData(signingInput.signingAlgoType,
-        signingInput.hashingAlgoType, DateTime.now().toUtc());
+    final atSigningMetadata = AtSigningMetaData(
+        signingInput.signingAlgoType ??
+            signingAlgorithm.getSigningAlgo() ??
+            SigningAlgoType.rsa2048,
+        signingInput.hashingAlgoType ??
+            signingAlgorithm.getHashingAlgo() ??
+            HashingAlgoType.sha256,
+        DateTime.now().toUtc());
     final atSigningResult = AtSigningResult()
       ..atSigningMetaData = atSigningMetadata
       ..atSigningResultType = AtSigningResultType.bytes;
@@ -232,8 +238,12 @@ class AtChopsImpl extends AtChops {
     _logger
         .finer('verification algo: ${signingAlgorithm.runtimeType.toString()}');
     final atSigningMetadata = AtSigningMetaData(
-        verificationInput.signingAlgoType,
-        verificationInput.hashingAlgoType,
+        verificationInput.signingAlgoType ??
+            signingAlgorithm.getSigningAlgo() ??
+            SigningAlgoType.rsa2048,
+        verificationInput.hashingAlgoType ??
+            signingAlgorithm.getHashingAlgo() ??
+            HashingAlgoType.sha256,
         DateTime.now().toUtc());
     final atSigningResult = AtSigningResult()
       ..atSigningMetaData = atSigningMetadata
@@ -323,7 +333,10 @@ class AtChopsImpl extends AtChops {
   Uint8List _getBytes(dynamic data) {
     if (data is String) {
       return utf8.encode(data) as Uint8List;
+    } else if (data is Uint8List) {
+      return data;
+    } else {
+      throw AtException('Unrecognized type of data: $data');
     }
-    return data;
   }
 }

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -200,11 +200,12 @@ class AtChopsImpl extends AtChops {
   @override
   AtSigningResult sign(AtSigningInput signingInput) {
     final dataBytes = utf8.encode(signingInput.plainText) as Uint8List;
-    return signBytes(dataBytes, signingInput.signingKeyType, digestLength: signingInput.digestLength);
+    return signBytes(dataBytes, signingInput.signingKeyType,
+        digestLength: signingInput.digestLength);
   }
 
   @override
-  AtSigningResult verify(AtSigningInput verifyInput){
+  AtSigningResult verify(AtSigningInput verifyInput) {
     return verifySignatureBytes(data, signature, signingKeyType);
   }
 

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -209,14 +209,8 @@ class AtChopsImpl extends AtChops {
   AtSigningResult _signBytes(Uint8List data, AtSigningInput signingInput,
       {AtSigningAlgorithm? signingAlgorithm}) {
     signingAlgorithm ??= _getSigningAlgorithmV2(signingInput)!;
-    final atSigningMetadata = AtSigningMetaData(
-        signingInput.signingAlgoType ??
-            signingAlgorithm.getSigningAlgo() ??
-            SigningAlgoType.rsa2048,
-        signingInput.hashingAlgoType ??
-            signingAlgorithm.getHashingAlgo() ??
-            HashingAlgoType.sha256,
-        DateTime.now().toUtc());
+    final atSigningMetadata = AtSigningMetaData(signingInput.signingAlgoType,
+        signingInput.hashingAlgoType, DateTime.now().toUtc());
     final atSigningResult = AtSigningResult()
       ..atSigningMetaData = atSigningMetadata
       ..atSigningResultType = AtSigningResultType.bytes;
@@ -238,12 +232,8 @@ class AtChopsImpl extends AtChops {
     _logger
         .finer('verification algo: ${signingAlgorithm.runtimeType.toString()}');
     final atSigningMetadata = AtSigningMetaData(
-        verificationInput.signingAlgoType ??
-            signingAlgorithm.getSigningAlgo() ??
-            SigningAlgoType.rsa2048,
-        verificationInput.hashingAlgoType ??
-            signingAlgorithm.getHashingAlgo() ??
-            HashingAlgoType.sha256,
+        verificationInput.signingAlgoType,
+        verificationInput.hashingAlgoType,
         DateTime.now().toUtc());
     final atSigningResult = AtSigningResult()
       ..atSigningMetaData = atSigningMetadata
@@ -287,9 +277,11 @@ class AtChopsImpl extends AtChops {
   AtSigningAlgorithm? _getSigningAlgorithm(SigningKeyType signingKeyType) {
     switch (signingKeyType) {
       case SigningKeyType.pkamSha256:
-        return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!);
+        return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
+            SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       case SigningKeyType.signingSha256:
-        return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!);
+        return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
+            SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       default:
         throw Exception(
             'Cannot find signing algorithm for signing key type $signingKeyType');
@@ -301,10 +293,12 @@ class AtChopsImpl extends AtChops {
       return signingInput.signingAlgorithm;
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.pkam) {
-      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!);
+      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.data) {
-      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!);
+      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
     } else {
       throw Exception(
           'Cannot find signing algorithm for signing input  $signingInput');
@@ -320,10 +314,12 @@ class AtChopsImpl extends AtChops {
       return EccSigningAlgo();
     } else if (verificationInput.signingMode != null &&
         verificationInput.signingMode == AtSigningMode.pkam) {
-      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair);
+      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
     } else if (verificationInput.signingMode != null &&
         verificationInput.signingMode == AtSigningMode.data) {
-      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!);
+      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
     } else {
       throw Exception(
           'Cannot find signing algorithm for signing input  $verificationInput');

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -7,6 +7,7 @@ import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/algorithm/default_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/default_signing_algo.dart';
+import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
 import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_chops/src/at_chops_base.dart';
 import 'package:at_chops/src/key/impl/aes_key.dart';
@@ -297,7 +298,15 @@ class AtChopsImpl extends AtChops {
       AtSigningVerificationInput verificationInput) {
     if (verificationInput.signingAlgorithm != null) {
       return verificationInput.signingAlgorithm;
-    } else if (verificationInput.signingMode != null &&
+    }
+    if (verificationInput.publicKey != null) {
+      if (verificationInput.signingAlgoType == SigningAlgoType.ecc_secp256r1) {
+        return EccSigningAlgo()..publicKey = verificationInput.publicKey;
+      }
+
+      //#TODO return other algo if public key is passed
+    }
+    if (verificationInput.signingMode != null &&
         verificationInput.signingMode == AtSigningMode.pkam) {
       return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!);
     } else if (verificationInput.signingMode != null &&

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -168,7 +168,6 @@ class AtChopsImpl extends AtChops {
   }
 
   @override
-  //TODO: does this method need to have a fixed digest length of 256 as its already used somewhere
   AtSigningResult signString(String data, SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm}) {
     final signingResult = signBytes(
@@ -185,10 +184,10 @@ class AtChopsImpl extends AtChops {
   @override
   AtSigningResult verifySignatureString(
       String data, String signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? atSigningAlgorithm}) {
+      {AtSigningAlgorithm? signingAlgorithm}) {
     final signingResult = verifySignatureBytes(
         utf8.encode(data) as Uint8List, base64Decode(signature), signingKeyType,
-        signingAlgorithm: atSigningAlgorithm);
+        signingAlgorithm: signingAlgorithm);
     final atSigningMetadata = signingResult.atSigningMetaData;
     final atSigningResult = AtSigningResult()
       ..atSigningMetaData = atSigningMetadata
@@ -206,7 +205,11 @@ class AtChopsImpl extends AtChops {
 
   @override
   AtSigningResult verify(AtSigningInput verifyInput) {
-    return verifySignatureBytes(data, signature, signingKeyType);
+    final dataBytes = utf8.encode(verifyInput.plainText) as Uint8List;
+    final digestBytes = utf8.encode(verifyInput.digest!) as Uint8List;
+    return verifySignatureBytes(
+        dataBytes, digestBytes, verifyInput.signingKeyType,
+        signingAlgorithm: verifyInput.signingAlgorithm);
   }
 
   AtEncryptionAlgorithm? _getEncryptionAlgorithm(

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -220,6 +220,7 @@ class AtChopsImpl extends AtChops {
 
   @override
   AtSigningResult verify(AtSigningVerificationInput verificationInput) {
+    _logger.finer('Calling verify for input : $verificationInput ');
     final dataBytes = _getBytes(verificationInput.data);
     final signatureBytes = _getBytes(verificationInput.signature);
     return _verifySignatureBytes(dataBytes, signatureBytes, verificationInput);
@@ -314,11 +315,19 @@ class AtChopsImpl extends AtChops {
       return EccSigningAlgo();
     } else if (verificationInput.signingMode != null &&
         verificationInput.signingMode == AtSigningMode.pkam) {
-      return PkamSigningAlgo(atChopsKeys.atPkamKeyPair!,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      if (atChopsKeys.atPkamKeyPair != null) {
+        return PkamSigningAlgo(
+            atChopsKeys.atPkamKeyPair,
+            verificationInput.signingAlgoType,
+            verificationInput.hashingAlgoType);
+      } else {
+        return PkamSigningAlgo(null, verificationInput.signingAlgoType,
+            verificationInput.hashingAlgoType);
+      }
     } else if (verificationInput.signingMode != null &&
-        verificationInput.signingMode == AtSigningMode.data) {
-      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair!,
+        verificationInput.signingMode == AtSigningMode.data &&
+        atChopsKeys.atEncryptionKeyPair != null) {
+      return DefaultSigningAlgo(atChopsKeys.atEncryptionKeyPair,
           verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
     } else {
       throw Exception(

--- a/packages/at_chops/lib/src/key/key_type.dart
+++ b/packages/at_chops/lib/src/key/key_type.dart
@@ -1,3 +1,4 @@
 enum EncryptionKeyType { rsa2048, rsa4096, ecc, aes128, aes192, aes256 }
 
+@Deprecated('use signing/hashing algo type from algo_type.dart')
 enum SigningKeyType { pkamSha256, signingSha256 }

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -1,40 +1,118 @@
+import 'dart:typed_data';
+
 import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_chops/src/algorithm/default_signing_algo.dart';
+import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
+import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 
-// Input for data signing
+/// Input to generate data signature
+///
+/// [_data] field is required for successful
+/// generation of data signature
+///
+/// Algorithm used to sign/verify the data can be chosen
+/// using [hashingAlgoType] and [signingAlgoType]
+///
+/// Defaults are [HashingAlgoType.sha256] and [SigningAlgoType.rsa2048]
+///
+/// Please Use the same [HashingAlgoType] and [SigningAlgoType] used to generate
+/// the data signature
+///
+/// Please refer to the docs belonging to individual data fields
+/// to be able to generate a valid instance
 class AtSigningInput {
+  /// Data that needs to be signed
+  ///
+  /// Data either needs to be of type [String] or [Uint8List]
+  ///
+  /// AtException will be thrown if data is of any other type
   dynamic _data;
 
+  /// Choose [HashingAlgoType] from [HashingAlgoType.values]
+  ///
+  /// Default [HashingAlgoType] will be [HashingAlgoType.sha256]
   HashingAlgoType? hashingAlgoType;
 
+  /// Choose [SigningAlgoType] from [SigningAlgoType.values]
+  ///
+  /// Default [SigningAlgoType] will be [SigningAlgoType.rsa2048]
   SigningAlgoType? signingAlgoType;
 
+  /// SigningAlgorithm that will be used to sign/verify data
+  ///
+  /// Available options are [DefaultSigningAlgo], [PkamSigningAlgo], [EccSigningAlgo]
   AtSigningAlgorithm? signingAlgorithm;
 
+  /// Select signingMode from [AtSigningMode]
+  ///
+  /// Use [AtSigningMode.data] for a general purpose signing
+  ///
+  /// Use [AtSigningMode.pkam] when signing pkam challenges
   AtSigningMode? signingMode;
 
   AtSigningInput(this._data);
 
   dynamic get data => _data;
 
-  //#TODO implement toString
+//#TODO implement toString
 }
 
-// Input for data signature verification
+/// Input for data signature verification
+///
+/// [_data], [_signature] and [_publicKey] fields are required for successful
+/// verification of data signature
+///
+/// Algorithm used to sign/verify the data can be chosen
+/// using [hashingAlgoType] and [signingAlgoType]
+///
+/// Defaults are [HashingAlgoType.sha256] and [SigningAlgoType.rsa2048]
+///
+/// Please Use the same [HashingAlgoType] and [SigningAlgoType] used to generate
+/// the data signature
+///
+/// Please refer to the docs belonging to individual data fields
+/// to be able to generate a valid instance
 class AtSigningVerificationInput {
+  /// Data that has to verified
+  ///
+  /// Data needs to be either of type base64encoded [String] or [Uint8List]
+  ///
+  /// AtException will be thrown if data is of any other type
   dynamic _data;
 
+  /// Signature of [_data] that will be used to verify
+  ///
+  /// Signature needs to be either of type base64encoded [String] or [Uint8List]
+  ///
+  /// AtException will be thrown if signature is of any other type
   dynamic _signature;
 
+  /// Mandatory input
+  ///
+  /// PublicKey belonging to the AsymmetricKeypair that was used to sign [_signature]
   String _publicKey;
 
+  /// Choose [HashingAlgoType] from [HashingAlgoType.values]
+  ///
+  /// Default [HashingAlgoType] will be [HashingAlgoType.sha256]
   HashingAlgoType? hashingAlgoType;
 
+  /// Choose [SigningAlgoType] from [SigningAlgoType.values]
+  /// Default [SigningAlgoType] will be [SigningAlgoType.rsa2048]
   SigningAlgoType? signingAlgoType;
 
+  /// Select signingMode from [AtSigningMode]
+  ///
+  /// Use [AtSigningMode.data] for a general purpose signing
+  ///
+  /// Use [AtSigningMode.pkam] when signing pkam challenges
   AtSigningMode? signingMode;
 
+  /// SigningAlgorithm that will be used to sign/verify data
+  ///
+  /// Available options are [DefaultSigningAlgo], [PkamSigningAlgo], [EccSigningAlgo]
   AtSigningAlgorithm? signingAlgorithm;
 
   AtSigningVerificationInput(this._data, this._signature, this._publicKey);
@@ -45,7 +123,7 @@ class AtSigningVerificationInput {
 
   String get publicKey => _publicKey;
 
-  //#TODO implement toString
+//#TODO implement toString
 }
 
 enum AtSigningMode { pkam, data, sim }

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -7,21 +7,11 @@ import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
 import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 
-/// Input to generate data signature
+/// Represents input attributes required for data signing.
 ///
-/// [_data] field is required for successful
-/// generation of data signature
-///
-/// Algorithm used to sign/verify the data can be chosen
-/// using [hashingAlgoType] and [signingAlgoType]
-///
-/// Defaults are [HashingAlgoType.sha256] and [SigningAlgoType.rsa2048]
-///
-/// Please Use the same [HashingAlgoType] and [SigningAlgoType] used to generate
-/// the data signature
-///
-/// Please refer to the docs belonging to individual data fields
-/// to be able to generate a valid instance
+///   [_data] input data to be signed
+///  [hashingAlgoType] - Hashing algorithm used to hash the input data. Refer [HashingAlgoType]
+///  [signingAlgoType] - Signing algorithm used to generate signature for the input data. Refer [SigningAlgoType]
 class AtSigningInput {
   /// Data that needs to be signed
   ///
@@ -32,76 +22,67 @@ class AtSigningInput {
 
   /// Choose [HashingAlgoType] from [HashingAlgoType.values]
   ///
-  /// Default [HashingAlgoType] will be [HashingAlgoType.sha256]
-  HashingAlgoType? hashingAlgoType;
+  /// Default value will be [HashingAlgoType.sha256]
+  HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
 
   /// Choose [SigningAlgoType] from [SigningAlgoType.values]
   ///
-  /// Default [SigningAlgoType] will be [SigningAlgoType.rsa2048]
-  SigningAlgoType? signingAlgoType;
+  /// Default value will be [SigningAlgoType.rsa2048]
+  SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048;
 
   /// SigningAlgorithm that will be used to sign/verify data
   ///
-  /// Available options are [DefaultSigningAlgo], [PkamSigningAlgo], [EccSigningAlgo]
+  /// Available implementations are [DefaultSigningAlgo], [PkamSigningAlgo], [EccSigningAlgo]. Callers can set their own signing algorithm by implementing [AtSigningAlgorithm]
   AtSigningAlgorithm? signingAlgorithm;
 
   /// Select signingMode from [AtSigningMode]
   ///
-  /// Use [AtSigningMode.data] for a general purpose signing
+  /// Use [AtSigningMode.data] for general data signing
   ///
-  /// Use [AtSigningMode.pkam] when signing pkam challenges
+  /// Use [AtSigningMode.pkam] for pkam challenge signing
   AtSigningMode? signingMode;
 
   AtSigningInput(this._data);
 
   dynamic get data => _data;
 
-//#TODO implement toString
+  @override
+  String toString() {
+    return 'AtSigningInput{_data: $_data, hashingAlgoType: $hashingAlgoType, signingAlgoType: $signingAlgoType, signingAlgorithm: $signingAlgorithm, signingMode: $signingMode}';
+  }
 }
 
 /// Input for data signature verification
 ///
 /// [_data], [_signature] and [_publicKey] fields are required for successful
 /// verification of data signature
-///
-/// Algorithm used to sign/verify the data can be chosen
-/// using [hashingAlgoType] and [signingAlgoType]
-///
-/// Defaults are [HashingAlgoType.sha256] and [SigningAlgoType.rsa2048]
-///
-/// Please Use the same [HashingAlgoType] and [SigningAlgoType] used to generate
-/// the data signature
-///
-/// Please refer to the docs belonging to individual data fields
-/// to be able to generate a valid instance
+///  [hashingAlgoType] - Hashing algorithm used to hash the input data. Refer [HashingAlgoType]
+///  [signingAlgoType] - Signing algorithm used to verify signature for the input data. Refer [SigningAlgoType]
 class AtSigningVerificationInput {
   /// Data that has to verified
   ///
-  /// Data needs to be either of type base64encoded [String] or [Uint8List]
-  ///
-  /// AtException will be thrown if data is of any other type
+  /// Data has to be either of base64encoded [String] or [Uint8List]
   dynamic _data;
 
   /// Signature of [_data] that will be used to verify
   ///
   /// Signature needs to be either of type base64encoded [String] or [Uint8List]
-  ///
-  /// AtException will be thrown if signature is of any other type
   dynamic _signature;
 
   /// Mandatory input
   ///
-  /// PublicKey belonging to the AsymmetricKeypair that was used to sign [_signature]
+  /// PublicKey from AsymmetricKeypair whose private key was used to compute [_signature]
   String _publicKey;
 
   /// Choose [HashingAlgoType] from [HashingAlgoType.values]
   ///
   /// Default [HashingAlgoType] will be [HashingAlgoType.sha256]
-  HashingAlgoType? hashingAlgoType;
+  HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
 
   /// Choose [SigningAlgoType] from [SigningAlgoType.values]
+  ///
   /// Default [SigningAlgoType] will be [SigningAlgoType.rsa2048]
-  SigningAlgoType? signingAlgoType;
+  SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048;
 
   /// Select signingMode from [AtSigningMode]
   ///
@@ -123,7 +104,10 @@ class AtSigningVerificationInput {
 
   String get publicKey => _publicKey;
 
-//#TODO implement toString
+  @override
+  String toString() {
+    return 'AtSigningVerificationInput{_data: $_data, _signature: $_signature, _publicKey: $_publicKey, hashingAlgoType: $hashingAlgoType, signingAlgoType: $signingAlgoType, signingMode: $signingMode, signingAlgorithm: $signingAlgorithm}';
+  }
 }
 
 enum AtSigningMode { pkam, data, sim }

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -5,7 +5,7 @@ import 'package:at_commons/at_commons.dart';
 ///Bean type class to be used for passing data_signing related input information
 class AtSigningInput {
   ///data as String that is to be signed
-  String plainText;
+  dynamic plainText;
 
   ///Expected length of the digest [use 256 (or) 512]
   ///256 will use SHA-256 for signing

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -18,7 +18,7 @@ class AtSigningInput {
   /// Data either needs to be of type [String] or [Uint8List]
   ///
   /// AtException will be thrown if data is of any other type
-  dynamic _data;
+  final dynamic _data;
 
   /// Choose [HashingAlgoType] from [HashingAlgoType.values]
   ///
@@ -62,17 +62,17 @@ class AtSigningVerificationInput {
   /// Data that has to verified
   ///
   /// Data has to be either of base64encoded [String] or [Uint8List]
-  dynamic _data;
+  final dynamic _data;
 
   /// Signature of [_data] that will be used to verify
   ///
   /// Signature needs to be either of type base64encoded [String] or [Uint8List]
-  dynamic _signature;
+  final dynamic _signature;
 
   /// Mandatory input
   ///
   /// PublicKey from AsymmetricKeypair whose private key was used to compute [_signature]
-  String _publicKey;
+  final String _publicKey;
 
   /// Choose [HashingAlgoType] from [HashingAlgoType.values]
   ///

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -1,34 +1,52 @@
 import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_commons/at_commons.dart';
 
-///Bean type class to be used for passing data_signing related input information
+// Input for data signing
 class AtSigningInput {
-  ///data as String that is to be signed
-  dynamic plainText;
+  dynamic _data;
 
-  ///Expected length of the digest [use 256 (or) 512]
-  ///256 will use SHA-256 for signing
-  ///512 will use SHA-512 for signing
-  int digestLength;
+  HashingAlgoType? hashingAlgoType;
 
-  ///used while verification
-  ///Digest that needs to be verified
-  String? digest;
-
-  ///PublicKey used to verify digest
-  String? verificationPublicKey;
-
-  SigningKeyType signingKeyType;
+  SigningAlgoType? signingAlgoType;
 
   AtSigningAlgorithm? signingAlgorithm;
 
-  AtSigningInput(this.plainText, this.signingKeyType, InputType inputType,
-      {this.digest, this.signingAlgorithm, this.digestLength = 256}) {
-    if (inputType == InputType.verificationInput && digest == null) {
-      throw AtException('Digest required for verification');
-    }
-  }
+  AtSigningMode? signingMode;
+
+  AtSigningInput(this._data);
+
+  dynamic get data => _data;
+
+  //#TODO implement toString
 }
 
-enum InputType { signingInput, verificationInput }
+// Input for data signature verification
+class AtSigningVerificationInput {
+  dynamic _data;
+
+  dynamic _signature;
+
+  String _publicKey;
+
+  HashingAlgoType? hashingAlgoType;
+
+  SigningAlgoType? signingAlgoType;
+
+  AtSigningMode? signingMode;
+
+  AtSigningAlgorithm? signingAlgorithm;
+
+  AtSigningVerificationInput(this._data, this._signature, this._publicKey);
+
+  dynamic get data => _data;
+
+  dynamic get signature => _signature;
+
+  String get publicKey => _publicKey;
+
+  //#TODO implement toString
+}
+
+enum AtSigningMode { pkam, data, sim }

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -1,7 +1,6 @@
 import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_commons/at_commons.dart';
 
 // Input for data signing
 class AtSigningInput {

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -1,0 +1,34 @@
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_commons/at_commons.dart';
+
+///Bean type class to be used for passing data_signing related input information
+class AtSigningInput {
+  ///data as String that is to be signed
+  String plainText;
+
+  ///Expected length of the digest [use 256 (or) 512]
+  ///256 will use SHA-256 for signing
+  ///512 will use SHA-512 for signing
+  int digestLength;
+
+  ///used while verification
+  ///Digest that needs to be verified
+  String? digest;
+
+  ///PublicKey used to verify digest
+  String? verificationPublicKey;
+
+  SigningKeyType signingKeyType;
+
+  AtSigningAlgorithm? signingAlgorithm;
+
+  AtSigningInput(this.plainText, this.signingKeyType, InputType inputType,
+      {this.digest, this.signingAlgorithm, this.digestLength = 256}) {
+    if (inputType == InputType.verificationInput && digest == null) {
+      throw AtException('Digest required for verification');
+    }
+  }
+}
+
+enum InputType { signingInput, verificationInput }

--- a/packages/at_chops/lib/src/metadata/signing_metadata.dart
+++ b/packages/at_chops/lib/src/metadata/signing_metadata.dart
@@ -11,5 +11,10 @@ class AtSigningMetaData {
   AtSigningMetaData(
       this.signingAlgoType, this.hashingAlgoType, this.signatureTimestamp);
 
-  //TODO serialization/deserialization
+  @override
+  toString() {
+    return 'HashingAlgo: ${hashingAlgoType?.name}, '
+        'SigningAlgo: ${signingAlgoType?.name}, '
+        'SignatureTimestamp: ${signatureTimestamp.toString()}';
+  }
 }

--- a/packages/at_chops/lib/src/metadata/signing_metadata.dart
+++ b/packages/at_chops/lib/src/metadata/signing_metadata.dart
@@ -4,5 +4,11 @@ import 'package:at_chops/src/key/key_type.dart';
 class AtSigningMetaData {
   String atSigningAlgorithm;
   SigningKeyType signingKeyType;
-  AtSigningMetaData(this.atSigningAlgorithm, this.signingKeyType);
+  ///Timestamp of signature creation in UTC
+  DateTime signatureTimestamp;
+  ///Contains the Algorithm used and digestLength of this signature
+  String signatureSpec;
+  AtSigningMetaData(this.atSigningAlgorithm, this.signingKeyType, this.signatureTimestamp, this.signatureSpec);
+
+  //TODO serialization/deserialization
 }

--- a/packages/at_chops/lib/src/metadata/signing_metadata.dart
+++ b/packages/at_chops/lib/src/metadata/signing_metadata.dart
@@ -1,17 +1,15 @@
-import 'package:at_chops/src/key/key_type.dart';
+import 'package:at_chops/src/algorithm/algo_type.dart';
 
 /// Class which represents metadata for data signing.
 class AtSigningMetaData {
-  String atSigningAlgorithm;
-  SigningKeyType signingKeyType;
+  HashingAlgoType? hashingAlgoType;
+  SigningAlgoType? signingAlgoType;
 
   ///Timestamp of signature creation in UTC
   DateTime signatureTimestamp;
 
-  ///Contains the Algorithm used and digestLength of this signature
-  String signatureSpec;
-  AtSigningMetaData(this.atSigningAlgorithm, this.signingKeyType,
-      this.signatureTimestamp, this.signatureSpec);
+  AtSigningMetaData(
+      this.signingAlgoType, this.hashingAlgoType, this.signatureTimestamp);
 
   //TODO serialization/deserialization
 }

--- a/packages/at_chops/lib/src/metadata/signing_metadata.dart
+++ b/packages/at_chops/lib/src/metadata/signing_metadata.dart
@@ -4,11 +4,14 @@ import 'package:at_chops/src/key/key_type.dart';
 class AtSigningMetaData {
   String atSigningAlgorithm;
   SigningKeyType signingKeyType;
+
   ///Timestamp of signature creation in UTC
   DateTime signatureTimestamp;
+
   ///Contains the Algorithm used and digestLength of this signature
   String signatureSpec;
-  AtSigningMetaData(this.atSigningAlgorithm, this.signingKeyType, this.signatureTimestamp, this.signatureSpec);
+  AtSigningMetaData(this.atSigningAlgorithm, this.signingKeyType,
+      this.signatureTimestamp, this.signatureSpec);
 
   //TODO serialization/deserialization
 }

--- a/packages/at_chops/lib/src/metadata/signing_result.dart
+++ b/packages/at_chops/lib/src/metadata/signing_result.dart
@@ -6,7 +6,12 @@ class AtSigningResult {
   dynamic result;
   late AtSigningMetaData atSigningMetaData;
 
-  //TODO serialization/deserialization
+  @override
+  toString() {
+    return 'ResultType: ${atSigningResultType.name},'
+        'Result: ${result.toString()},'
+        'SigningMetadata: ${atSigningMetaData.toString()}';
+  }
 }
 
 enum AtSigningResultType { bytes, string, bool }

--- a/packages/at_chops/lib/src/metadata/signing_result.dart
+++ b/packages/at_chops/lib/src/metadata/signing_result.dart
@@ -5,6 +5,8 @@ class AtSigningResult {
   late AtSigningResultType atSigningResultType;
   dynamic result;
   late AtSigningMetaData atSigningMetaData;
+
+  //TODO serialization/deserialization
 }
 
 enum AtSigningResultType { bytes, string, bool }

--- a/packages/at_chops/lib/src/metadata/signing_result.dart
+++ b/packages/at_chops/lib/src/metadata/signing_result.dart
@@ -8,9 +8,9 @@ class AtSigningResult {
 
   @override
   toString() {
-    return 'ResultType: ${atSigningResultType.name},'
-        'Result: ${result.toString()},'
-        'SigningMetadata: ${atSigningMetaData.toString()}';
+    return 'ResultType: ${atSigningResultType.name}, '
+        'Result: ${result.toString()}, '
+        'SigningMetadata: {${atSigningMetaData.toString()}}';
   }
 }
 

--- a/packages/at_chops/lib/src/util/at_chops_util.dart
+++ b/packages/at_chops/lib/src/util/at_chops_util.dart
@@ -41,7 +41,7 @@ class AtChopsUtil {
   }
 
   static SymmetricKey generateSymmetricKey(EncryptionKeyType keyType) {
-    switch(keyType) {
+    switch (keyType) {
       case EncryptionKeyType.aes128:
         return AESKey.generate(16);
       case EncryptionKeyType.aes192:

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   crypton: ^2.1.0
   crypto: ^3.0.2
   at_commons: ^3.0.30
+  pointycastle: ^3.6.2
 
 
 dev_dependencies:

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   crypton: ^2.1.0
   crypto: ^3.0.2
   ecdsa: ^0.0.4
-  at_commons: ^3.0.30
+  at_commons: ^3.0.38
   pointycastle: ^3.6.2
   at_utils: ^3.0.11
 

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   crypton: ^2.1.0
   crypto: ^3.0.2
   ecdsa: ^0.0.4
+  elliptic: ^0.3.8
   at_commons: ^3.0.38
   pointycastle: ^3.6.2
   at_utils: ^3.0.11

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   ecdsa: ^0.0.4
   at_commons: ^3.0.30
   pointycastle: ^3.6.2
+  at_utils: ^3.0.11
 
 
 dev_dependencies:

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -12,17 +12,10 @@ dependencies:
   crypto: ^3.0.2
   ecdsa: ^0.0.4
   elliptic: ^0.3.8
-  at_commons: ^3.0.38
+  at_commons: ^3.0.39
   pointycastle: ^3.6.2
   at_utils: ^3.0.11
 
-
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: atchops_exceptions
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -17,6 +17,12 @@ dependencies:
   at_utils: ^3.0.11
 
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: atchops_exceptions
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   encrypt: ^5.0.1
   crypton: ^2.1.0
   crypto: ^3.0.2
+  ecdsa: ^0.0.4
   at_commons: ^3.0.30
   pointycastle: ^3.6.2
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -226,7 +226,6 @@ void main() {
 
       final signingResult = atChops.signBytes(
           Uint8List.fromList(data.codeUnits), SigningKeyType.pkamSha256);
-      print(signingResult);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
@@ -542,27 +541,13 @@ void main() {
 
       AtSigningInput signingInput = AtSigningInput('abcde');
       signingInput.signingAlgorithm = DefaultSigningAlgo(null);
-      expect(
-          () => atChops.sign(signingInput),
-          throwsA(predicate((e) =>
-              e is AtException &&
-              e.toString() ==
-                  'encryption key pair not set for default signing algo')));
-    });
-
-    test('Negative test - sign() fails with', () {
-      final atChopsKeys = AtChopsKeys.create(null, null);
-      final atChops = AtChopsImpl(atChopsKeys);
-
-      AtSigningInput signingInput = AtSigningInput('abcde');
-      signingInput.signingAlgorithm = DefaultSigningAlgo(null);
-
-      expect(
-          () => atChops.sign(signingInput),
-          throwsA(predicate((e) =>
-              e is AtException &&
-              e.toString() ==
-                  'encryption key pair not set for default signing algo')));
+      try {
+        atChops.sign(signingInput);
+      } catch (e, _) {
+        assert(e is AtException);
+        expect(e.toString(),
+            'Exception: encryption key pair not set for default signing algo');
+      }
     });
 
     test('Negative test - sign() with incorrect DataType', () {
@@ -572,12 +557,12 @@ void main() {
 
       AtSigningInput signingInput = AtSigningInput(213456777);
       signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
-
-      expect(
-          () => atChops.sign(signingInput),
-          throwsA(predicate((e) =>
-              e is AtException &&
-              e.toString() == ' Unrecognized type of data: 213456777')));
+      try {
+        atChops.sign(signingInput);
+      } catch (e, _) {
+        assert(e is AtException);
+        expect(e.toString(), 'Exception: Unrecognized type of data: 213456777');
+      }
     });
   });
 }

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -460,6 +460,72 @@ void main() {
       expect(verificationResult.result, true);
     });
 
+    test(
+        'Negative test - verify() fails when verifying sha256 sign using sha512',
+        () {
+      final data = 'data is important';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      signingInput.signingAlgoType = SigningAlgoType.rsa2048;
+      signingInput.hashingAlgoType = HashingAlgoType.sha256;
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      final signingResult = atChops.sign(signingInput);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              encryptionKeypair.atPublicKey.publicKey);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha512;
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha512);
+      expect(verificationResult.result, false);
+    });
+
+    test(
+        'Negative test - verify() fails when verifying sha512 sign using sha256',
+        () {
+      final data = 'data atad';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      signingInput.signingAlgoType = SigningAlgoType.rsa2048;
+      signingInput.hashingAlgoType = HashingAlgoType.sha512;
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      final signingResult = atChops.sign(signingInput);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              encryptionKeypair.atPublicKey.publicKey);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha256;
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+      expect(verificationResult.result, false);
+    });
+
     test('Negative test - verify() fails with sha256 as hashing algo', () {
       final data = 'random data string';
       final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -621,7 +621,7 @@ void main() {
       try {
         atChops.sign(signingInput);
       } catch (e, _) {
-        assert(e is AtException);
+        assert(e is AtSigningException);
         expect(e.toString(),
             'Exception: encryption key pair not set for default signing algo');
       }
@@ -638,7 +638,7 @@ void main() {
       try {
         atChops.sign(signingInput);
       } catch (e, _) {
-        assert(e is AtException);
+        assert(e is InvalidDataException);
         expect(e.toString(), 'Exception: Unrecognized type of data: 213456777');
       }
     });

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -341,7 +341,8 @@ void main() {
           RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result,
@@ -355,8 +356,8 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               encryptionKeypair.atPublicKey.publicKey);
-      verificationInput.signingAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -378,10 +379,12 @@ void main() {
           RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      AtSigningAlgorithm signingAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      signingAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
-      signingAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      signingInput.signingAlgoType = SigningAlgoType.rsa2048;
+      signingInput.hashingAlgoType = HashingAlgoType.sha256;
+      AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair,
+          signingInput.signingAlgoType,
+          signingInput.hashingAlgoType);
       signingInput.signingAlgorithm = signingAlgorithm;
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
@@ -396,10 +399,10 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               encryptionKeypair.atPublicKey.publicKey);
-      AtSigningAlgorithm verifyAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
-      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha256;
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -422,10 +425,12 @@ void main() {
           RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      AtSigningAlgorithm signingAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      signingAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
-      signingAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      signingInput.signingAlgoType = SigningAlgoType.rsa2048;
+      signingInput.hashingAlgoType = HashingAlgoType.sha512;
+      AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair,
+          signingInput.signingAlgoType,
+          signingInput.hashingAlgoType);
       signingInput.signingAlgorithm = signingAlgorithm;
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
@@ -440,10 +445,10 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               encryptionKeypair.atPublicKey.publicKey);
-      AtSigningAlgorithm verifyAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
-      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha512;
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -464,10 +469,10 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(
               data, 'dummysignature', encryptionKeypair.atPublicKey.publicKey);
-      AtSigningAlgorithm verifyAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
-      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha256;
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
@@ -489,10 +494,10 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, 'newdummysignature',
               encryptionKeypair.atPublicKey.publicKey);
-      AtSigningAlgorithm verifyAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
-      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
-      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
+      verificationInput.hashingAlgoType = HashingAlgoType.sha512;
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
@@ -516,14 +521,15 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               anotherEncryptionKeypair.atPublicKey.publicKey);
-      verificationInput.signingAlgorithm =
-          DefaultSigningAlgo(encryptionKeypair);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -540,7 +546,8 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       AtSigningInput signingInput = AtSigningInput('abcde');
-      signingInput.signingAlgorithm = DefaultSigningAlgo(null);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(
+          null, signingInput.signingAlgoType, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
       } catch (e, _) {
@@ -556,7 +563,8 @@ void main() {
       final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
 
       AtSigningInput signingInput = AtSigningInput(213456777);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
+          signingInput.signingAlgoType, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
       } catch (e, _) {

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
-import 'package:at_chops/src/metadata/signing_result.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -2,15 +2,22 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_chops/src/algorithm/default_signing_algo.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:crypton/crypton.dart';
 import 'package:test/test.dart';
 
 void main() {
+  AtSignLogger.root_level = 'finest';
   group('A group of tests for encryption and decryption', () {
     test('Test rsa encryption/decryption string', () {
       final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
       final atChops = AtChopsImpl(atChopsKeys);
       final data = 'Hello World';
+
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.rsa2048);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
@@ -19,6 +26,7 @@ void main() {
           EncryptionKeyType.rsa2048);
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'DefaultEncryptionAlgo');
+
       final decryptionResult = atChops.decryptString(
           encryptionResult.result, EncryptionKeyType.rsa2048);
       expect(decryptionResult.atEncryptionMetaData, isNotNull);
@@ -29,12 +37,14 @@ void main() {
           'DefaultEncryptionAlgo');
       expect(decryptionResult.result, data);
     });
+
     test('Test symmetric encrypt/decrypt bytes with initialisation vector', () {
       String data = 'Hello World';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
           iv: iv);
@@ -45,6 +55,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptBytes(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -56,12 +67,14 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.iv, iv);
       expect(utf8.decode(decryptionResult.result), data);
     });
+
     test('Test symmetric encrypt/decrypt bytes with emoji char', () {
       String data = 'Hello World🛠';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
           iv: iv);
@@ -72,6 +85,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptBytes(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -90,6 +104,7 @@ void main() {
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
           iv: iv);
@@ -100,6 +115,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptBytes(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -111,6 +127,7 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.iv, iv);
       expect(utf8.decode(decryptionResult.result), data);
     });
+
     test('Test symmetric encrypt/decrypt string with initialisation vector',
         () {
       String data = 'Hello World';
@@ -118,6 +135,7 @@ void main() {
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
@@ -127,6 +145,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptString(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -138,12 +157,14 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.iv, iv);
       expect(decryptionResult.result, data);
     });
+
     test('Test symmetric encrypt/decrypt string with special chars', () {
       String data = 'Hello``*+%';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
@@ -153,6 +174,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptString(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -164,12 +186,14 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.iv, iv);
       expect(decryptionResult.result, data);
     });
+
     test('Test symmetric encrypt/decrypt string with emoji', () {
       String data = 'Hello World🛠';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
       final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
       final atChops = AtChopsImpl(atChopsKeys);
       final iv = AtChopsUtil.generateIV(16);
+
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
@@ -179,6 +203,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
           'AESEncryptionAlgo');
       expect(encryptionResult.atEncryptionMetaData.iv, iv);
+
       final decryptionResult = atChops.decryptString(
           encryptionResult.result, EncryptionKeyType.aes256,
           iv: iv);
@@ -191,57 +216,64 @@ void main() {
       expect(decryptionResult.result, data);
     });
   });
+
   group('A group of tests for data signing and verification', () {
     test('Test pkam signing and verification', () {
       String data = 'Hello World';
       final atPkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final atChopsKeys = AtChopsKeys.create(null, atPkamKeyPair);
       final atChops = AtChopsImpl(atChopsKeys);
+
       final signingResult = atChops.signBytes(
           Uint8List.fromList(data.codeUnits), SigningKeyType.pkamSha256);
+      print(signingResult);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.pkamSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'PkamSigningAlgo');
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
           SigningKeyType.pkamSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.pkamSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'PkamSigningAlgo');
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
       expect(verificationResult.result, true);
     });
+
     test('Test data signing and verification - emoji char', () {
       String data = 'Hello World🛠';
       final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
       final atChops = AtChopsImpl(atChopsKeys);
+
       final signingResult = atChops.signBytes(
           Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
           SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
       expect(verificationResult.result, true);
     });
 
@@ -250,25 +282,27 @@ void main() {
       final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
       final atChops = AtChopsImpl(atChopsKeys);
+
       final signingResult = atChops.signBytes(
           Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
           SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
       expect(verificationResult.result, true);
     });
 
@@ -277,24 +311,273 @@ void main() {
       final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
       final atChops = AtChopsImpl(atChopsKeys);
+
       final signingResult =
           atChops.signString(data, SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.string);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
       final verificationResult = atChops.verifySignatureString(
           data, signingResult.result, SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(signingResult.atSigningMetaData.signingKeyType,
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData.atSigningAlgorithm,
-          'DefaultSigningAlgo');
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
       expect(verificationResult.result, true);
+    });
+
+    test('Test sign() and verify() with default algorithms', () {
+      final data = 'testData';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+      RSAPrivateKey rsaPrivateKey =
+          RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+      final signingResult = atChops.sign(signingInput);
+      expect(signingResult.atSigningMetaData, isNotNull);
+      expect(signingResult.result,
+          rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List));
+      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              encryptionKeypair.atPublicKey.publicKey);
+      verificationInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+      expect(verificationResult.result, true);
+    });
+
+    test(
+        'Test sign() and verify() with signingAlgo - rsa2048 and hashing algo - sha256',
+        () {
+      final data = 'randomText';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+      RSAPrivateKey rsaPrivateKey =
+          RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      AtSigningAlgorithm signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      signingAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
+      signingAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      signingInput.signingAlgorithm = signingAlgorithm;
+      final signingResult = atChops.sign(signingInput);
+      expect(signingResult.atSigningMetaData, isNotNull);
+      expect(signingResult.result,
+          rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List));
+      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              encryptionKeypair.atPublicKey.publicKey);
+      AtSigningAlgorithm verifyAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
+      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgorithm = verifyAlgorithm;
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+      expect(verificationResult.result, true);
+    });
+
+    test(
+        'Test sign() and verify() with signingAlgo - rsa2048 and hashing algo - sha512',
+        () {
+      final data = 'aBcDeFg';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+      RSAPrivateKey rsaPrivateKey =
+          RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      AtSigningAlgorithm signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      signingAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
+      signingAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      signingInput.signingAlgorithm = signingAlgorithm;
+      final signingResult = atChops.sign(signingInput);
+      expect(signingResult.atSigningMetaData, isNotNull);
+      expect(signingResult.result,
+          rsaPrivateKey.createSHA512Signature(utf8.encode(data) as Uint8List));
+      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
+      expect(signingResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(signingResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha512);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              encryptionKeypair.atPublicKey.publicKey);
+      AtSigningAlgorithm verifyAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
+      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgorithm = verifyAlgorithm;
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha512);
+      expect(verificationResult.result, true);
+    });
+
+    test('Negative test - verify() fails with sha256 as hashing algo', () {
+      final data = 'random data string';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(
+              data, 'dummysignature', encryptionKeypair.atPublicKey.publicKey);
+      AtSigningAlgorithm verifyAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha256);
+      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgorithm = verifyAlgorithm;
+
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+      expect(verificationResult.result, false);
+    });
+
+    test('Negative test - verify() fails with sha512 as hashing algo', () {
+      final data = 'some other random data string';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final atChopsKeys = AtChopsKeys.create(encryptionKeypair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, 'newdummysignature',
+              encryptionKeypair.atPublicKey.publicKey);
+      AtSigningAlgorithm verifyAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+      verifyAlgorithm.setHashingAlgoType(HashingAlgoType.sha512);
+      verifyAlgorithm.setSigningAlgoType(SigningAlgoType.rsa2048);
+      verificationInput.signingAlgorithm = verifyAlgorithm;
+
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha512);
+      expect(verificationResult.result, false);
+    });
+
+    test('Negative test - verify() fails with incorrect publicKey', () {
+      final data = 'data does not matter';
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final anotherEncryptionKeypair =
+          AtChopsUtil.generateAtEncryptionKeyPair();
+      AtEncryptionKeyPair dummyKeyPair = AtEncryptionKeyPair.create(
+          encryptionKeypair.atPrivateKey.privateKey, '');
+      final atChopsKeys = AtChopsKeys.create(dummyKeyPair, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningInput signingInput = AtSigningInput(data);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+      final signingResult = atChops.sign(signingInput);
+
+      AtSigningVerificationInput? verificationInput =
+          AtSigningVerificationInput(data, signingResult.result,
+              anotherEncryptionKeypair.atPublicKey.publicKey);
+      verificationInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair);
+
+      AtSigningResult verificationResult = atChops.verify(verificationInput);
+      expect(verificationResult.atSigningMetaData, isNotNull);
+      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
+      expect(verificationResult.atSigningMetaData.signingAlgoType,
+          SigningAlgoType.rsa2048);
+      expect(verificationResult.atSigningMetaData.hashingAlgoType,
+          HashingAlgoType.sha256);
+      expect(verificationResult.result, false);
+    });
+
+    test('Negative test - sign() fails without encryptionKeypair', () {
+      final atChopsKeys = AtChopsKeys.create(null, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningInput signingInput = AtSigningInput('abcde');
+      signingInput.signingAlgorithm = DefaultSigningAlgo(null);
+      expect(
+          () => atChops.sign(signingInput),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString() ==
+                  'encryption key pair not set for default signing algo')));
+    });
+
+    test('Negative test - sign() fails with', () {
+      final atChopsKeys = AtChopsKeys.create(null, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      AtSigningInput signingInput = AtSigningInput('abcde');
+      signingInput.signingAlgorithm = DefaultSigningAlgo(null);
+
+      expect(
+          () => atChops.sign(signingInput),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString() ==
+                  'encryption key pair not set for default signing algo')));
+    });
+
+    test('Negative test - sign() with incorrect DataType', () {
+      final atChopsKeys = AtChopsKeys.create(null, null);
+      final atChops = AtChopsImpl(atChopsKeys);
+      final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
+
+      AtSigningInput signingInput = AtSigningInput(213456777);
+      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair);
+
+      expect(
+          () => atChops.sign(signingInput),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString() == ' Unrecognized type of data: 213456777')));
     });
   });
 }

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -225,6 +225,7 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
+          // ignore: deprecated_member_use_from_same_package
           Uint8List.fromList(data.codeUnits), SigningKeyType.pkamSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
@@ -237,6 +238,7 @@ void main() {
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
+          // ignore: deprecated_member_use_from_same_package
           SigningKeyType.pkamSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -254,6 +256,7 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
+        // ignore: deprecated_member_use_from_same_package
           Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
@@ -266,6 +269,7 @@ void main() {
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
+          // ignore: deprecated_member_use_from_same_package
           SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -283,6 +287,7 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
+        // ignore: deprecated_member_use_from_same_package
           Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
@@ -295,6 +300,7 @@ void main() {
       final verificationResult = atChops.verifySignatureBytes(
           Uint8List.fromList(data.codeUnits),
           signingResult.result,
+          // ignore: deprecated_member_use_from_same_package
           SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -312,6 +318,7 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult =
+      // ignore: deprecated_member_use_from_same_package
           atChops.signString(data, SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
@@ -322,6 +329,7 @@ void main() {
           HashingAlgoType.sha256);
 
       final verificationResult = atChops.verifySignatureString(
+        // ignore: deprecated_member_use_from_same_package
           data, signingResult.result, SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -341,8 +349,8 @@ void main() {
           RSAPrivateKey.fromString(encryptionKeypair.atPrivateKey.privateKey);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result,
@@ -356,8 +364,8 @@ void main() {
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               encryptionKeypair.atPublicKey.publicKey);
-      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
@@ -381,10 +389,8 @@ void main() {
       AtSigningInput signingInput = AtSigningInput(data);
       signingInput.signingAlgoType = SigningAlgoType.rsa2048;
       signingInput.hashingAlgoType = HashingAlgoType.sha256;
-      AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
-          encryptionKeypair,
-          signingInput.signingAlgoType,
-          signingInput.hashingAlgoType);
+      AtSigningAlgorithm signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       signingInput.signingAlgorithm = signingAlgorithm;
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
@@ -401,8 +407,8 @@ void main() {
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha256;
-      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -427,10 +433,8 @@ void main() {
       AtSigningInput signingInput = AtSigningInput(data);
       signingInput.signingAlgoType = SigningAlgoType.rsa2048;
       signingInput.hashingAlgoType = HashingAlgoType.sha512;
-      AtSigningAlgorithm signingAlgorithm = DefaultSigningAlgo(
-          encryptionKeypair,
-          signingInput.signingAlgoType,
-          signingInput.hashingAlgoType);
+      AtSigningAlgorithm signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       signingInput.signingAlgorithm = signingAlgorithm;
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
@@ -447,8 +451,8 @@ void main() {
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha512;
-      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -471,8 +475,8 @@ void main() {
       AtSigningInput signingInput = AtSigningInput(data);
       signingInput.signingAlgoType = SigningAlgoType.rsa2048;
       signingInput.hashingAlgoType = HashingAlgoType.sha256;
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
@@ -480,8 +484,8 @@ void main() {
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha512;
-      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -504,8 +508,8 @@ void main() {
       AtSigningInput signingInput = AtSigningInput(data);
       signingInput.signingAlgoType = SigningAlgoType.rsa2048;
       signingInput.hashingAlgoType = HashingAlgoType.sha512;
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
@@ -513,8 +517,8 @@ void main() {
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha256;
-      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -537,8 +541,8 @@ void main() {
               data, 'dummysignature', encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha256;
-      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
@@ -562,8 +566,8 @@ void main() {
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha512;
-      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      AtSigningAlgorithm verifyAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
       verificationInput.signingAlgorithm = verifyAlgorithm;
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
@@ -587,15 +591,15 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       AtSigningInput signingInput = AtSigningInput(data);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
           AtSigningVerificationInput(data, signingResult.result,
               anotherEncryptionKeypair.atPublicKey.publicKey);
-      verificationInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          verificationInput.signingAlgoType, verificationInput.hashingAlgoType);
+      verificationInput.signingAlgorithm = DefaultSigningAlgo(
+          encryptionKeypair, verificationInput.hashingAlgoType);
 
       AtSigningResult verificationResult = atChops.verify(verificationInput);
       expect(verificationResult.atSigningMetaData, isNotNull);
@@ -612,8 +616,8 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       AtSigningInput signingInput = AtSigningInput('abcde');
-      signingInput.signingAlgorithm = DefaultSigningAlgo(
-          null, signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(null, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
       } catch (e, _) {
@@ -629,8 +633,8 @@ void main() {
       final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
 
       AtSigningInput signingInput = AtSigningInput(213456777);
-      signingInput.signingAlgorithm = DefaultSigningAlgo(encryptionKeypair,
-          signingInput.signingAlgoType, signingInput.hashingAlgoType);
+      signingInput.signingAlgorithm =
+          DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
       } catch (e, _) {

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
+import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -11,7 +12,8 @@ void main() {
         'Test default signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -24,7 +26,8 @@ void main() {
         'Test default signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 4096);
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -35,8 +38,8 @@ void main() {
     });
     test('Test default signing and verification - set sha256 hashing algo', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
-      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.sha256);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -47,8 +50,8 @@ void main() {
     });
     test('Test default signing and verification - set sha512 hashing algo', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
-      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -61,8 +64,8 @@ void main() {
         'Test default signing and verification - set md5 hashing algo - not supported',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
-      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.md5);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.md5);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -74,7 +77,8 @@ void main() {
                   'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
     });
     test('Test default signing - key pair not set', () {
-      final defaultSigningAlgo = DefaultSigningAlgo(null);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          null, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -87,7 +91,8 @@ void main() {
     });
     test('Test default verification - passing public key', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -12,8 +11,8 @@ void main() {
         'Test default signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -27,7 +26,7 @@ void main() {
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 4096);
       final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
+          keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -38,8 +37,8 @@ void main() {
     });
     test('Test default signing and verification - set sha256 hashing algo', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -50,8 +49,8 @@ void main() {
     });
     test('Test default signing and verification - set sha512 hashing algo', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha512);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -64,8 +63,8 @@ void main() {
         'Test default signing and verification - set md5 hashing algo - not supported',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.md5);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.md5);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -77,8 +76,8 @@ void main() {
                   'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
     });
     test('Test default signing - key pair not set', () {
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          null, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(null, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -92,7 +91,7 @@ void main() {
     test('Test default verification - passing public key', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+          keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -59,6 +59,33 @@ void main() {
           defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, true);
     });
+    test('Test invalid default signing and verification - sign with sha256 and verify with sha512 hashing algo', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo_sha256 =
+      DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo_sha512 = DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo_sha256.sign(dataInBytes);
+      var verifyResult =
+      defaultSigningAlgo_sha512.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, false);
+    });
+
+    test('Test invalid default signing and verification - sign with sha512 and verify with sha256 hashing algo', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo_sha256 =
+      DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo_sha512 = DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo_sha512.sign(dataInBytes);
+      var verifyResult =
+      defaultSigningAlgo_sha256.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, false);
+    });
     test(
         'Test default signing and verification - set md5 hashing algo - not supported',
         () {
@@ -71,7 +98,7 @@ void main() {
       expect(
           () => defaultSigningAlgo.sign(dataInBytes),
           throwsA(predicate((e) =>
-              e is AtException &&
+              e is AtSigningException &&
               e.toString().contains(
                   'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
     });
@@ -84,7 +111,7 @@ void main() {
       expect(
           () => defaultSigningAlgo.sign(dataInBytes),
           throwsA(predicate((e) =>
-              e is AtException &&
+              e is AtSigningException &&
               e.toString().contains(
                   'encryption key pair not set for default signing algo'))));
     });
@@ -100,6 +127,21 @@ void main() {
       var verifyResult = defaultSigningAlgo
           .verify(dataInBytes, signatureInBytes, publicKey: publicKeyString);
       expect(verifyResult, true);
+    });
+
+    test('Test invalid verification - passing different public key', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      var keyPair2 = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(
+          keyPair, HashingAlgoType.sha256);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      final publicKeyString = keyPair2.atPublicKey.publicKey;
+      var verifyResult = defaultSigningAlgo
+          .verify(dataInBytes, signatureInBytes, publicKey: publicKeyString);
+      expect(verifyResult, false);
     });
   });
 }

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -1,0 +1,101 @@
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/default_signing_algo.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests for default signing and verification', () {
+    test(
+        'Test default signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
+        () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      var verifyResult =
+          defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test(
+        'Test default signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
+        () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 4096);
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      var verifyResult =
+          defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test('Test default signing and verification - set sha256 hashing algo', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.sha256);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      var verifyResult =
+          defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test('Test default signing and verification - set sha512 hashing algo', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      var verifyResult =
+          defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test(
+        'Test default signing and verification - set md5 hashing algo - not supported',
+        () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      defaultSigningAlgo.setHashingAlgoType(HashingAlgoType.md5);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      expect(
+          () => defaultSigningAlgo.sign(dataInBytes),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString().contains(
+                  'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
+    });
+    test('Test default signing - key pair not set', () {
+      final defaultSigningAlgo = DefaultSigningAlgo(null);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      expect(
+          () => defaultSigningAlgo.sign(dataInBytes),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString().contains(
+                  'encryption key pair not set for default signing algo'))));
+    });
+    test('Test default verification - passing public key', () {
+      var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      final defaultSigningAlgo = DefaultSigningAlgo(keyPair);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = defaultSigningAlgo.sign(dataInBytes);
+      final publicKeyString = keyPair.atPublicKey.publicKey;
+      var verifyResult = defaultSigningAlgo
+          .verify(dataInBytes, signatureInBytes, publicKey: publicKeyString);
+      expect(verifyResult, true);
+    });
+  });
+}

--- a/packages/at_chops/test/ecc_signing_algo_test.dart
+++ b/packages/at_chops/test/ecc_signing_algo_test.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
+import 'package:ecdsa/ecdsa.dart';
+import 'package:elliptic/elliptic.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:at_chops/src/algorithm/default_signing_algo.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:crypton/crypton.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests for ecc signing and verification', () {
+    test(
+        'Test ecc signing and verification using generated private key from ecc',
+        () {
+      final eccAlgo = EccSigningAlgo();
+      var ec = getSecp256r1();
+      final eccPrivateKey = ec.generatePrivateKey();
+      eccAlgo.privateKey = eccPrivateKey;
+      final dataToSign = 'Hello World';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signature = eccAlgo.sign(dataInBytes);
+      var verifyResult = eccAlgo.verify(dataInBytes, signature);
+      expect(verifyResult, true);
+    });
+    test('Test ecc verification by passing public key', () {
+      final eccAlgo = EccSigningAlgo();
+      var ec = getSecp256r1();
+      final eccPrivateKey = ec.generatePrivateKey();
+      eccAlgo.privateKey = eccPrivateKey;
+      final publicKey = eccPrivateKey.publicKey;
+      final dataToSign = 'Hello World';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signature = eccAlgo.sign(dataInBytes);
+      var verifyResult = eccAlgo.verify(dataInBytes, signature,
+          publicKey: publicKey.toString());
+      expect(verifyResult, true);
+    });
+    test('Test ecc signing - private key not set', () {
+      final eccAlgo = EccSigningAlgo();
+      final dataToSign = 'Hello World';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      expect(
+          () => eccAlgo.sign(dataInBytes),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString().contains(
+                  'elliptic private key has to be set for signing operation'))));
+    });
+    test('Test ecc verification - private key and public key not available',
+        () {
+      final eccAlgo = EccSigningAlgo();
+      var ec = getSecp256r1();
+      final eccPrivateKey = ec.generatePrivateKey();
+      eccAlgo.privateKey = eccPrivateKey;
+      final dataToSign = 'Hello World';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signature = eccAlgo.sign(dataInBytes);
+      eccAlgo.privateKey = null;
+      expect(
+          () => eccAlgo.verify(dataInBytes, signature),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e
+                  .toString()
+                  .contains('public key not set not ecc verification'))));
+    });
+  });
+}

--- a/packages/at_chops/test/ecc_signing_algo_test.dart
+++ b/packages/at_chops/test/ecc_signing_algo_test.dart
@@ -1,15 +1,8 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
-import 'package:ecdsa/ecdsa.dart';
 import 'package:elliptic/elliptic.dart';
-import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:at_utils/at_logger.dart';
-import 'package:crypton/crypton.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -27,7 +20,7 @@ void main() {
       var verifyResult = eccAlgo.verify(dataInBytes, signature);
       expect(verifyResult, true);
     });
-    test('Test ecc verification by passing public key', () {
+    test('Test ecc verification - passing public key', () {
       final eccAlgo = EccSigningAlgo();
       var ec = getSecp256r1();
       final eccPrivateKey = ec.generatePrivateKey();

--- a/packages/at_chops/test/ecc_signing_algo_test.dart
+++ b/packages/at_chops/test/ecc_signing_algo_test.dart
@@ -33,6 +33,20 @@ void main() {
           publicKey: publicKey.toString());
       expect(verifyResult, true);
     });
+    test('Test invalid ecc verification - passing different public key', () {
+      final eccAlgo = EccSigningAlgo();
+      var ec = getSecp256r1();
+      var ec2 = getSecp256r1();
+      final eccPrivateKey = ec.generatePrivateKey();
+      eccAlgo.privateKey = eccPrivateKey;
+      final publicKey = ec2.generatePrivateKey().publicKey;
+      final dataToSign = 'Hello World';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signature = eccAlgo.sign(dataInBytes);
+      var verifyResult = eccAlgo.verify(dataInBytes, signature,
+          publicKey: publicKey.toString());
+      expect(verifyResult, false);
+    });
     test('Test ecc signing - private key not set', () {
       final eccAlgo = EccSigningAlgo();
       final dataToSign = 'Hello World';

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -33,7 +33,7 @@ void main() {
       var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, true);
     });
-    test('Test pkam signing and verification - set sha256 hashing algo', () {
+    test('Test pkam signing and verification - set sha256 hashing algo.', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
           pkamKeyPair, HashingAlgoType.sha256);
@@ -43,6 +43,33 @@ void main() {
       final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
       var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, true);
+    });
+    test('Test pkam signing and verification - sign with sha256 and verify with sha512.', () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo256 = PkamSigningAlgo(
+          pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo512 = PkamSigningAlgo(
+          pkamKeyPair, HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo256.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo512.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, false);
+    });
+
+    test('Test pkam signing and verification - sign with sha512 and verify with sha256.', () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo256 = PkamSigningAlgo(
+          pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo512 = PkamSigningAlgo(
+          pkamKeyPair, HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo512.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo256.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, false);
     });
     test('Test pkam signing and verification - set sha512 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -11,7 +11,8 @@ void main() {
         'Test pkam signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -23,7 +24,8 @@ void main() {
         'Test pkam signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair(keySize: 4096);
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -33,8 +35,8 @@ void main() {
     });
     test('Test pkam signing and verification - set sha256 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
-      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha256);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -44,8 +46,8 @@ void main() {
     });
     test('Test pkam signing and verification - set sha512 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
-      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -57,8 +59,8 @@ void main() {
         'Test pkam signing and verification - set md5 hashing algo - not supported',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
-      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.md5);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.md5);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -70,7 +72,8 @@ void main() {
                   'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
     });
     test('Test pkam signing - pkam key pair not set', () {
-      final pkamSigningAlgo = PkamSigningAlgo(null);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          null, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -84,8 +87,8 @@ void main() {
     });
     test('Test pkam verification - passing public key', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
-      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final pkamSigningAlgo = PkamSigningAlgo(
+          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -12,7 +12,7 @@ void main() {
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa2048, HashingAlgoType.sha256);
+          pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -25,7 +25,7 @@ void main() {
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair(keySize: 4096);
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
+          pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -36,7 +36,7 @@ void main() {
     test('Test pkam signing and verification - set sha256 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
+          pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -47,7 +47,7 @@ void main() {
     test('Test pkam signing and verification - set sha512 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha512);
+          pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -60,7 +60,7 @@ void main() {
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.md5);
+          pkamKeyPair, HashingAlgoType.md5);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -73,7 +73,7 @@ void main() {
     });
     test('Test pkam signing - pkam key pair not set', () {
       final pkamSigningAlgo = PkamSigningAlgo(
-          null, SigningAlgoType.rsa4096, HashingAlgoType.sha256);
+          null, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -88,7 +88,7 @@ void main() {
     test('Test pkam verification - passing public key', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
       final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, SigningAlgoType.rsa4096, HashingAlgoType.sha512);
+          pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -1,0 +1,99 @@
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests for pkam signing and verification', () {
+    test(
+        'Test pkam signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
+        () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test(
+        'Test pkam signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
+        () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair(keySize: 4096);
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test('Test pkam signing and verification - set sha256 hashing algo', () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha256);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test('Test pkam signing and verification - set sha512 hashing algo', () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
+      var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
+      expect(verifyResult, true);
+    });
+    test(
+        'Test pkam signing and verification - set md5 hashing algo - not supported',
+        () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.md5);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      expect(
+          () => pkamSigningAlgo.sign(dataInBytes),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e.toString().contains(
+                  'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
+    });
+    test('Test pkam signing - pkam key pair not set', () {
+      final pkamSigningAlgo = PkamSigningAlgo(null);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      expect(
+          () => pkamSigningAlgo.sign(dataInBytes),
+          throwsA(predicate((e) =>
+              e is AtException &&
+              e
+                  .toString()
+                  .contains('pkam key pair is null. cannot sign data'))));
+    });
+    test('Test pkam verification - passing public key', () {
+      var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair);
+      pkamSigningAlgo.setHashingAlgoType(HashingAlgoType.sha512);
+      final dataToSign =
+          '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
+      final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
+      final signatureInBytes = pkamSigningAlgo.sign(dataInBytes);
+      final publicKeyString = pkamKeyPair.atPublicKey.publicKey;
+      var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes,
+          publicKey: publicKeyString);
+      expect(verifyResult, true);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- added implementation for ECC signing algorithm
- refactored signing algorithm implementation
**- How I did it**
- deprecated signString and verifyString method in at_chops_base.dart
- introduced new method sign(AtSigningInput signingInput) and verify(AtSigningVerificationInput verifyInput) in at_chops_base.dart
- deprecated SigningKeyType enum and introduced new enums SigningAlgoType, HashingAlgoType
- added optional param publicKey to AtSigningAlgorithm.verify() method. 
- added new ECC signing implementation in ecc_signing_algo.dart
- added attributes _signingAlgoType and _hashingAlgoType to signing algorithm implementation. Based on _hashingAlgoType set, corresponding implementation will be called.
- in at_chops_impl added two private methods _verifySignatureBytes and _signBytes. These will replace the existing verifySignatureBytes  and signBytes public methods in the next major release
- added new objects for signing input - AtSigningInput and verification input - AtSigningVerificationInput
**- How to verify it**
- run the unit tests
