### PR TITLE
fix: Refactor tests at_onboarding_cli functional tests

### DIFF
--- a/packages/at_onboarding_cli/bin/activate_cli.dart
+++ b/packages/at_onboarding_cli/bin/activate_cli.dart
@@ -1,6 +1,14 @@
+import 'dart:io';
+
 import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
     as activate_cli;
 
 Future<void> main(List<String> args) async {
   await activate_cli.main(args);
+  // The onboarding_service_impl creates an AtClient instance which will start
+  // the following services: SyncService, AtClientCommitLogCompaction,
+  // Monitor connection in NotificationService.
+  // We do not have an stop method in at_client that stop(s) the services, hence
+  // to force quit, calling exit method.
+  exit(0);
 }

--- a/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
@@ -26,24 +26,22 @@ Future<void> main(List<String> arguments) async {
 
   if (argResults.wasParsed('help')) {
     print(parser.usage);
-    exit(0);
+    return;
   }
 
   if (!argResults.wasParsed('atsign')) {
     stderr.writeln(
         '--atsign (or -a) is required. Run with --help (or -h) for more.');
-    exit(1);
+    return;
   }
 
   if (!argResults.wasParsed('cramkey') && !argResults.wasParsed('qr_path')) {
     stderr.writeln(
         'Either of --cramkey(-c) or --qr_path(-q) is required. Run with --help (or -h) for more.');
-    exit(2);
+    return;
   }
 
   stdout.writeln('[Information] Root server is ${argResults['rootServer']}');
-
-  // var downloadPath = '${Directory.current.path}/.atsign/keys';
   var homeDirectory = getHomeDirectory();
   var downloadPath = "$homeDirectory/.atsign/keys";
 
@@ -55,9 +53,8 @@ Future<void> main(List<String> arguments) async {
     ..downloadPath = downloadPath;
 
   //onboard the atSign
-  AtOnboardingService? onboardingService =
+  AtOnboardingService onboardingService =
       AtOnboardingServiceImpl(argResults['atsign'], atOnboardingPreference);
-
   stdout.writeln(
       '[Information] Activating your atSign. This may take up to 2 minutes.');
   try {
@@ -66,13 +63,11 @@ Future<void> main(List<String> arguments) async {
     stderr.writeln(
         '[Error] Activation failed. It looks like something went wrong on our side.\n'
         'Please try again or contact support@atsign.com\nCause: ${e.toString()}');
-    exit(3);
+  } finally {
+    await onboardingService.close();
   }
-  await onboardingService.close();
-  //free the object after it's used and no longer required
-  onboardingService = null;
   stdout.writeln(
       '[Information] Your .atKeys file has been saved to the following location:\n$downloadPath');
   stdout.writeln('-------atSign activation complete-------');
-  exit(0);
+  return;
 }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -450,7 +450,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     }
     _atClient = null;
     logger.info('Closing current instance of at_onboarding_cli');
-    exit(0);
   }
 
   @override

--- a/tests/at_onboarding_cli_functional_tests/test/ecc_secure_element_mock_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/ecc_secure_element_mock_test.dart
@@ -14,7 +14,7 @@ void main() {
   AtSignLogger.root_level = 'FINER';
   var logger = AtSignLogger('OnboardSecureElement');
 
-  final atSign = '@bob🛠';
+  final atSign = '@egcreditbureau🛠'.trim();
   test('Test auth functionality', () async {
     AtOnboardingPreference preference = getPreferences(atSign);
     AtOnboardingService onboardingService =
@@ -24,18 +24,18 @@ void main() {
         AtChopsSecureElementMock(AtChopsKeys.create(null, null));
     onboardingService.atChops = atChopsImpl;
     atChopsImpl.init();
-    logger.info('calling onboard');
+    logger.info('Onboarding the atSign: $atSign');
     bool isOnboarded = await onboardingService.onboard();
     expect(isOnboarded, true);
-    logger.info('onboard done');
-    logger.info('calling auth');
+    logger.info('Onboarding completed successfully');
 
+    logger.info('Authenticating the atSign: $atSign');
     bool status = await onboardingService.authenticate();
-    logger.info('auth done');
     expect(status, true);
+    logger.info('Authentication completed successfully for atSign: $atSign');
 
     // update a key
-    AtClient? atClient = await onboardingService.getAtClient();
+    AtClient? atClient = await onboardingService.atClient;
     await insertSelfEncKey(atClient, atSign,
         selfEncryptionKey:
             await getSelfEncryptionKey(preference.atKeysFilePath!));
@@ -55,7 +55,7 @@ void main() {
   });
 }
 
-AtOnboardingPreference getPreferences(String atsign) {
+AtOnboardingPreference getPreferences(String atSign) {
   AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
     ..hiveStoragePath = 'storage/hive'
     ..namespace = 'wavi'
@@ -64,13 +64,13 @@ AtOnboardingPreference getPreferences(String atsign) {
     ..commitLogPath = 'storage/commitLog'
     ..rootDomain = 'vip.ve.atsign.zone'
     ..fetchOfflineNotifications = true
-    ..atKeysFilePath = 'storage/files/@bob🛠_key.atKeys'
+    ..atKeysFilePath = 'storage/files/$atSign' + '_key.atKeys'
     ..useAtChops = true
     ..signingAlgoType = SigningAlgoType.ecc_secp256r1
     ..hashingAlgoType = HashingAlgoType.sha256
     ..authMode = PkamAuthMode.sim
     ..publicKeyId = '3023020'
-    ..cramSecret = at_demos.cramKeyMap[atsign]
+    ..cramSecret = at_demos.cramKeyMap[atSign]
     ..skipSync = true;
 
   return atOnboardingPreference;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Remove the call to exit method in activate_cli which is causing the functional tests in at_onboarding_cli to exit and ignore the rest of the test cases
* Refactor the existing test cases

**- How I did it**
* Replaced the call "exit" methods with "return" statements.

**- How to verify it**
* All tests should pass

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->