### PR TITLE
Move IoT Safe code examples to at_chops

### DIFF
--- a/packages/at_chops/example/zariot/at_chops_secure_element.dart
+++ b/packages/at_chops/example/zariot/at_chops_secure_element.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:crypto/crypto.dart';
+import 'package:at_chops/at_chops.dart';
+
+import 'external_signer.dart';
+
+class AtChopsSecureElement extends AtChopsImpl {
+  late ExternalSigner externalSigner;
+  AtChopsSecureElement(AtChopsKeys atChopsKeys) : super(atChopsKeys);
+
+  @override
+  AtSigningResult sign(AtSigningInput signingInput) {
+    final dataHash = sha256.convert(_getBytes(signingInput.data));
+    var externalSignature = externalSigner.sign(dataHash.toString());
+    if (externalSignature == null) {
+      throw Exception('error while computing signature');
+    }
+    var base64Signature = base64Encode(externalSignature.codeUnits);
+    final atSigningMetadata = AtSigningMetaData(signingInput.signingAlgoType,
+        signingInput.hashingAlgoType, DateTime.now().toUtc());
+    final atSigningResult = AtSigningResult()
+      ..result = base64Signature
+      ..atSigningMetaData = atSigningMetadata
+      ..atSigningResultType = AtSigningResultType.string;
+    return atSigningResult;
+  }
+
+  Uint8List _getBytes(dynamic data) {
+    if (data is String) {
+      return utf8.encode(data) as Uint8List;
+    } else if (data is Uint8List) {
+      return data;
+    } else {
+      throw Exception('Unrecognized type of data: $data');
+    }
+  }
+
+  @override
+  String readPublicKey(String publicKeyId) {
+    return externalSigner.getPublicKey(publicKeyId).toLowerCase();
+  }
+}

--- a/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
+++ b/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
@@ -29,7 +29,7 @@ void main() {
     }
     // Step 2. Select IOTsafe by application id
     serialPort.writeString(
-        "AT+CSIM=24, \"${channelNumber}A4040007${applicationId}\"\r\n");
+        "AT+CSIM=24, \"${channelNumber}A4040007$applicationId\"\r\n");
     var selectApplicationResult = serialPort.read(256, 1000);
     print('selectApplicationResult :$selectApplicationResult');
     bool isValidApplication =
