### PR TITLE
fix: Onboarding_cli throws exception when atsign does not start with '@'

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.4
-_ fix: Onboarding_cli throws exception when atsign does not start with '@'
+- fix: Onboarding_cli throws exception when atsign does not start with '@'
+- build: upgrade dependency at_utils to v3.0.12
 ## 1.2.3
 - Enable use of AtChops
 ## 1.2.2

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.2.4
+_ fix: Onboarding_cli throws exception when atsign does not start with '@'
 ## 1.2.3
 - Enable use of AtChops
 ## 1.2.2

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -28,7 +28,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
     //performs atSign format checks on the atSign
-    _atSign = AtUtils.fixAtSign(AtUtils.formatAtSign(atsign)!);
+    _atSign = AtUtils.fixAtSign(atsign);
   }
 
   Future<void> _init(AtChops atChops) async {

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -2,18 +2,19 @@
 
 import 'dart:convert';
 import 'dart:io';
+
+import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
-import 'package:at_utils/at_utils.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
-import 'package:at_server_status/at_server_status.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_server_status/at_server_status.dart';
+import 'package:at_utils/at_utils.dart';
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
-import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
-import 'package:at_chops/at_chops.dart';
+import 'package:zxing2/qrcode.dart';
 
 ///class containing service that can onboard/activate/authenticate @signs
 class AtOnboardingServiceImpl implements AtOnboardingService {
@@ -27,7 +28,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference) {
     //performs atSign format checks on the atSign
-    _atSign = AtUtils.formatAtSign(AtUtils.fixAtSign(atsign))!;
+    _atSign = AtUtils.fixAtSign(AtUtils.formatAtSign(atsign)!);
   }
 
   Future<void> _init(AtChops atChops) async {

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tool to authenticate, onboard and perform complex operations on atSign seccondaries from command-line-interface.
-version: 1.2.3
+version: 1.2.4
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -27,7 +27,9 @@ dependencies:
    http: ^0.13.5
    at_chops: ^1.0.0
 
-#dependency_overrides:
+dependency_overrides:
+  at_client:
+    path: C:\Users\Srie\Desktop\work\at_client_sdk\packages\at_client
 #  at_client:
 #    git:
 #      url: https://github.com/atsign-foundation/at_client_sdk.git

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -13,7 +13,7 @@ executables:
   at_activate: activate_cli
 
 dependencies:
-   at_utils: ^3.0.11
+   at_utils: ^3.0.12
    at_client: ^3.0.52
    at_lookup: ^3.0.35
    zxing2: ^0.1.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -27,26 +27,6 @@ dependencies:
    http: ^0.13.5
    at_chops: ^1.0.0
 
-dependency_overrides:
-  at_client:
-    path: C:\Users\Srie\Desktop\work\at_client_sdk\packages\at_client
-#  at_client:
-#    git:
-#      url: https://github.com/atsign-foundation/at_client_sdk.git
-#      path: packages/at_client
-#      ref: gkc-inject-atChops-into-RemoteSecondary
-#  at_lookup:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_lookup
-#      ref: uptake_atchops
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
-
-
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.22.1

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -2,20 +2,20 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
-import 'package:at_lookup/at_lookup.dart';
-import 'package:at_utils/at_logger.dart';
-import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_server_status/at_server_status.dart';
-import 'package:test/test.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
     as activate_cli;
+import 'package:at_server_status/at_server_status.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
 
 Future<void> main() async {
   AtSignLogger.root_level = 'finest';
   group('Tests to validate authenticate functionality', () {
     test('Test using atKeys File', () async {
-      String atsign = '@alice🛠';
+      String atsign = 'alice🛠';
       AtOnboardingPreference preference = getPreferences(atsign, false);
       await generateAtKeysFile(atsign, preference.atKeysFilePath!);
       AtOnboardingService atOnboardingService =


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/299
**- What I did**
- fix: re-order AtUtils.fixAtSign() and AtUtils.formatAtsign()
- test: modify existing test to include verification of current fix
- build: pubspec and changelog updates

**- How I did it**
- previously the code was AtUtils.formatAtSign(AtUtils.fixAtSign(atsign)) which means that the checks present in AtUtils.fixAtsign were being performed before AtUtils.fomatAtSign had a change to prefix the '@' symbol.
- Now the code is AtUtils.fixAtSign(AtUtils.formatAtSign(atsign)!). When an atsign is missing '@' the formatAtSign() will prefix it and then further checks are performed in fixAtSign()

**- How to verify it**
- modified an existing test
- removed '@' from an atsign in func_tests. Functional tests successfully passing should mean that the fix works

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- fix: Onboarding_cli throws exception when atsign does not start with '@'