### PR TITLE
feat: compute activation key

### DIFF
--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -39,7 +39,6 @@ class ExternalSigner {
         _logger.finest('closing channel $channelNumber');
         _closeChannel(_serialPort, channelNumber);
       }
-
     }
   }
 
@@ -151,7 +150,8 @@ class ExternalSigner {
     return null;
   }
 
-  String _computePRF(String channelNumber, String keyId, String simSecret, String labelId) {
+  String _computePRF(
+      String channelNumber, String keyId, String simSecret, String labelId) {
     // 48 - tag for compute PRF
     // 10 - activation key length
     _serialPort.writeString(
@@ -159,10 +159,11 @@ class ExternalSigner {
     var computePRFResult = _serialPort.read(256, 1000);
     _logger.finest('computePRFResult :$computePRFResult');
     bool isComputePRFSuccess =
-    _parseResult(computePRFResult.toString(), ATCommand.computePRF);
+        _parseResult(computePRFResult.toString(), ATCommand.computePRF);
     _logger.finest('isComputePRFSuccess $isComputePRFSuccess');
-    _serialPort.writeString("AT+CSIM=10, \"8${channelNumber.substring(1)}C0000010\"\r\n");
-    var  prfResult = _serialPort.read(256, 1000);
+    _serialPort.writeString(
+        "AT+CSIM=10, \"8${channelNumber.substring(1)}C0000010\"\r\n");
+    var prfResult = _serialPort.read(256, 1000);
     _logger.finest('prfResult :$prfResult');
     return prfResult.toString();
   }
@@ -241,11 +242,11 @@ class ExternalSigner {
   bool _generateKeyPair(String privateKeyId, String channelNumber) {
     _serialPort.writeString(
         "AT+CSIM=20,\"8${channelNumber.substring(1)}B90000058403$privateKeyId\"\r\n");
-    var generateKeyPairResult='';
-    while(true) {
+    var generateKeyPairResult = '';
+    while (true) {
       final readEvent = _serialPort.read(512, 1000);
       generateKeyPairResult += readEvent.toString();
-      if(!readEvent.toString().contains('OK')) {
+      if (!readEvent.toString().contains('OK')) {
         _logger.finest('Got result: $generateKeyPairResult');
         sleep(Duration(seconds: 2));
         continue;
@@ -253,8 +254,8 @@ class ExternalSigner {
       break;
     }
     _logger.info('generateKeyPair result :${generateKeyPairResult.toString()}');
-    bool isGenerateKeyPairSuccess =
-        _parseResult(generateKeyPairResult.toString(), ATCommand.generateKeyPair);
+    bool isGenerateKeyPairSuccess = _parseResult(
+        generateKeyPairResult.toString(), ATCommand.generateKeyPair);
     return isGenerateKeyPairSuccess;
   }
 
@@ -366,10 +367,10 @@ class ExternalSigner {
     } else if (atCommand == ATCommand.generateKeyPair &&
         atCsimResult.result == '6151') {
       return true;
-    } else if (atCommand == ATCommand.computePRF && atCsimResult.result == '6110'){
+    } else if (atCommand == ATCommand.computePRF &&
+        atCsimResult.result == '6110') {
       return true;
-    }
-      else {
+    } else {
       _logger.finest(
           'failure code in ${atCommand.toString()} ${atCsimResult.result}');
     }
@@ -399,8 +400,7 @@ class ExternalSigner {
     }
     int startIndex = result.indexOf(AtCsimResult.pattern);
     int bytesStartIndex = startIndex + AtCsimResult.pattern.length;
-    int bytesEndindex =
-        startIndex + result.substring(startIndex).indexOf(',"');
+    int bytesEndindex = startIndex + result.substring(startIndex).indexOf(',"');
     String bytesToRead = result.substring(bytesStartIndex, bytesEndindex);
     atCsimResult.bytesToRead = int.parse(bytesToRead);
     atCsimResult.result = result.substring(

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -159,9 +159,9 @@ class ExternalSigner {
     var computePRFResult = _serialPort.read(256, 1000);
     _logger.finest('computePRFResult :$computePRFResult');
     bool isComputePRFSuccess =
-    _parseResult(computePRFResult.toString(), ATCommand.selectApp);
+    _parseResult(computePRFResult.toString(), ATCommand.computePRF);
     _logger.finest('isComputePRFSuccess $isComputePRFSuccess');
-    _serialPort.writeString("AT+CSIM=10, \"8${channelNumber.substring(1)}C0000010\"");
+    _serialPort.writeString("AT+CSIM=10, \"8${channelNumber.substring(1)}C0000010\"\r\n");
     var  prfResult = _serialPort.read(256, 1000);
     _logger.finest('prfResult :$prfResult');
     return prfResult.toString();
@@ -366,7 +366,7 @@ class ExternalSigner {
     } else if (atCommand == ATCommand.generateKeyPair &&
         atCsimResult.result == '6151') {
       return true;
-    } else if (atCommand == ATCommand.computePRF && atCsimResult.result == '6150'){
+    } else if (atCommand == ATCommand.computePRF && atCsimResult.result == '6110'){
       return true;
     }
       else {

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -127,6 +127,46 @@ class ExternalSigner {
     return null;
   }
 
+  String? computeActivationKey(String keyId, String simSecret, String labelId) {
+    String? channelNumber;
+    try {
+      // Step 1. Open a logical channel. This should return a logical port  number [01|02|03] followed by [9000]. 9000 is success code.
+      channelNumber = _openLogicalChannel();
+      _logger.info('opened logical channel #:$channelNumber');
+      // Step 2. Select IOTsafe by application id
+      _selectIOTSafeApplication(channelNumber!);
+
+      _logger.info('selected IOTSafe application');
+      _computePRF(channelNumber, keyId, simSecret, labelId);
+    } on Exception catch (e, trace) {
+      _logger.severe('exception during generate key pair ${e.toString()}');
+      _logger.severe(trace);
+    } finally {
+      if (channelNumber != null &&
+          channelNumber.startsWith(RegExp(r'01|02|03'))) {
+        _logger.finest('closing channel $channelNumber');
+        _closeChannel(_serialPort, channelNumber);
+      }
+    }
+    return null;
+  }
+
+  String _computePRF(String channelNumber, String keyId, String simSecret, String labelId) {
+    // 48 - tag for compute PRF
+    // 10 - activation key length
+    _serialPort.writeString(
+        "AT+CSIM=110, \"8${channelNumber.substring(1)}48000032$keyId$simSecret$labelId}D30110\"\r\n");
+    var computePRFResult = _serialPort.read(256, 1000);
+    _logger.finest('computePRFResult :$computePRFResult');
+    bool isComputePRFSuccess =
+    _parseResult(computePRFResult.toString(), ATCommand.selectApp);
+    _logger.finest('isComputePRFSuccess $isComputePRFSuccess');
+    _serialPort.writeString("AT+CSIM=10, \"8${channelNumber.substring(1)}C0000010\"");
+    var  prfResult = _serialPort.read(256, 1000);
+    _logger.finest('prfResult :$prfResult');
+    return prfResult.toString();
+  }
+
   String _readPublicKey(
       Serial serialPort, String channelNumber, String publicKeyId) {
     // INS - CD -read public key
@@ -326,7 +366,10 @@ class ExternalSigner {
     } else if (atCommand == ATCommand.generateKeyPair &&
         atCsimResult.result == '6151') {
       return true;
-    } else {
+    } else if (atCommand == ATCommand.computePRF && atCsimResult.result == '6150'){
+      return true;
+    }
+      else {
       _logger.finest(
           'failure code in ${atCommand.toString()} ${atCsimResult.result}');
     }
@@ -407,7 +450,8 @@ enum ATCommand {
   computeSignatureInit,
   computeSignatureUpdate,
   readPublicKey,
-  generateKeyPair
+  generateKeyPair,
+  computePRF
 }
 
 class AsymmetricKeyPair {

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -155,7 +155,7 @@ class ExternalSigner {
     // 48 - tag for compute PRF
     // 10 - activation key length
     _serialPort.writeString(
-        "AT+CSIM=110, \"8${channelNumber.substring(1)}48000032$keyId$simSecret$labelId}D30110\"\r\n");
+        "AT+CSIM=110, \"8${channelNumber.substring(1)}48000032$keyId$simSecret${labelId}D30110\"\r\n");
     var computePRFResult = _serialPort.read(256, 1000);
     _logger.finest('computePRFResult :$computePRFResult');
     bool isComputePRFSuccess =

--- a/packages/at_chops/example/zariot/external_signer.dart
+++ b/packages/at_chops/example/zariot/external_signer.dart
@@ -230,7 +230,7 @@ class ExternalSigner {
 
   void _selectIOTSafeApplication(String channelNumber) {
     _serialPort.writeString(
-        "AT+CSIM=24, \"${channelNumber}A4040007$_applicationId}\"\r\n");
+        "AT+CSIM=24, \"${channelNumber}A4040007$_applicationId\"\r\n");
     var selectApplicationResult = _serialPort.read(256, 1000);
     _logger.finest('selectApplicationResult :$selectApplicationResult');
     bool isValidApplication =

--- a/packages/at_chops/example/zariot/test/compute_activation_key.dart
+++ b/packages/at_chops/example/zariot/test/compute_activation_key.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+
+import '../external_signer.dart';
+
+
+Future<void> main(List<String> args) async {
+  var parser = ArgParser();
+  parser.addOption('privateKeyId',
+      abbr: 'p',
+      mandatory: true,
+      help: 'Private key id from sim card used to sign pkam challenge');
+  parser.addOption('serialPort',
+      abbr: 's',
+      mandatory: false,
+      defaultsTo: '/dev/ttyS0',
+      help: 'serial port on which sim card is mounted');
+  parser.addOption('libPeripheryLocation',
+      abbr: 'l',
+      mandatory: false,
+      defaultsTo: '/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so',
+      help: 'location of native library libperiphery_arm.so');
+  parser.addOption('keyId', abbr:'k', mandatory: true, help: 'key id from sim used to compute PRF');
+  parser.addOption('simSecret', abbr:'s', mandatory: true, help: 'secret from sim');
+  parser.addOption('labelId', abbr:'l', mandatory: true, help: 'label id from sim');
+  dynamic results;
+  try {
+    results = parser.parse(args);
+  } catch (e) {
+    print(parser.usage);
+    print(e);
+    exit(1);
+  }
+  final externalSigner = ExternalSigner();
+  externalSigner.init(results['privateKeyId'], results['serialPort'],
+      results['libPeripheryLocation']);
+  externalSigner.computeActivationKey(results['keyId'], results['simSecret'], results['labelId']);
+}
+

--- a/packages/at_chops/example/zariot/test/compute_activation_key.dart
+++ b/packages/at_chops/example/zariot/test/compute_activation_key.dart
@@ -4,8 +4,11 @@ import 'package:args/args.dart';
 
 import '../external_signer.dart';
 
+import 'package:at_utils/at_logger.dart';
+
 
 Future<void> main(List<String> args) async {
+  AtSignLogger.root_level = 'FINEST';
   var parser = ArgParser();
   parser.addOption('privateKeyId',
       abbr: 'p',
@@ -22,8 +25,8 @@ Future<void> main(List<String> args) async {
       defaultsTo: '/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so',
       help: 'location of native library libperiphery_arm.so');
   parser.addOption('keyId', abbr:'k', mandatory: true, help: 'key id from sim used to compute PRF');
-  parser.addOption('simSecret', abbr:'s', mandatory: true, help: 'secret from sim');
-  parser.addOption('labelId', abbr:'l', mandatory: true, help: 'label id from sim');
+  parser.addOption('simSecret', abbr:'t', mandatory: true, help: 'secret from sim');
+  parser.addOption('labelId', abbr:'i', mandatory: true, help: 'label id from sim');
   dynamic results;
   try {
     results = parser.parse(args);

--- a/packages/at_chops/example/zariot/test/compute_activation_key.dart
+++ b/packages/at_chops/example/zariot/test/compute_activation_key.dart
@@ -6,7 +6,6 @@ import '../external_signer.dart';
 
 import 'package:at_utils/at_logger.dart';
 
-
 Future<void> main(List<String> args) async {
   AtSignLogger.root_level = 'FINEST';
   var parser = ArgParser();
@@ -24,9 +23,12 @@ Future<void> main(List<String> args) async {
       mandatory: false,
       defaultsTo: '/usr/lib/arm-linux-gnueabihf/libperiphery_arm.so',
       help: 'location of native library libperiphery_arm.so');
-  parser.addOption('keyId', abbr:'k', mandatory: true, help: 'key id from sim used to compute PRF');
-  parser.addOption('simSecret', abbr:'t', mandatory: true, help: 'secret from sim');
-  parser.addOption('labelId', abbr:'i', mandatory: true, help: 'label id from sim');
+  parser.addOption('keyId',
+      abbr: 'k', mandatory: true, help: 'key id from sim used to compute PRF');
+  parser.addOption('simSecret',
+      abbr: 't', mandatory: true, help: 'secret from sim');
+  parser.addOption('labelId',
+      abbr: 'i', mandatory: true, help: 'label id from sim');
   dynamic results;
   try {
     results = parser.parse(args);
@@ -38,6 +40,7 @@ Future<void> main(List<String> args) async {
   final externalSigner = ExternalSigner();
   externalSigner.init(results['privateKeyId'], results['serialPort'],
       results['libPeripheryLocation']);
-  externalSigner.computeActivationKey(results['keyId'], results['simSecret'], results['labelId']);
+  String? activationKeyResult = externalSigner.computeActivationKey(
+      results['keyId'], results['simSecret'], results['labelId']);
+  print('activationKeyResult: $activationKeyResult');
 }
-


### PR DESCRIPTION
**- What I did**
- implementation for computing activation key for cram generation
**- How I did it**
- added a new method computeActivationKey in external_signer.dart.This method constructs the command for computePRF in IoTSafe spec based on key ID, sim secreat , label ID and returns the PRF which will be used as activation key to registrar API
**- How to verify it**
- run the sample code example/zariot/test/compute_activation_key.dart
