### PR TITLE
feat: at_lookup changes for new at_chops signing method

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.36
+- feat: changes to call at_chops.sign() method which supports different signing algorithms.
+- chore: upgrade at_commons to 3.0.39 and at_utils to 3.0.12
 ## 3.0.35
 - fix: fallback code for backward compatibility if at_chops instance is not set
 ## 3.0.34

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.36
 - feat: changes to call at_chops.sign() method which supports different signing algorithms.
-- chore: upgrade at_commons to 3.0.39 and at_utils to 3.0.12
+- chore: upgrade at_commons to 3.0.39, at_utils to 3.0.12 and at_chops to 1.0.2
 ## 3.0.35
 - fix: fallback code for backward compatibility if at_chops instance is not set
 ## 3.0.34

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.36
 - feat: changes to call at_chops.sign() method which supports different signing algorithms.
-- chore: upgrade at_commons to 3.0.39, at_utils to 3.0.12 and at_chops to 1.0.2
+- chore: upgrade at_commons to 3.0.43, at_utils to 3.0.12 and at_chops to 1.0.3
 ## 3.0.35
 - fix: fallback code for backward compatibility if at_chops instance is not set
 ## 3.0.34

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -27,8 +27,8 @@ abstract class AtLookUp {
   Future<String?> executeVerb(VerbBuilder builder, {bool sync = false});
 
   /// performs a PKAM authentication using private key on the client side and public key on secondary server
-  /// Optionally pass the signing algorithm [SigningAlgoType] and hashing algorithm [HashingAlgoType]
-  Future<bool> pkamAuthenticate({SigningAlgoType signingAlgoType, HashingAlgoType hashingAlgoType});
+  /// Default signing algorithm for pkam signature is [SigningAlgoType.rsa2048] and default hashing algorithm is [HashingAlgoType.sha256]
+  Future<bool> pkamAuthenticate();
 
   /// set an instance of  [AtChops] for signing and verification operations.
   set atChops(AtChops? atChops);

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -38,4 +38,14 @@ abstract class AtLookUp {
   set secondaryAddressFinder(SecondaryAddressFinder secondaryAddressFinder);
 
   SecondaryAddressFinder get secondaryAddressFinder;
+
+  /// Signing algorithm for pkam signature
+  set signingAlgoType(SigningAlgoType signingAlgoType);
+
+  SigningAlgoType get signingAlgoType;
+
+  /// Hashing algorithm for pkam signature
+  set hashingAlgoType(HashingAlgoType hashingAlgoType);
+
+  HashingAlgoType get hashingAlgoType;
 }

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -27,7 +27,8 @@ abstract class AtLookUp {
   Future<String?> executeVerb(VerbBuilder builder, {bool sync = false});
 
   /// performs a PKAM authentication using private key on the client side and public key on secondary server
-  Future<bool> pkamAuthenticate();
+  /// Optionally pass the signing algorithm [SigningAlgoType] and hashing algorithm [HashingAlgoType]
+  Future<bool> pkamAuthenticate({SigningAlgoType signingAlgoType, HashingAlgoType hashingAlgoType});
 
   /// set an instance of  [AtChops] for signing and verification operations.
   set atChops(AtChops? atChops);

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -47,9 +47,6 @@ class AtLookupImpl implements AtLookUp {
 
   AtChops? _atChops;
 
-  /// To use a specific signing algorithm for pkam auth, set the [SigningAlgoType] and [HashingAlgoType] in clientConfig map
-  /// e.g clientConfig[AT_PKAM_SIGNING_ALGO] = SigningAlgoType.ecc_secp256r1
-  /// clientConfig[AT_PKAM_HASHING_ALGO] = HashingAlgoType.sha256
   AtLookupImpl(String atSign, String rootDomain, int rootPort,
       {this.privateKey,
       this.cramSecret,
@@ -442,10 +439,6 @@ class AtLookupImpl implements AtLookUp {
         }
         fromResponse = fromResponse.trim().replaceAll('data:', '');
         logger.finer('fromResponse $fromResponse');
-        var signingAlgoType =
-            _clientConfig[AT_PKAM_SIGNING_ALGO] ?? SigningAlgoType.rsa2048;
-        var hashingAlgoType =
-            _clientConfig[AT_PKAM_HASHING_ALGO] ?? HashingAlgoType.sha256;
         logger.finer(
             'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');
         final atSigningInput = AtSigningInput(fromResponse)
@@ -621,4 +614,11 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   AtChops? get atChops => _atChops;
+
+  /// To use a specific signing algorithm other than default one for pkam auth, set the [SigningAlgoType] and [HashingAlgoType]
+  @override
+  HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
+
+  @override
+  SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048;
 }

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -47,6 +47,9 @@ class AtLookupImpl implements AtLookUp {
 
   AtChops? _atChops;
 
+  /// To use a specific signing algorithm for pkam auth, set the [SigningAlgoType] and [HashingAlgoType] in clientConfig map
+  /// e.g clientConfig[AT_PKAM_SIGNING_ALGO] = SigningAlgoType.ecc_secp256r1
+  /// clientConfig[AT_PKAM_HASHING_ALGO] = HashingAlgoType.sha256
   AtLookupImpl(String atSign, String rootDomain, int rootPort,
       {this.privateKey,
       this.cramSecret,
@@ -423,9 +426,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @override
-  Future<bool> pkamAuthenticate(
-      {SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048,
-      HashingAlgoType hashingAlgoType = HashingAlgoType.sha256}) async {
+  Future<bool> pkamAuthenticate() async {
     await createConnection();
     try {
       await _pkamAuthenticationMutex.acquire();
@@ -441,7 +442,10 @@ class AtLookupImpl implements AtLookUp {
         }
         fromResponse = fromResponse.trim().replaceAll('data:', '');
         logger.finer('fromResponse $fromResponse');
-
+        var signingAlgoType =
+            _clientConfig[AT_PKAM_SIGNING_ALGO] ?? SigningAlgoType.rsa2048;
+        var hashingAlgoType =
+            _clientConfig[AT_PKAM_HASHING_ALGO] ?? HashingAlgoType.sha256;
         logger.finer(
             'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');
         final atSigningInput = AtSigningInput(fromResponse)

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -424,8 +424,8 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   Future<bool> pkamAuthenticate(
-      {SigningAlgoType? signingAlgoType,
-      HashingAlgoType? hashingAlgoType}) async {
+      {SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048,
+      HashingAlgoType hashingAlgoType = HashingAlgoType.sha256}) async {
     await createConnection();
     try {
       await _pkamAuthenticationMutex.acquire();
@@ -442,8 +442,6 @@ class AtLookupImpl implements AtLookUp {
         fromResponse = fromResponse.trim().replaceAll('data:', '');
         logger.finer('fromResponse $fromResponse');
 
-        signingAlgoType ??= SigningAlgoType.rsa2048;
-        hashingAlgoType ??= HashingAlgoType.sha256;
         logger.finer(
             'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');
         final atSigningInput = AtSigningInput(fromResponse)

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -423,7 +423,9 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @override
-  Future<bool> pkamAuthenticate() async {
+  Future<bool> pkamAuthenticate(
+      {SigningAlgoType? signingAlgoType,
+      HashingAlgoType? hashingAlgoType}) async {
     await createConnection();
     try {
       await _pkamAuthenticationMutex.acquire();
@@ -439,10 +441,21 @@ class AtLookupImpl implements AtLookUp {
         }
         fromResponse = fromResponse.trim().replaceAll('data:', '');
         logger.finer('fromResponse $fromResponse');
-        var signingResult =
-            _atChops!.signString(fromResponse, SigningKeyType.pkamSha256);
-        logger.finer('Sending command pkam:${signingResult.result}');
-        await _sendCommand('pkam:${signingResult.result}\n');
+
+        signingAlgoType ??= SigningAlgoType.rsa2048;
+        hashingAlgoType ??= HashingAlgoType.sha256;
+        logger.finer(
+            'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');
+        final atSigningInput = AtSigningInput(fromResponse)
+          ..signingAlgoType = signingAlgoType
+          ..hashingAlgoType = hashingAlgoType
+          ..signingMode = AtSigningMode.pkam;
+        var signingResult = _atChops!.sign(atSigningInput);
+        var pkamCommand =
+            'pkam:signingAlgo:${signingAlgoType.name}:hashingAlgo:${hashingAlgoType.name}:${signingResult.result}\n';
+        logger.finer('pkamCommand:$pkamCommand');
+        await _sendCommand(pkamCommand);
+
         var pkamResponse = await messageListener.read();
         if (pkamResponse == 'data:success') {
           logger.info('auth success');

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.35
+version: 3.0.36
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -12,18 +12,20 @@ dependencies:
   path: ^1.8.0
   crypton: ^2.0.1
   crypto: ^3.0.1
-  at_utils: ^3.0.11
-  at_commons: ^3.0.34
+  at_utils: ^3.0.12
+  at_commons: ^3.0.39
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
   at_chops: ^1.0.0
-#dependency_overrides:
-#  at_chops:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_chops
-#      ref: at_chops
+
+dependency_overrides:
+  # TODO replace overrides with at_chops published version
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_chops
+      ref: at_chops_changes_pkam_secure_element
 #    path: ../at_chops
 
 dev_dependencies:

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -17,16 +17,7 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
-  at_chops: ^1.0.0
-
-dependency_overrides:
-  # TODO replace overrides with at_chops published version
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_chops
-      ref: at_chops_changes_pkam_secure_element
-#    path: ../at_chops
+  at_chops: ^1.0.2
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
   crypton: ^2.0.1
   crypto: ^3.0.1
   at_utils: ^3.0.12
-  at_commons: ^3.0.39
+  at_commons: ^3.0.43
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
-  at_chops: ^1.0.2
+  at_chops: ^1.0.3
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
- changes to call at chops sign method
- upgraded at_commons and at_utils version
**- How I did it**
- Added optional params in at_lookup.pkamAuthenticate method to pass signing and hashing algorithm
- replaced deprecated at_chops.signString method with at_chops.sign method 
- pass the optional signing and hashing algorithm to pkam verb. if no params are passed, pkam will be called with default signing (rsa2048) and hashing(sha256)
**- How to verify it**
- point to this branch of at_lookup and run at_client and at_server tests
https://github.com/atsign-foundation/at_client_sdk/pull/977
https://github.com/atsign-foundation/at_server/pull/1285