@@ -161,7 +161,7 @@ void main() {
     print('verifySignatureInitResult $verifySignatureInitResult');
     bool isVerifyInitSuccess =
         _parseVerifyResult(verifySignatureInitResult.toString());
-    print('isVerifyInitSuccess ${isVerifyInitSuccess}');
+    print('isVerifyInitSuccess $isVerifyInitSuccess');
 
     // Step 9. Verify signature update
     // 2D - tag for signature update
@@ -171,7 +171,7 @@ void main() {
     // 33 - tag for signature
     // 0040 - length of signature
     serialPort.writeString(
-        "AT+CSIM=212,\"8${channelNumber.substring(1)}2D8002659E20${dataHash}330040${signatureStr}\"\r\n");
+        "AT+CSIM=212,\"8${channelNumber.substring(1)}2D8002659E20${dataHash}330040$signatureStr\"\r\n");
     var verifySignatureResult = serialPort.read(256, 1000);
     print('verifySignatureResult $verifySignatureResult');
     var verifyResult = '';
@@ -188,7 +188,7 @@ void main() {
     }
     print('verifyResult: $verifyResult');
     bool isVerifyUpdateSuccess = _parseVerifyResult(verifyResult);
-    print('isVerifyUpdateSuccess ${isVerifyUpdateSuccess}');
+    print('isVerifyUpdateSuccess $isVerifyUpdateSuccess');
   } finally {
     if (channelNumber != null &&
         channelNumber.startsWith(RegExp(r'01|02|03'))) {
@@ -268,19 +268,6 @@ AtCsimResult _parseGetFileDataResult(String getFileDataResult) {
   return atCsimResult;
 }
 
-bool _parseQueryFileResult(String queryFileResult) {
-  final atCsimResult = _parseAtCsimResult(queryFileResult);
-  if (atCsimResult.result == null ||
-      atCsimResult.result!.isEmpty ||
-      atCsimResult.success == false) {
-    return false;
-  }
-  if (atCsimResult.result!.startsWith('61')) {
-    return true;
-  }
-  return false;
-}
-
 bool _parseGenerateChallengeResult(String generateChallengeResult) {
   final atCsimResult = _parseAtCsimResult(generateChallengeResult);
   if (atCsimResult.result == null ||
@@ -313,7 +300,7 @@ bool _parseSelectApplicationResult(String selectApplicationResult) {
 
 String _openChannel(Serial serialPort) {
   print('Opening a non-default logical channel');
-  serialPort.writeString('AT+CSIM=10, \"0070000000\"\r\n');
+  serialPort.writeString('AT+CSIM=10, "0070000000"\r\n');
   var event = serialPort.read(256, 1000);
   final result = event.toString();
   print('openChannelResult: $result');
@@ -324,7 +311,7 @@ void _closeSession(
     Serial port, String channelNumber, String tag, String sessionNumber) {
   print('closing session');
   final sessionCloseCommand =
-      'AT+CSIM=10, \"8${channelNumber}${tag}01${sessionNumber}00\"\r\n';
+      'AT+CSIM=10, "8$channelNumber${tag}01${sessionNumber}00"\r\n';
   print('close session command: $sessionCloseCommand');
   port.writeString(sessionCloseCommand);
   final result = port.read(256, 1000);
@@ -333,7 +320,7 @@ void _closeSession(
 
 void _closeChannel(Serial port, String channelNumber) {
   print('closing channel : $channelNumber');
-  final channelCloseCommand = 'AT+CSIM=10, \"007080${channelNumber}00\"\r\n';
+  final channelCloseCommand = 'AT+CSIM=10, "007080${channelNumber}00"\r\n';
   print('channelCloseCommand: $channelCloseCommand');
   port.writeString(channelCloseCommand);
   final result = port.read(256, 1000);
@@ -373,7 +360,7 @@ AtCsimResult _parseAtCsimResult(String result) {
   }
   int startIndex = result.indexOf(AtCsimResult.pattern);
   int bytesStartIndex = startIndex + AtCsimResult.pattern.length;
-  int bytesEndindex = startIndex + result.substring(startIndex).indexOf(',\"');
+  int bytesEndindex = startIndex + result.substring(startIndex).indexOf(',"');
   String bytesToRead = result.substring(bytesStartIndex, bytesEndindex);
   atCsimResult.bytesToRead = int.parse(bytesToRead);
   atCsimResult.result = result.substring(

--- a/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
+++ b/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dart_periphery/dart_periphery.dart';
 
+// Sample code for checking signing and verify commands on the sim card for a precomputed hash
 void main() {
   setCustomLibrary('/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so');
   print('Connecting to serial port');

--- a/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
+++ b/packages/at_chops/example/zariot/compute_verify_signature_sim.dart
@@ -1,0 +1,402 @@
+import 'dart:io';
+
+import 'package:dart_periphery/dart_periphery.dart';
+
+void main() {
+  setCustomLibrary('/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so');
+  print('Connecting to serial port');
+  var serialPort = Serial('/dev/ttyS0', Baudrate.b115200);
+  const String applicationId = 'A0000005590010';
+  var privateKeyId = '303036';
+  var publicKeyId = '303037';
+  // hard code hash of 'hello world' string for testing.
+  const String dataHash =
+      'B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9';
+  String? channelNumber;
+  try {
+    print('Serial interface info: ${serialPort.getSerialInfo()}');
+    // final openChannelResult = '+CSIM: 6,\"019000\"\nabcd';
+    // Step 1. Open a logical channel. This should return a logical port  number [01|02|03] followed by [9000]. 9000 is success code.
+    final openChannelResult = _getChannelNumber(_openChannel(serialPort));
+    channelNumber = openChannelResult.channelNumber;
+    print('channelNumber:$channelNumber');
+    if (openChannelResult.success) {
+      print('continue');
+    } else {
+      print('open channel failed');
+      exit(0);
+    }
+    // Step 2. Select IOTsafe by application id
+    serialPort.writeString(
+        "AT+CSIM=24, \"${channelNumber}A4040007${applicationId}\"\r\n");
+    var selectApplicationResult = serialPort.read(256, 1000);
+    print('selectApplicationResult :$selectApplicationResult');
+    bool isValidApplication =
+        _parseSelectApplicationResult(selectApplicationResult.toString());
+    print('isValidApplication $isValidApplication');
+
+    // Step 3. Generate random challenge to check whether application id is selected correctly
+    serialPort.writeString(
+        "AT+CSIM=10,\"8${channelNumber!.substring(1)}84000000\"\r\n");
+    final generateChallengeResult = serialPort.read(600, 1000);
+    print('generateChallengeResult: ${generateChallengeResult.toString()}');
+    bool isChallengeSuccess =
+        _parseGenerateChallengeResult(generateChallengeResult.toString());
+    print('generate challenge result: $isChallengeSuccess');
+
+    // Step 4. Generate key pair.
+    // This step will overcome any manual errors in loading key pair on the sim.
+    // Also ensures security since new keypair will be used.
+    // This operation may modify key ID.
+    serialPort.writeString(
+        "AT+CSIM=20,\"8${channelNumber.substring(1)}B90000058403$privateKeyId\"\r\n");
+    var generateKeyPairResult = '';
+    // Generate key pair commands takes a while to execute. Read until OK is received.
+    while (true) {
+      final readEvent = serialPort.read(512, 1000);
+      generateKeyPairResult += readEvent.toString();
+      if (!readEvent.toString().contains('OK')) {
+        print('Got result: $generateKeyPairResult');
+        sleep(Duration(seconds: 2));
+        continue;
+      }
+      print('generateKeyPairResult_1 $generateKeyPairResult');
+      break;
+    }
+    print('generateKeyPairResult ${generateKeyPairResult.toString()}');
+    final isGenerateKeyPairSuccess =
+        _parseGenerateKeyPairResult(generateKeyPairResult.toString());
+    print('isGenerateKeyPairSuccess $isGenerateKeyPairSuccess');
+
+    // Step 6.1 Parse generate key pair result and check if key id is modified.
+    serialPort.writeString(
+        "AT+CSIM=10,\"8${channelNumber.substring(1)}C0000051\"\r\n");
+    final getKeyPairDataResult = serialPort.read(256, 1000);
+    print('getFileDataResult $getKeyPairDataResult');
+    final getKeyPairResult =
+        _parseGetFileDataResult(getKeyPairDataResult.toString());
+    print('getKeyPairResult ${getKeyPairResult.result}');
+    privateKeyId = getKeyPairResult.result!.substring(4, 10);
+    publicKeyId = getKeyPairResult.result!.substring(14, 20);
+    print('generated privateKeyId: $privateKeyId');
+    print('generated publicKeyId: $publicKeyId');
+
+    // Step 5. Compute signature init
+    // 2A - tag for compute signature init
+    // 0F - length of command
+    // 84 - private key tag
+    // A1 - tag for mode of operation
+    // 03 - value for mode of operation - external hash
+    // 91 - tag for hash algorithm.
+    // 01-  value for hash algorithm. sha256
+    // 92 - tag for signature algorithm
+    // 04 - value for signature algorithm. ecdsa
+    serialPort.writeString(
+        "AT+CSIM=40,\"8${channelNumber.substring(1)}2A00010F8403${privateKeyId}A1010391020001920104\"\r\n");
+    var computeSignatureInitResult = serialPort.read(256, 1000);
+    print('computeSignatureInitResult :$computeSignatureInitResult');
+    bool isComputeSignatureInitSuccess =
+        _parseComputeSignatureInitResult(computeSignatureInitResult.toString());
+    print('generate challenge result: $isComputeSignatureInitSuccess');
+
+    // Step 6. Compute signature update
+    // 2B Tag for compute signature update
+    // 80 - last incoming data
+    // 01 - session number
+    // 22 - length of command
+    // 9E - tag for hash
+    // 20 -length of hash
+    serialPort.writeString(
+        "AT+CSIM=78,\"8${channelNumber.substring(1)}2B8001229E20$dataHash\"\r\n");
+    var computeSignatureUpdateResult = '';
+    // command takes a while to execute. Read until OK is received.
+    while (true) {
+      final readEvent = serialPort.read(512, 1000);
+      computeSignatureUpdateResult += readEvent.toString();
+      if (!readEvent.toString().contains('OK')) {
+        print('Got result: $computeSignatureUpdateResult');
+        sleep(Duration(seconds: 2));
+        continue;
+      }
+      // print('computeSignatureUpdateResult $computeSignatureUpdateResult');
+      break;
+    }
+    print(
+        'computeSignatureUpdateResult ${computeSignatureUpdateResult.toString()}');
+    bool isComputeSignatureSuccess = _parseComputeSignatureUpdateResult(
+        computeSignatureUpdateResult.toString());
+    print('isComputeSignatureSuccess :$isComputeSignatureSuccess');
+
+    // Step 7. Retrieve the computed signature
+    serialPort.writeString(
+        "AT+CSIM=10,\"8${channelNumber.substring(1)}C0000043\"\r\n");
+    var getSignatureResult = serialPort.read(256, 1000);
+    print('getSignatureResult $getSignatureResult');
+    final signatureData =
+        _parseGetFileDataResult(getSignatureResult.toString());
+    print('signature: ${signatureData.result}');
+    var signatureStr = '';
+    if (signatureData.result != null &&
+        signatureData.result!.startsWith('330040')) {
+      // remove start tag, length and success code at the end.
+      signatureStr =
+          signatureData.result!.substring(6, signatureData.result!.length - 4);
+    }
+    print('signatureStr: $signatureStr');
+
+    // Step 8. Verify signature init
+    // 2C - tag for signature init
+    // 02 - session number. Use a different session number for verify
+    // 85 - tag of public key id
+    // A1 - tag for mode of operation
+    // 03 - value for mode of operation - external hash
+    // 91 - tag for hash algorithm.
+    // 01-  value for hash algorithm. sha256
+    // 92 - tag for signature algorithm
+    // 04 - value for signature algorithm. ecdsa
+    serialPort.writeString(
+        "AT+CSIM=40,\"8${channelNumber.substring(1)}2C00020F8503${publicKeyId}A1010391020001920104\"\r\n");
+    var verifySignatureInitResult = serialPort.read(256, 1000);
+    print('verifySignatureInitResult $verifySignatureInitResult');
+    bool isVerifyInitSuccess =
+        _parseVerifyResult(verifySignatureInitResult.toString());
+    print('isVerifyInitSuccess ${isVerifyInitSuccess}');
+
+    // Step 9. Verify signature update
+    // 2D - tag for signature update
+    // 02 - session number.
+    // 9E - tag for passing hash value
+    // 20 - length of hash
+    // 33 - tag for signature
+    // 0040 - length of signature
+    serialPort.writeString(
+        "AT+CSIM=212,\"8${channelNumber.substring(1)}2D8002659E20${dataHash}330040${signatureStr}\"\r\n");
+    var verifySignatureResult = serialPort.read(256, 1000);
+    print('verifySignatureResult $verifySignatureResult');
+    var verifyResult = '';
+    while (true) {
+      final readEvent = serialPort.read(256, 1000);
+      verifyResult += readEvent.toString();
+      if (!readEvent.toString().contains('OK')) {
+        print('Got result: $verifyResult');
+        sleep(Duration(seconds: 2));
+        continue;
+      }
+      // print('computeSignatureUpdateResult $computeSignatureUpdateResult');
+      break;
+    }
+    print('verifyResult: $verifyResult');
+    bool isVerifyUpdateSuccess = _parseVerifyResult(verifyResult);
+    print('isVerifyUpdateSuccess ${isVerifyUpdateSuccess}');
+  } finally {
+    if (channelNumber != null &&
+        channelNumber.startsWith(RegExp(r'01|02|03'))) {
+      print('closing compute signature session');
+      _closeSession(serialPort, channelNumber.substring(1), '2A', '01');
+      print('closing verify session');
+      _closeSession(serialPort, channelNumber.substring(1), '2C', '02');
+      print('closing channel $channelNumber');
+      _closeChannel(serialPort, channelNumber);
+    }
+    serialPort.setVMIN(0);
+    serialPort.dispose();
+  }
+}
+
+bool _parseComputeSignatureUpdateResult(String result) {
+  final atCsimResult = _parseAtCsimResult(result);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    print('unexpected response from compute signature update: $atCsimResult');
+    return false;
+  }
+  if (atCsimResult.result == '6143') {
+    return true;
+  }
+  return false;
+}
+
+bool _parseVerifyResult(String result) {
+  final atCsimResult = _parseAtCsimResult(result);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    print('unexpected response from verify signature : $atCsimResult');
+    return false;
+  }
+  if (atCsimResult.result == '9000') {
+    return true;
+  } else {
+    print('failure code in verify signature: ${atCsimResult.result}');
+  }
+  return false;
+}
+
+bool _parseComputeSignatureInitResult(String result) {
+  final atCsimResult = _parseAtCsimResult(result);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    print('unexpected response from compute signature init: $atCsimResult');
+    return false;
+  }
+  if (atCsimResult.result == '9000') {
+    return true;
+  } else {
+    print('failure code in compute signature init ${atCsimResult.result}');
+  }
+  return false;
+}
+
+bool _parseGenerateKeyPairResult(String generateKeyPairResult) {
+  final atCsimResult = _parseAtCsimResult(generateKeyPairResult);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    return false;
+  }
+  if (atCsimResult.result == '6151') {
+    return true;
+  }
+  return false;
+}
+
+AtCsimResult _parseGetFileDataResult(String getFileDataResult) {
+  final atCsimResult = _parseAtCsimResult(getFileDataResult);
+  return atCsimResult;
+}
+
+bool _parseQueryFileResult(String queryFileResult) {
+  final atCsimResult = _parseAtCsimResult(queryFileResult);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    return false;
+  }
+  if (atCsimResult.result!.startsWith('61')) {
+    return true;
+  }
+  return false;
+}
+
+bool _parseGenerateChallengeResult(String generateChallengeResult) {
+  final atCsimResult = _parseAtCsimResult(generateChallengeResult);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    return false;
+  }
+  if (atCsimResult.result!.length == atCsimResult.bytesToRead) {
+    return true;
+  }
+  return false;
+}
+
+bool _parseSelectApplicationResult(String selectApplicationResult) {
+  final atCsimResult = _parseAtCsimResult(selectApplicationResult);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    print(
+        'unexpected response from select application: $selectApplicationResult');
+    return false;
+  }
+  if (atCsimResult.result == '9000') {
+    return true;
+  } else {
+    print('failure code in select application ${atCsimResult.result}');
+  }
+  return false;
+}
+
+String _openChannel(Serial serialPort) {
+  print('Opening a non-default logical channel');
+  serialPort.writeString('AT+CSIM=10, \"0070000000\"\r\n');
+  var event = serialPort.read(256, 1000);
+  final result = event.toString();
+  print('openChannelResult: $result');
+  return result;
+}
+
+void _closeSession(
+    Serial port, String channelNumber, String tag, String sessionNumber) {
+  print('closing session');
+  final sessionCloseCommand =
+      'AT+CSIM=10, \"8${channelNumber}${tag}01${sessionNumber}00\"\r\n';
+  print('close session command: $sessionCloseCommand');
+  port.writeString(sessionCloseCommand);
+  final result = port.read(256, 1000);
+  print('close session result: ${result.toString()}');
+}
+
+void _closeChannel(Serial port, String channelNumber) {
+  print('closing channel : $channelNumber');
+  final channelCloseCommand = 'AT+CSIM=10, \"007080${channelNumber}00\"\r\n';
+  print('channelCloseCommand: $channelCloseCommand');
+  port.writeString(channelCloseCommand);
+  final result = port.read(256, 1000);
+  print('close channel result: ${result.toString()}');
+}
+
+OpenChannelResult _getChannelNumber(String openChannelResult) {
+  final atCsimResult = _parseAtCsimResult(openChannelResult);
+  if (atCsimResult.result == null ||
+      atCsimResult.result!.isEmpty ||
+      atCsimResult.success == false) {
+    print('unexpected response from open channel: $openChannelResult');
+    return OpenChannelResult(false, null);
+  }
+  if (atCsimResult.result!.startsWith(RegExp(r'01|02|03'))) {
+    if (atCsimResult.result!.substring(2, 6) == '9000') {
+      final channelNumber = atCsimResult.result!.substring(0, 2);
+      print('open channel successful');
+      return OpenChannelResult(true, channelNumber);
+    } else {
+      print(
+          'open channel failed with non-success code: ${atCsimResult.result!.substring(2, 6)}');
+    }
+  } else {
+    print(
+        'open channel failed.Returned channel number : ${atCsimResult.result!.substring(0, 2)}');
+    return OpenChannelResult(false, atCsimResult.result!.substring(0, 2));
+  }
+  return OpenChannelResult(false, null);
+}
+
+AtCsimResult _parseAtCsimResult(String result) {
+  final atCsimResult = AtCsimResult();
+  if (result.isEmpty || !result.contains(AtCsimResult.pattern)) {
+    print('unexpected response : $result');
+    return atCsimResult;
+  }
+  int startIndex = result.indexOf(AtCsimResult.pattern);
+  int bytesStartIndex = startIndex + AtCsimResult.pattern.length;
+  int bytesEndindex = startIndex + result.substring(startIndex).indexOf(',\"');
+  String bytesToRead = result.substring(bytesStartIndex, bytesEndindex);
+  atCsimResult.bytesToRead = int.parse(bytesToRead);
+  atCsimResult.result = result.substring(
+      bytesEndindex + 2, bytesEndindex + 2 + atCsimResult.bytesToRead);
+  print('atCsimResult.result ${atCsimResult.result}');
+  atCsimResult.success = true;
+  return atCsimResult;
+}
+
+class OpenChannelResult {
+  bool success;
+  String? channelNumber;
+
+  OpenChannelResult(this.success, this.channelNumber);
+}
+
+class AtCsimResult {
+  String? result;
+  late int bytesToRead;
+  bool success = false;
+  static const String pattern = '+CSIM: ';
+
+  @override
+  String toString() {
+    return 'AtCsimResult{result: $result, bytesToRead: $bytesToRead, success: $success}';
+  }
+}

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -1,0 +1,404 @@
+import 'dart:io';
+import 'package:dart_periphery/dart_periphery.dart';
+
+import 'package:at_utils/at_logger.dart';
+
+class ExternalSigner {
+  late Serial _serialPort;
+  late String _customLibraryLocation;
+  late String _applicationId;
+  late String _privateKeyId;
+  late AtSignLogger _logger;
+  ExternalSigner();
+
+  void init(
+      String privateKeyId, String serialPort, String libPeripheryLocation) {
+    _customLibraryLocation = libPeripheryLocation;
+    setCustomLibrary(_customLibraryLocation);
+    _serialPort = Serial(serialPort, Baudrate.b115200);
+    _applicationId = 'A0000005590010';
+    _privateKeyId = privateKeyId;
+    _logger = AtSignLogger('ExternalSigner');
+  }
+
+  String getPublicKey(String publicKeyId) {
+    var channelNumber;
+    try {
+      // Step 1. Open a logical channel. This should return a logical port  number [01|02|03] followed by [9000]. 9000 is success code.
+      channelNumber = _openLogicalChannel();
+      // Step 2. Select IOTsafe by application id
+      _selectIOTSafeApplication(channelNumber!);
+      return _readPublicKey(_serialPort, channelNumber, publicKeyId);
+    } on Exception catch (e, trace) {
+      _logger.severe('exception during signing ${e.toString()}');
+      _logger.severe(trace);
+      throw e;
+    } finally {
+      if (channelNumber != null &&
+          channelNumber.startsWith(RegExp(r'01|02|03'))) {
+        _logger.finest('closing channel $channelNumber');
+        _closeChannel(_serialPort, channelNumber);
+      }
+      _serialPort.setVMIN(0);
+      _serialPort.dispose();
+    }
+  }
+
+  String? sign(String dataHash) {
+    var channelNumber;
+    try {
+      // Step 1. Open a logical channel. This should return a logical port  number [01|02|03] followed by [9000]. 9000 is success code.
+      channelNumber = _openLogicalChannel();
+      _logger.info('opened logical channel #:$channelNumber');
+      // Step 2. Select IOTsafe by application id
+      _selectIOTSafeApplication(channelNumber!);
+
+      _logger.info('selected IOTSafe application');
+
+      // Step 3. Compute signature init
+      _computeSignatureInit(channelNumber);
+
+      // Step 4. Compute signature update
+      _computeSignatureUpdate(channelNumber, dataHash.toUpperCase());
+      _logger.info('signature computed. Retrieving the signature');
+      // Step 5. Retrieve computed signature
+      var signature = _retrieveSignature(channelNumber);
+      return signature.toLowerCase();
+    } on Exception catch (e, trace) {
+      _logger.severe('exception during signing ${e.toString()}');
+      _logger.severe(trace);
+    } finally {
+      if (channelNumber != null &&
+          channelNumber.startsWith(RegExp(r'01|02|03'))) {
+        _logger.finest('closing channel $channelNumber');
+        _closeChannel(_serialPort, channelNumber);
+      }
+      _serialPort.setVMIN(0);
+      _serialPort.dispose();
+    }
+    return null;
+  }
+
+  AsymmetricKeyPair? generateKeyPair(String privateKeyId) {
+    var channelNumber;
+    try {
+      // Step 1. Open a logical channel. This should return a logical port  number [01|02|03] followed by [9000]. 9000 is success code.
+      channelNumber = _openLogicalChannel();
+      _logger.info('opened logical channel #:$channelNumber');
+      // Step 2. Select IOTsafe by application id
+      _selectIOTSafeApplication(channelNumber!);
+
+      _logger.info('selected IOTSafe application');
+
+      // Step 3. Generate key pair
+      bool isGenerateKeyPairSuccess =
+          _generateKeyPair(privateKeyId, channelNumber);
+
+      _logger.finest('isGenerateKeyPairSuccess $isGenerateKeyPairSuccess');
+      if (!isGenerateKeyPairSuccess) {
+        throw Exception('Generate key pair failure');
+      }
+
+      _serialPort.writeString(
+          "AT+CSIM=10,\"8${channelNumber.substring(1)}C0000051\"\r\n");
+      var generateKeyPairResult = _serialPort.read(256, 1000);
+      var csimResult = _parseAtCsimResult(generateKeyPairResult.toString());
+      String? newPrivateKeyId = csimResult.result!.substring(4, 10);
+      String? newPublicKeyId = csimResult.result!.substring(14, 20);
+
+      // These IDs may or  may not change. As per spec - "Note: This operation(generate key pair) may modify the key ID."
+      _logger.finest('privateKeyId :$newPrivateKeyId');
+      _logger.finest('publicKeyId :$newPublicKeyId');
+      if (newPrivateKeyId == null || newPublicKeyId == null) {
+        throw Exception(
+            'privateKeyId or publicKeyId cannot be retrieved from generate keypair');
+      }
+      _privateKeyId = newPrivateKeyId;
+
+      return AsymmetricKeyPair(newPrivateKeyId, newPrivateKeyId);
+    } finally {
+      if (channelNumber != null &&
+          channelNumber.startsWith(RegExp(r'01|02|03'))) {
+        _logger.finest('closing channel $channelNumber');
+        _closeChannel(_serialPort, channelNumber);
+      }
+      _serialPort.setVMIN(0);
+      _serialPort.dispose();
+    }
+    return null;
+  }
+
+  String _readPublicKey(
+      Serial serialPort, String channelNumber, String publicKeyId) {
+    // INS - CD -read public key
+    // P1 - 00
+    // P2 - 00
+    // 05 - length of command
+    // 85 - public key id
+    // 03 - data length
+    _serialPort.writeString(
+        "AT+CSIM=20, \"8${channelNumber.substring(1)}CD0000058503${publicKeyId}\"\r\n");
+    var readPublicKeyResult = _serialPort.read(256, 1000);
+    _logger.finest('readPublicKeyResult :$readPublicKeyResult');
+    bool isReadPublicKeyResultSuccess =
+        _parseResult(readPublicKeyResult.toString(), ATCommand.readPublicKey);
+    _logger
+        .finest('isReadPublicKeyResultSuccess $isReadPublicKeyResultSuccess');
+    if (!isReadPublicKeyResultSuccess) {
+      throw Exception('Read public key failure');
+    }
+    _serialPort.writeString(
+        "AT+CSIM=10, \"8${channelNumber.substring(1)}C0000047\"\r\n");
+    var retrievePublicKeyResult = _serialPort.read(256, 1000);
+    var csimResult = _parseAtCsimResult(retrievePublicKeyResult.toString());
+    final publicKey = _parsePublicKeyResult(csimResult);
+    if (publicKey == null) {
+      throw Exception('cannot read public key');
+    }
+    _logger.finest('retrievePublicKeyResult :$publicKey');
+    return publicKey;
+  }
+
+  String? _parsePublicKeyResult(AtCsimResult csimResult) {
+    var commandResult = csimResult.result;
+    _logger.finest(commandResult);
+    if (commandResult != null && commandResult.startsWith('344549438641')) {
+      commandResult = commandResult.substring(12, commandResult.length - 4);
+      return commandResult;
+    }
+    return null;
+  }
+
+  String? _openLogicalChannel() {
+    final openChannelResult = _getChannelNumber(_openChannel(_serialPort));
+    var channelNumber = openChannelResult.channelNumber;
+    _logger.finest('channelNumber:$channelNumber');
+    if (openChannelResult.success) {
+      return channelNumber;
+    } else {
+      throw Exception('open channel failed');
+    }
+  }
+
+  String _openChannel(Serial serialPort) {
+    _logger.finest('Opening a non-default logical channel');
+    serialPort.writeString('AT+CSIM=10, \"0070000000\"\r\n');
+    var event = serialPort.read(256, 1000);
+    final result = event.toString();
+    _logger.finest('openChannelResult: $result');
+    return result;
+  }
+
+  void _selectIOTSafeApplication(String channelNumber) {
+    _serialPort.writeString(
+        "AT+CSIM=24, \"${channelNumber}A4040007${_applicationId}\"\r\n");
+    var selectApplicationResult = _serialPort.read(256, 1000);
+    _logger.finest('selectApplicationResult :$selectApplicationResult');
+    bool isValidApplication =
+        _parseResult(selectApplicationResult.toString(), ATCommand.selectApp);
+    _logger.finest('isValidApplication $isValidApplication');
+  }
+
+  bool _generateKeyPair(String privateKeyId, String channelNumber) {
+    _serialPort.writeString(
+        "AT+CSIM=20,\"8${channelNumber.substring(1)}B90000058403$privateKeyId\"\r\n");
+    var generateKeyPair = _serialPort.read(256, 1000);
+    _logger.finest('selectApplicationResult :$generateKeyPair');
+    bool generateKeyPairResult =
+        _parseResult(generateKeyPair.toString(), ATCommand.generateKeyPair);
+    return generateKeyPairResult;
+  }
+
+  void _computeSignatureInit(String channelNumber) {
+    // 2A - tag for compute signature init
+    // 0F - length of command
+    // 84 - private key tag
+    // A1 - tag for mode of operation
+    // 03 - value for mode of operation - external hash
+    // 91 - tag for hash algorithm.
+    // 01-  value for hash algorithm. sha256
+    // 92 - tag for signature algorithm
+    // 04 - value for signature algorithm. ecdsa
+    _serialPort.writeString(
+        "AT+CSIM=40,\"8${channelNumber.substring(1)}2A00010F8403${_privateKeyId}A1010391020001920104\"\r\n");
+    var computeSignatureInitResult = _serialPort.read(256, 1000);
+    _logger.info('computeSignatureInitResult :$computeSignatureInitResult');
+    bool isComputeSignatureInitSuccess = _parseResult(
+        computeSignatureInitResult.toString(), ATCommand.computeSignatureInit);
+    _logger.finest(
+        'isComputeSignatureInitSuccess: $isComputeSignatureInitSuccess');
+  }
+
+  void _computeSignatureUpdate(String channelNumber, String dataHash) {
+    // 2B Tag for compute signature update
+    // 80 - last incoming data_
+    // 01 - session number
+    // 22 - length of command
+    // 9E - tag for hash
+    // 20 -length of hash
+    _logger.finest('computing signature from external hash');
+    _serialPort.writeString(
+        "AT+CSIM=78,\"8${channelNumber.substring(1)}2B8001229E20$dataHash\"\r\n");
+    var computeSignatureUpdateResult = '';
+    // command takes a while to execute. Read until OK is received.
+    while (true) {
+      final readEvent = _serialPort.read(512, 1000);
+      computeSignatureUpdateResult += readEvent.toString();
+      if (!readEvent.toString().contains('OK')) {
+        _logger.finest('Got result: $computeSignatureUpdateResult');
+        sleep(Duration(seconds: 2));
+        continue;
+      }
+      break;
+    }
+    _logger.finest(
+        'computeSignatureUpdateResult ${computeSignatureUpdateResult.toString()}');
+    bool isComputeSignatureSuccess = _parseComputeSignatureUpdateResult(
+        computeSignatureUpdateResult.toString());
+    _logger.finest('isComputeSignatureSuccess :$isComputeSignatureSuccess');
+  }
+
+  String _retrieveSignature(String channelNumber) {
+    _serialPort.writeString(
+        "AT+CSIM=10,\"8${channelNumber.substring(1)}C0000043\"\r\n");
+    var getSignatureResult = _serialPort.read(256, 1000);
+    _logger.finest('getSignatureResult $getSignatureResult');
+    final signatureData = _parseAtCsimResult(getSignatureResult.toString());
+    _logger.info('signature: ${signatureData.result}');
+    var signatureStr = '';
+    if (signatureData.result != null &&
+        signatureData.result!.startsWith('330040')) {
+      // remove start tag, length and success code at the end.
+      signatureStr =
+          signatureData.result!.substring(6, signatureData.result!.length - 4);
+    }
+    return signatureStr.toLowerCase();
+  }
+
+  OpenChannelResult _getChannelNumber(String openChannelResult) {
+    final atCsimResult = _parseAtCsimResult(openChannelResult);
+    if (atCsimResult.result == null ||
+        atCsimResult.result!.isEmpty ||
+        atCsimResult.success == false) {
+      _logger
+          .finest('unexpected response from open channel: $openChannelResult');
+      return OpenChannelResult(false, null);
+    }
+    if (atCsimResult.result!.startsWith(RegExp(r'01|02|03'))) {
+      if (atCsimResult.result!.substring(2, 6) == '9000') {
+        final channelNumber = atCsimResult.result!.substring(0, 2);
+        _logger.finest('open channel successful');
+        return OpenChannelResult(true, channelNumber);
+      } else {
+        _logger.finest(
+            'open channel failed with non-success code: ${atCsimResult.result!.substring(2, 6)}');
+      }
+    } else {
+      _logger.finest(
+          'open channel failed.Returned channel number : ${atCsimResult.result!.substring(0, 2)}');
+      return OpenChannelResult(false, atCsimResult.result!.substring(0, 2));
+    }
+    return OpenChannelResult(false, null);
+  }
+
+  bool _parseResult(String result, ATCommand atCommand) {
+    final atCsimResult = _parseAtCsimResult(result);
+    if (atCsimResult.result == null ||
+        atCsimResult.result!.isEmpty ||
+        atCsimResult.success == false) {
+      _logger.finest(
+          'unexpected response from ${atCommand.toString()}: $atCsimResult');
+      return false;
+    }
+    if (atCommand == ATCommand.readPublicKey && atCsimResult.result == '6147') {
+      return true;
+    } else if (atCsimResult.result == '9000') {
+      return true;
+    } else if (atCommand == ATCommand.generateKeyPair &&
+        atCsimResult.result == '6151') {
+      return true;
+    } else {
+      _logger.finest(
+          'failure code in ${atCommand.toString()} ${atCsimResult.result}');
+    }
+    return false;
+  }
+
+  bool _parseComputeSignatureUpdateResult(String result) {
+    final atCsimResult = _parseAtCsimResult(result);
+    if (atCsimResult.result == null ||
+        atCsimResult.result!.isEmpty ||
+        atCsimResult.success == false) {
+      _logger.finest(
+          'unexpected response from compute signature update: $atCsimResult');
+      return false;
+    }
+    if (atCsimResult.result == '6143') {
+      return true;
+    }
+    return false;
+  }
+
+  AtCsimResult _parseAtCsimResult(String result) {
+    final atCsimResult = AtCsimResult();
+    if (result.isEmpty || !result.contains(AtCsimResult.pattern)) {
+      _logger.finest('unexpected response : $result');
+      return atCsimResult;
+    }
+    int startIndex = result.indexOf(AtCsimResult.pattern);
+    int bytesStartIndex = startIndex + AtCsimResult.pattern.length;
+    int bytesEndindex =
+        startIndex + result.substring(startIndex).indexOf(',\"');
+    String bytesToRead = result.substring(bytesStartIndex, bytesEndindex);
+    atCsimResult.bytesToRead = int.parse(bytesToRead);
+    atCsimResult.result = result.substring(
+        bytesEndindex + 2, bytesEndindex + 2 + atCsimResult.bytesToRead);
+    _logger.finest('atCsimResult.result ${atCsimResult.result}');
+    atCsimResult.success = true;
+    return atCsimResult;
+  }
+
+  void _closeChannel(Serial port, String channelNumber) {
+    _logger.finest('closing channel : $channelNumber');
+    final channelCloseCommand = 'AT+CSIM=10, \"007080${channelNumber}00\"\r\n';
+    _logger.finest('channelCloseCommand: $channelCloseCommand');
+    port.writeString(channelCloseCommand);
+    final result = port.read(256, 1000);
+    _logger.finest('close channel result: ${result.toString()}');
+  }
+}
+
+class OpenChannelResult {
+  bool success;
+  String? channelNumber;
+
+  OpenChannelResult(this.success, this.channelNumber);
+}
+
+class AtCsimResult {
+  String? result;
+  late int bytesToRead;
+  bool success = false;
+  static const String pattern = '+CSIM: ';
+
+  @override
+  String toString() {
+    return 'AtCsimResult{result: $result, bytesToRead: $bytesToRead, success: $success}';
+  }
+}
+
+enum ATCommand {
+  openChannel,
+  selectApp,
+  computeSignatureInit,
+  computeSignatureUpdate,
+  readPublicKey,
+  generateKeyPair
+}
+
+class AsymmetricKeyPair {
+  String privateKeyId;
+  String publicKeyId;
+
+  AsymmetricKeyPair(this.privateKeyId, this.publicKeyId);
+}

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -115,7 +115,7 @@ class ExternalSigner {
       }
       _privateKeyId = newPrivateKeyId;
 
-      return AsymmetricKeyPair(newPrivateKeyId, newPrivateKeyId);
+      return AsymmetricKeyPair(newPrivateKeyId, newPublicKeyId);
     } finally {
       if (channelNumber != null &&
           channelNumber.startsWith(RegExp(r'01|02|03'))) {

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -91,6 +91,7 @@ class ExternalSigner {
       _logger.info('selected IOTSafe application');
 
       // Step 3. Generate key pair
+      _logger.info('generating key pair - private key id: $privateKeyId');
       bool isGenerateKeyPairSuccess =
           _generateKeyPair(privateKeyId, channelNumber);
 
@@ -203,7 +204,7 @@ class ExternalSigner {
     _serialPort.writeString(
         "AT+CSIM=20,\"8${channelNumber.substring(1)}B90000058403$privateKeyId\"\r\n");
     var generateKeyPair = _serialPort.read(256, 1000);
-    _logger.finest('selectApplicationResult :$generateKeyPair');
+    _logger.finest('generateKeyPair result :${generateKeyPair.toString()}');
     bool generateKeyPairResult =
         _parseResult(generateKeyPair.toString(), ATCommand.generateKeyPair);
     return generateKeyPairResult;

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -203,11 +203,21 @@ class ExternalSigner {
   bool _generateKeyPair(String privateKeyId, String channelNumber) {
     _serialPort.writeString(
         "AT+CSIM=20,\"8${channelNumber.substring(1)}B90000058403$privateKeyId\"\r\n");
-    var generateKeyPair = _serialPort.read(256, 1000);
-    _logger.finest('generateKeyPair result :${generateKeyPair.toString()}');
-    bool generateKeyPairResult =
+    var generateKeyPairResult;
+    while(true) {
+      final readEvent = _serialPort.read(512, 1000);
+      generateKeyPairResult += readEvent.toString();
+      if(!readEvent.toString().contains('OK')) {
+        _logger.finest('Got result: $generateKeyPairResult');
+        sleep(Duration(seconds: 2));
+        continue;
+      }
+      break;
+    }
+    _logger.info('generateKeyPair result :${generateKeyPairResult.toString()}');
+    bool isGenerateKeyPairSuccess =
         _parseResult(generateKeyPair.toString(), ATCommand.generateKeyPair);
-    return generateKeyPairResult;
+    return isGenerateKeyPairSuccess;
   }
 
   void _computeSignatureInit(String channelNumber) {

--- a/packages/at_chops/example/zariot/onboard_secure_element.dart
+++ b/packages/at_chops/example/zariot/onboard_secure_element.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_chops/at_chops.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:at_commons/at_commons.dart';
+
+import 'at_chops_secure_element.dart';
+import 'external_signer.dart';
+
+/// Usage: dart main.dart <cram_secret>
+Future<void> main(List<String> args) async {
+  final atSign = '@jacstest001';
+  AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
+    ..hiveStoragePath = 'storage/hive'
+    ..namespace = 'wavi'
+    ..downloadPath = 'storage/files'
+    ..isLocalStoreRequired = true
+    ..commitLogPath = 'storage/commitLog'
+    ..rootDomain = 'root.atsign.wtf'
+    ..fetchOfflineNotifications = true
+    ..atKeysFilePath = 'storage/files/@jacstest001_key.atKeys'
+    ..useAtChops = true
+    ..signingAlgoType = SigningAlgoType.ecc_secp256r1
+    ..hashingAlgoType = HashingAlgoType.sha256
+    ..authMode = PkamAuthMode.sim
+    ..skipSync = true;
+  AtSignLogger.root_level = 'INFO';
+  var logger = AtSignLogger('OnboardSecureElement');
+  var parser = ArgParser();
+  parser.addOption('privateKeyId',
+      abbr: 'pr',
+      mandatory: true,
+      help: 'Private key id from sim card used to sign pkam challenge');
+  parser.addOption('serialPort',
+      abbr: 's',
+      mandatory: false,
+      defaultsTo: '/dev/ttyS0',
+      help: 'serial port on which sim card is mounted');
+  parser.addOption('libPeripheryLocation',
+      abbr: 'l',
+      mandatory: false,
+      defaultsTo: '/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so',
+      help: 'location of native library libperiphery_arm.so');
+  parser.addOption('cramSecret',
+      abbr: 'c',
+      mandatory: true,
+      help: 'cram of the atsign from registration flow');
+  dynamic results;
+  try {
+    results = parser.parse(args);
+    atOnboardingConfig.cramSecret = results['cramSecret'];
+  } catch (e) {
+    print(parser.usage);
+    print(e);
+    exit(1);
+  }
+  final externalSigner = ExternalSigner();
+  externalSigner.init(results['privateKeyId'], results['serialPort'],
+      results['libPeripheryLocation']);
+  var keyPair = externalSigner.generateKeyPair(results['privateKeyId']);
+  if (keyPair == null) {
+    logger.severe('Generate key pair returned null. Exiting');
+    exit(1);
+  }
+  atOnboardingConfig.publicKeyId = keyPair.publicKeyId;
+  AtOnboardingService onboardingService =
+      AtOnboardingServiceImpl(atSign, atOnboardingConfig);
+  // create empty keys in atchops. Encryption key pair will be set later on after generation
+  onboardingService.atChops =
+      AtChopsSecureElement(AtChopsKeys.create(null, null));
+
+  logger.info('calling onboard');
+  await onboardingService.onboard();
+  logger.info('onboard done');
+  logger.info('calling auth');
+  await onboardingService.authenticate();
+  logger.info('auth done');
+}

--- a/packages/at_chops/example/zariot/onboard_secure_element.dart
+++ b/packages/at_chops/example/zariot/onboard_secure_element.dart
@@ -30,7 +30,7 @@ Future<void> main(List<String> args) async {
   var logger = AtSignLogger('OnboardSecureElement');
   var parser = ArgParser();
   parser.addOption('privateKeyId',
-      abbr: 'pr',
+      abbr: 'p',
       mandatory: true,
       help: 'Private key id from sim card used to sign pkam challenge');
   parser.addOption('serialPort',

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -7,14 +7,19 @@ environment:
   sdk: '>=2.15.1 <3.0.0'
 
 dependencies:
+  args: ^2.4.0
   encrypt: ^5.0.1
   crypton: ^2.1.0
   crypto: ^3.0.2
   ecdsa: ^0.0.4
+  dart_periphery: ^0.9.3
   elliptic: ^0.3.8
-  at_commons: ^3.0.39
   pointycastle: ^3.6.2
+  at_commons: ^3.0.39
+  at_onboarding_cli: ^1.2.3
   at_utils: ^3.0.11
+
+
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
**- What I did**
- Moved IoT safe code from at_talk repo to at_chops
**- How I did it**
- packages/at_chops/example/zariot/compute_verify_signature_sim.dart
 This example will generate a new key pair, compute signature using generated ECC private keyfor a pre defined hash (hello world) and verify the signature using ECC public key. 
 - packages/at_chops/example/zariot/external_signer.dart
 All AT commands to interact with IoT Safe interface are implemented in external_signer
-  packages/at_chops/example/zariot/at_chops_secure_element.dart
implementation of at_chops which delegates signing functionality to external_signer
- packages/at_chops/example/zariot/onboard_secure_element.dart
sample code to test onboarding for an atsign whose pkam private key is in the sim card.
**- How to verify it**
- Run compute_verify_signature_sim.dart in a pi device which has sim mounted. Verify result should be success
- Run onboard_secure_element.dart in a pi device 
pre conditions:  atsign is provisioned in staging/prod. Atsign is activated through registrar API and cram secret should be available.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->