### PR TITLE
feat: at_chops changes for pkam using private key from secure element

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.2
+- feat: changes for pkam using private key from secure element.
 ## 1.0.1
 - feat: Added implementation for different signing algorithms.
 ## 1.0.0

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -5,6 +5,7 @@ export 'src/at_chops_impl.dart';
 export 'src/key/impl/at_chops_keys.dart';
 export 'src/key/impl/at_encryption_key_pair.dart';
 export 'src/key/impl/at_pkam_key_pair.dart';
+export 'src/key/impl/aes_key.dart';
 export 'src/key/key_type.dart';
 export 'src/metadata/at_signing_input.dart';
 export 'src/metadata/encryption_metadata.dart';

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -30,7 +30,7 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
     if (publicKey == null && _privateKey == null) {
       throw AtSigningVerificationException(
-          'public key not set not ecc verification');
+          'Cannot verify signature - publicKey not provided or privateKey not available');
     }
     var ec = elliptic.getSecp256r1();
     var hashHex = sha256.convert(signedData).toString();

--- a/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/ecc_signing_algo.dart
@@ -29,7 +29,8 @@ class EccSigningAlgo implements AtSigningAlgorithm {
   @override
   bool verify(Uint8List signedData, Uint8List signature, {String? publicKey}) {
     if (publicKey == null && _privateKey == null) {
-      throw AtSigningVerificationException('public key not set not ecc verification');
+      throw AtSigningVerificationException(
+          'public key not set not ecc verification');
     }
     var ec = elliptic.getSecp256r1();
     var hashHex = sha256.convert(signedData).toString();

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -49,7 +49,8 @@ class PkamSigningAlgo implements AtSigningAlgorithm {
       case HashingAlgoType.sha512:
         return rsaPublicKey.verifySHA512Signature(signedData, signature);
       default:
-        throw AtSigningVerificationException('Invalid hashing algo $_hashingAlgoType provided');
+        throw AtSigningVerificationException(
+            'Invalid hashing algo $_hashingAlgoType provided');
     }
   }
 }

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -111,7 +111,8 @@ abstract class AtChops {
   /// Refer to [DefaultHash] for default implementation of hashing.
   String hash(Uint8List signedData, AtHashingAlgorithm hashingAlgorithm);
 
-  /// Reads a public key from SIM card based on ID. SIM card should have an IOTSafe compliant app
-  /// with a key pair preinstalled.
+  /// Reads a public key from a secure element or any other source
+  /// Clients can implement this method if want to use a different keypair for pkam authentication.
+  /// e.g. Secure element can be a SIM card with an IOTSafe compliant app with a key pair preinstalled.
   String readPublicKey(String publicKeyId);
 }

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -76,9 +76,9 @@ abstract class AtChops {
   // ignore: deprecated_member_use_from_same_package
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult verifySignatureBytes(
-      // ignore: deprecated_member_use_from_same_package
       Uint8List data,
       Uint8List signature,
+      // ignore: deprecated_member_use_from_same_package
       SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 
@@ -100,11 +100,13 @@ abstract class AtChops {
   /// Compute data signature using the private key from a key pair
   /// Input has to be set using [AtSigningInput] object
   /// Please refer to [AtSigningInput] to create a valid input instance
+  /// [AtSigningResult.result] should be base64Encoded
   AtSigningResult sign(AtSigningInput signingInput);
 
-  /// Verifies the signature computed for input data using the public key from a key pair
-  /// Input has to set using [AtSigningVerificationInput] obect
+  /// Verifies the signature computed for inpuat data using the public key from a key pair
+  /// Input has to set using [AtSigningVerificationInput] object
   /// Please refer to [AtSigningVerificationInput] docs to create a valid input instance
+  /// [AtSigningVerificationInput.result] should be base64Decoded if [AtSigningResult.result] is base64Encoded
   AtSigningResult verify(AtSigningVerificationInput verifyInput);
 
   /// Create a hash of input [signedData] using a [hashingAlgorithm].

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -77,7 +77,9 @@ abstract class AtChops {
   /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
   AtSigningResult verifySignatureBytes(
       // ignore: deprecated_member_use_from_same_package
-      Uint8List data, Uint8List signature, SigningKeyType signingKeyType,
+      Uint8List data,
+      Uint8List signature,
+      SigningKeyType signingKeyType,
       {AtSigningAlgorithm? signingAlgorithm});
 
   /// Sign the input string [data] using a [signingAlgorithm].
@@ -108,4 +110,8 @@ abstract class AtChops {
   /// Create a hash of input [signedData] using a [hashingAlgorithm].
   /// Refer to [DefaultHash] for default implementation of hashing.
   String hash(Uint8List signedData, AtHashingAlgorithm hashingAlgorithm);
+
+  /// Reads a public key from SIM card based on ID. SIM card should have an IOTSafe compliant app
+  /// with a key pair preinstalled.
+  String readPublicKey(String publicKeyId);
 }

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -364,7 +364,7 @@ class AtChopsImpl extends AtChops {
 
   @override
   String readPublicKey(String publicKeyId) {
-    // This method is implemented only for extensions of AtChops that use secure element for private keys
+    // This method is implemented only for extensions of AtChops that use secure element or any other source for private keys apart from the default source(.atKeys file)
     throw UnimplementedError();
   }
 }

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -361,4 +361,10 @@ class AtChopsImpl extends AtChops {
       throw InvalidDataException('Unrecognized type of data: $data');
     }
   }
+
+  @override
+  String readPublicKey(String publicKeyId) {
+    // This method is implemented only for extensions of AtChops that use secure element for private keys
+    throw UnimplementedError();
+  }
 }

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -214,7 +214,7 @@ class AtChopsImpl extends AtChops {
         signingAlgorithm: signingInput.signingAlgorithm);
   }
 
-  // change this method to public in the next major release and remove exisitng public method.
+  // change this method to public in the next major release and remove existing public method.
   AtSigningResult _signBytes(Uint8List data, AtSigningInput signingInput,
       {AtSigningAlgorithm? signingAlgorithm}) {
     signingAlgorithm ??= _getSigningAlgorithmV2(signingInput)!;
@@ -224,7 +224,7 @@ class AtChopsImpl extends AtChops {
       ..atSigningMetaData = atSigningMetadata
       ..atSigningResultType = AtSigningResultType.bytes;
     try {
-      atSigningResult.result = signingAlgorithm.sign(data);
+      atSigningResult.result = base64Encode(signingAlgorithm.sign(data));
     } on AtSigningException {
       rethrow;
     }
@@ -364,7 +364,7 @@ class AtChopsImpl extends AtChops {
 
   @override
   String readPublicKey(String publicKeyId) {
-    // This method is implemented only for extensions of AtChops that use secure element or any other source for private keys apart from the default source(.atKeys file)
+    // This method is implemented only for extensions of AtChops that use secure element or any other source for private keys other than the default source(.atKeys file)
     throw UnimplementedError();
   }
 }

--- a/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
+++ b/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
@@ -18,4 +18,12 @@ class AtChopsKeys {
   AtPkamKeyPair? get atPkamKeyPair => _atPkamKeyPair;
 
   SymmetricKey? get symmetricKey => _symmetricKey;
+
+  set atEncryptionKeyPair(AtEncryptionKeyPair? value) {
+    _atEncryptionKeyPair = value;
+  }
+
+  set symmetricKey(SymmetricKey? value) {
+    _symmetricKey = value;
+  }
 }

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -61,12 +61,12 @@ class AtSigningInput {
 class AtSigningVerificationInput {
   /// Data that has to verified
   ///
-  /// Data has to be either of base64encoded [String] or [Uint8List]
+  /// Data has to be either of [String] or [Uint8List]
   final dynamic _data;
 
   /// Signature of [_data] that will be used to verify
   ///
-  /// Signature needs to be either of type base64encoded [String] or [Uint8List]
+  /// Signature has to be base64decoded if signing result is base64Encoded.
   final dynamic _signature;
 
   /// Mandatory input

--- a/packages/at_chops/lib/src/metadata/signing_result.dart
+++ b/packages/at_chops/lib/src/metadata/signing_result.dart
@@ -1,8 +1,10 @@
 import 'package:at_chops/src/metadata/signing_metadata.dart';
 
-// Class that contains the signing/verification result with data type [AtSigningResultType] and metadata [AtSigningMetaData]
+/// Class that contains the signing/verification result with data type [AtSigningResultType] and metadata [AtSigningMetaData]
+/// [result] should be base64Encoded string
 class AtSigningResult {
   late AtSigningResultType atSigningResultType;
+
   dynamic result;
   late AtSigningMetaData atSigningMetaData;
 

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 1.0.1
+version: 1.0.2
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -225,8 +225,9 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
+          Uint8List.fromList(data.codeUnits),
           // ignore: deprecated_member_use_from_same_package
-          Uint8List.fromList(data.codeUnits), SigningKeyType.pkamSha256);
+          SigningKeyType.pkamSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
@@ -256,8 +257,9 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
-        // ignore: deprecated_member_use_from_same_package
-          Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
+          Uint8List.fromList(data.codeUnits),
+          // ignore: deprecated_member_use_from_same_package
+          SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
@@ -287,8 +289,9 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult = atChops.signBytes(
-        // ignore: deprecated_member_use_from_same_package
-          Uint8List.fromList(data.codeUnits), SigningKeyType.signingSha256);
+          Uint8List.fromList(data.codeUnits),
+          // ignore: deprecated_member_use_from_same_package
+          SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
@@ -318,7 +321,7 @@ void main() {
       final atChops = AtChopsImpl(atChopsKeys);
 
       final signingResult =
-      // ignore: deprecated_member_use_from_same_package
+          // ignore: deprecated_member_use_from_same_package
           atChops.signString(data, SigningKeyType.signingSha256);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result, isNotEmpty);
@@ -329,8 +332,10 @@ void main() {
           HashingAlgoType.sha256);
 
       final verificationResult = atChops.verifySignatureString(
-        // ignore: deprecated_member_use_from_same_package
-          data, signingResult.result, SigningKeyType.signingSha256);
+          data,
+          signingResult.result,
+          // ignore: deprecated_member_use_from_same_package
+          SigningKeyType.signingSha256);
       expect(verificationResult.atSigningMetaData, isNotNull);
       expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
       expect(verificationResult.atSigningMetaData.signingAlgoType,
@@ -354,7 +359,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result,
-          rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List));
+          base64Encode(rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,
           SigningAlgoType.rsa2048);
@@ -362,7 +367,7 @@ void main() {
           HashingAlgoType.sha256);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgorithm = DefaultSigningAlgo(
           encryptionKeypair, verificationInput.hashingAlgoType);
@@ -395,7 +400,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result,
-          rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List));
+          base64Encode(rsaPrivateKey.createSHA256Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,
           SigningAlgoType.rsa2048);
@@ -403,7 +408,7 @@ void main() {
           HashingAlgoType.sha256);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha256;
@@ -439,7 +444,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
       expect(signingResult.atSigningMetaData, isNotNull);
       expect(signingResult.result,
-          rsaPrivateKey.createSHA512Signature(utf8.encode(data) as Uint8List));
+          base64Encode(rsaPrivateKey.createSHA512Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,
           SigningAlgoType.rsa2048);
@@ -447,7 +452,7 @@ void main() {
           HashingAlgoType.sha512);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha512;
@@ -480,7 +485,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha512;
@@ -513,7 +518,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               encryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgoType = SigningAlgoType.rsa2048;
       verificationInput.hashingAlgoType = HashingAlgoType.sha256;
@@ -596,7 +601,7 @@ void main() {
       final signingResult = atChops.sign(signingInput);
 
       AtSigningVerificationInput? verificationInput =
-          AtSigningVerificationInput(data, signingResult.result,
+          AtSigningVerificationInput(data, base64Decode(signingResult.result),
               anotherEncryptionKeypair.atPublicKey.publicKey);
       verificationInput.signingAlgorithm = DefaultSigningAlgo(
           encryptionKeypair, verificationInput.hashingAlgoType);

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -25,8 +25,8 @@ void main() {
         'Test default signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
         () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair(keySize: 4096);
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -59,31 +59,37 @@ void main() {
           defaultSigningAlgo.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, true);
     });
-    test('Test invalid default signing and verification - sign with sha256 and verify with sha512 hashing algo', () {
+    test(
+        'Test invalid default signing and verification - sign with sha256 and verify with sha512 hashing algo',
+        () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final defaultSigningAlgo_sha256 =
-      DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
-      final defaultSigningAlgo_sha512 = DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo_sha512 =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
       final signatureInBytes = defaultSigningAlgo_sha256.sign(dataInBytes);
       var verifyResult =
-      defaultSigningAlgo_sha512.verify(dataInBytes, signatureInBytes);
+          defaultSigningAlgo_sha512.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, false);
     });
 
-    test('Test invalid default signing and verification - sign with sha512 and verify with sha256 hashing algo', () {
+    test(
+        'Test invalid default signing and verification - sign with sha512 and verify with sha256 hashing algo',
+        () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       final defaultSigningAlgo_sha256 =
-      DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
-      final defaultSigningAlgo_sha512 = DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo_sha512 =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
       final signatureInBytes = defaultSigningAlgo_sha512.sign(dataInBytes);
       var verifyResult =
-      defaultSigningAlgo_sha256.verify(dataInBytes, signatureInBytes);
+          defaultSigningAlgo_sha256.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, false);
     });
     test(
@@ -117,8 +123,8 @@ void main() {
     });
     test('Test default verification - passing public key', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -132,8 +138,8 @@ void main() {
     test('Test invalid verification - passing different public key', () {
       var keyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       var keyPair2 = AtChopsUtil.generateAtEncryptionKeyPair();
-      final defaultSigningAlgo = DefaultSigningAlgo(
-          keyPair, HashingAlgoType.sha256);
+      final defaultSigningAlgo =
+          DefaultSigningAlgo(keyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -11,8 +11,8 @@ void main() {
         'Test pkam signing and verification using generated rsa 2048 key pair, default signing and hashing algo',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -24,8 +24,8 @@ void main() {
         'Test pkam signing and verification using generated rsa 4096 key pair, default signing and hashing algo',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair(keySize: 4096);
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -35,8 +35,8 @@ void main() {
     });
     test('Test pkam signing and verification - set sha256 hashing algo.', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -44,37 +44,43 @@ void main() {
       var verifyResult = pkamSigningAlgo.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, true);
     });
-    test('Test pkam signing and verification - sign with sha256 and verify with sha512.', () {
+    test(
+        'Test pkam signing and verification - sign with sha256 and verify with sha512.',
+        () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo256 = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha256);
-      final pkamSigningAlgo512 = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha512);
+      final pkamSigningAlgo256 =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo512 =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
       final signatureInBytes = pkamSigningAlgo256.sign(dataInBytes);
-      var verifyResult = pkamSigningAlgo512.verify(dataInBytes, signatureInBytes);
+      var verifyResult =
+          pkamSigningAlgo512.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, false);
     });
 
-    test('Test pkam signing and verification - sign with sha512 and verify with sha256.', () {
+    test(
+        'Test pkam signing and verification - sign with sha512 and verify with sha256.',
+        () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo256 = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha256);
-      final pkamSigningAlgo512 = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha512);
+      final pkamSigningAlgo256 =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha256);
+      final pkamSigningAlgo512 =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
       final signatureInBytes = pkamSigningAlgo512.sign(dataInBytes);
-      var verifyResult = pkamSigningAlgo256.verify(dataInBytes, signatureInBytes);
+      var verifyResult =
+          pkamSigningAlgo256.verify(dataInBytes, signatureInBytes);
       expect(verifyResult, false);
     });
     test('Test pkam signing and verification - set sha512 hashing algo', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha512);
+      final pkamSigningAlgo =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -86,8 +92,7 @@ void main() {
         'Test pkam signing and verification - set md5 hashing algo - not supported',
         () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.md5);
+      final pkamSigningAlgo = PkamSigningAlgo(pkamKeyPair, HashingAlgoType.md5);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -99,8 +104,7 @@ void main() {
                   'Hashing algo HashingAlgoType.md5 is invalid/not supported'))));
     });
     test('Test pkam signing - pkam key pair not set', () {
-      final pkamSigningAlgo = PkamSigningAlgo(
-          null, HashingAlgoType.sha256);
+      final pkamSigningAlgo = PkamSigningAlgo(null, HashingAlgoType.sha256);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);
@@ -114,8 +118,8 @@ void main() {
     });
     test('Test pkam verification - passing public key', () {
       var pkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final pkamSigningAlgo = PkamSigningAlgo(
-          pkamKeyPair, HashingAlgoType.sha512);
+      final pkamSigningAlgo =
+          PkamSigningAlgo(pkamKeyPair, HashingAlgoType.sha512);
       final dataToSign =
           '_a7028ce7-aaa8-4c52-9cf4-b94ca3bdf971@alice:c2834cd4-bb16-4801-8abc-efe79cdceb8f';
       final dataInBytes = Uint8List.fromList(dataToSign.codeUnits);


### PR DESCRIPTION
**- What I did**
 - changes to support pkam using private key from secure element
 - analyser changes
 - bug fix in encoding/decoding of signature
**- How I did it**
- introduced a public method readPublicKey(String publicKeyId) in at_chops_base. Clients using secure element will be extending AtChopsImpl and override readPublicKey(...) method
- provided setters for encryption key pair and symmetric key. If these keys are not available during at_chops creation, they can be set later on.
- added base64Encoding to the recently added method sign(..). Modified documentation for base64encoding/base64decoding
**- How to verify it**
n/a since no changes in implementation in at_chops
