### PR TITLE
fix: remove pkam auth mode enum and use the enum from at_commons

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -3,7 +3,6 @@
 - fix: issue with atKeys file creation while onboarding if the downloadPath directory does not exist
 - fix: activate_cli throws exit(0) even though the process fails
 - fix: onboarding_cli throws exception now when secondary address not found. Previously exit(1)
-- build: upgrade zxing2 dependency to 0.2.0 and image dependency to 4.0.15
 ## 1.2.5
 - feat: atkeys file now placed in standard location ~/.atsign/keys
 ## 1.2.4

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: issue with atKeys file creation while onboarding if the downloadPath directory does not exist
 - fix: activate_cli throws exit(0) even though the process fails
 - fix: onboarding_cli throws exception now when secondary address not found. Previously exit(1)
+- build: upgrade zxing2 dependency to 0.2.0 and image dependency to 4.0.15
 ## 1.2.5
 - feat: atkeys file now placed in standard location ~/.atsign/keys
 ## 1.2.4

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -166,7 +166,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         '[Information] Generating your encryption keys and .atKeys file\n');
     //mapping encryption keys pairs to their names
     Map<String, String> atKeysMap = <String, String>{};
-    var pkamPublicKey;
+    String pkamPublicKey;
     //generating pkamKeyPair only if authMode is keysFile
     if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
       logger.info('Generating pkam keypair');

--- a/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
+import 'package:at_commons/at_commons.dart';
 
 class AtOnboardingPreference extends AtClientPreference {
   //specify path of .atKeysFile containing encryption keys
@@ -23,8 +24,3 @@ class AtOnboardingPreference extends AtClientPreference {
 
   bool skipSync = false;
 }
-
-// If pkam auth mode is keysFile then pkam private key will be generated during onboarding and saved in the keys file.
-// For subsequent authentication, pkam private key will be read from the keys file supplied by the user.
-// If pkam auth mode is sim or any other secure element, then private key is not accessible directly. Only the data will be passed to the sim/secure element, pkam signature can be retrieved and verified.pkam private key will not be a part of keys file in this case.
-enum PkamAuthMode { keysFile, sim }

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -16,10 +16,10 @@ dependencies:
    at_utils: ^3.0.12
    at_client: ^3.0.58
    at_lookup: ^3.0.36
-   zxing2: ^0.1.0
-   image: ^3.1.1
+   zxing2: ^0.2.0
+   image: ^4.0.15
    crypton: ^2.0.3
-   at_commons: ^3.0.43
+   at_commons: ^3.0.44
    encrypt: ^5.0.1
    at_server_status: ^1.0.3
    path: ^1.8.1

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
    at_utils: ^3.0.12
    at_client: ^3.0.58
    at_lookup: ^3.0.36
-   zxing2: ^0.2.0
-   image: ^4.0.15
+   zxing2: ^0.1.0
+   image: ^3.1.1
    crypton: ^2.0.3
    at_commons: ^3.0.44
    encrypt: ^5.0.1


### PR DESCRIPTION
**- What I did**
- removed pkam auth mode enum from onboarding preference
**- How I did it**
- upgraded at_commons version to 3.0.44 in pubspec
- removed the enum PkamAuthMode and used the one from at_commons
**- How to verify it**
- unit and functional tests should pass
