### PR TITLE
build: Changes for Dart 3

### DIFF
--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -19,19 +19,6 @@ dependencies:
   at_onboarding_cli: ^1.2.3
   at_utils: ^3.0.11
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_onboarding_cli:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_onboarding_cli
-      ref: dart-3
-
-
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.3
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: '>=2.15.1 <4.0.0'
 
 dependencies:
   args: ^2.4.0
@@ -19,6 +19,17 @@ dependencies:
   at_onboarding_cli: ^1.2.3
   at_utils: ^3.0.11
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_onboarding_cli:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_onboarding_cli
+      ref: dart-3
 
 
 dev_dependencies:

--- a/packages/at_contact/CHANGELOG.md
+++ b/packages/at_contact/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.8
+- **Build**: Fix lint warnings from Dart 3
 ## 3.0.7
 - **chore**: Upgraded to latest at_client version 3.0.27
 ## 3.0.6

--- a/packages/at_contact/lib/src/at_contacts_impl.dart
+++ b/packages/at_contact/lib/src/at_contacts_impl.dart
@@ -150,7 +150,7 @@ class AtContactsImpl implements AtContactsLibrary {
     if (scanList.isEmpty) {
       return contactList;
     }
-    for (var key in scanList) {
+    for (final key in scanList) {
       var atsign = reduceKey(key.key!);
       var atKey = _formAtKeyFromScanKeys(key);
       AtContact? contact;
@@ -308,7 +308,7 @@ class AtContactsImpl implements AtContactsLibrary {
     list = (result?.value != null) ? jsonDecode(result?.value) : [];
     list = List<String>.from(list!);
     var groupNames = <String?>[];
-    for (var group in list) {
+    for (final group in list) {
       var groupInfo = AtGroupBasicInfo.fromJson(jsonDecode(group));
       groupNames.add(groupInfo.atGroupName);
     }
@@ -346,7 +346,7 @@ class AtContactsImpl implements AtContactsLibrary {
     list = (result?.value != null) ? jsonDecode(result?.value) : [];
     list = List<String>.from(list!);
     var groupIds = <String?>[];
-    for (var group in list) {
+    for (final group in list) {
       var groupInfo = AtGroupBasicInfo.fromJson(jsonDecode(group));
       groupIds.add(groupInfo.atGroupId);
     }
@@ -442,7 +442,7 @@ class AtContactsImpl implements AtContactsLibrary {
     }
     var atKey = _formKey(KeyType.group, key: atGroup.groupId!);
     var members = atGroup.members;
-    for (var atContact in atContacts) {
+    for (final atContact in atContacts) {
       var contactName = atContact.atSign;
       members!.removeWhere((contact) => (contact.atSign == contactName));
     }
@@ -610,7 +610,7 @@ class AtContactsImpl implements AtContactsLibrary {
   bool isMember(AtContact atContact, AtGroup atGroup) {
     var result = false;
     var members = atGroup.members!;
-    for (var contact in members) {
+    for (final contact in members) {
       if (contact.atSign.toString() == atContact.atSign.toString()) {
         return true;
       }

--- a/packages/at_contact/lib/src/at_contacts_impl.dart
+++ b/packages/at_contact/lib/src/at_contacts_impl.dart
@@ -24,7 +24,7 @@ class AtContactsImpl implements AtContactsLibrary {
   static Future<AtContactsImpl> getInstance(String atSign,
       {RegexType? regexType}) async {
     try {
-      atSign = AtUtils.fixAtSign(AtUtils.formatAtSign(atSign)!);
+      atSign = AtUtils.fixAtSign(atSign);
     } on Exception {
       rethrow;
     }
@@ -462,7 +462,7 @@ class AtContactsImpl implements AtContactsLibrary {
 
     if (key != null) {
       try {
-        key = AtUtils.fixAtSign(AtUtils.formatAtSign(key)!);
+        key = AtUtils.fixAtSign(key);
       } on Exception {
         rethrow;
       }
@@ -525,8 +525,7 @@ class AtContactsImpl implements AtContactsLibrary {
 
   /// Created group key from the group name provided
   String formGroupKey(String groupName) {
-    var key = AtUtils.formatAtSign(groupName)!;
-    key = AtUtils.fixAtSign(key);
+    var key = AtUtils.fixAtSign(groupName);
     key = key.replaceFirst('@', '');
     var modifiedKey =
         '${AppConstants.CONTACT_KEY_PREFIX}.${AppConstants.GROUP_KEY_PREFIX}.$key.${atSign.replaceFirst('@', '')}';

--- a/packages/at_contact/lib/src/at_contacts_impl.dart
+++ b/packages/at_contact/lib/src/at_contacts_impl.dart
@@ -8,14 +8,12 @@ import 'package:at_contact/src/service/at_contacts_library.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:uuid/uuid.dart';
 
-import 'config/app_constants.dart';
-
 enum RegexType { all, appSpecific }
 
 class AtContactsImpl implements AtContactsLibrary {
   AtClient? atClient;
   late String atSign;
-  late var logger;
+  late AtSignLogger logger;
   late RegexType _regexType;
 
   AtContactsImpl(this.atClient, this.atSign, {RegexType? regexType}) {
@@ -83,7 +81,7 @@ class AtContactsImpl implements AtContactsLibrary {
       atKey = _formKey(KeyType.contact, key: atSign, isOld: true);
       atValue = await _get(atKey);
     }
-    //migrate key to new keyformat if atKey is old.
+    //migrate key to new key format if atKey is old.
     if (atValue?.value != null && _isOldKey(atKey)) {
       var newAtKey = _formKey(KeyType.contact, key: atSign);
       await atClient!.put(newAtKey, atValue?.value);
@@ -95,7 +93,7 @@ class AtContactsImpl implements AtContactsLibrary {
       var value = atValue?.value;
       value = value?.replaceAll('data:', '');
       if (value != null && value != 'null') {
-        var json;
+        dynamic json;
         try {
           json = jsonDecode(value);
         } on FormatException catch (e) {
@@ -207,7 +205,7 @@ class AtContactsImpl implements AtContactsLibrary {
     if (id != null) {
       var group = await getGroup(id);
       if (group != null) {
-        throw AlreadyExistsException('Group is already exisits with id $id');
+        throw AlreadyExistsException('Group is already exists with id $id');
       }
     }
     //create groupID
@@ -247,7 +245,7 @@ class AtContactsImpl implements AtContactsLibrary {
     var group = await getGroup(groupId);
     if (group == null) {
       throw GroupNotExistsException(
-          'There is no Group exisits with Id $groupId');
+          'No Group exists with Id $groupId');
     }
     var atKey = _formKey(KeyType.group, key: atGroup.groupId!);
     //update atGroup
@@ -294,7 +292,7 @@ class AtContactsImpl implements AtContactsLibrary {
       atKey = _formKey(KeyType.groupList, isOld: true);
       result = await _get(atKey);
     }
-    //migrate key to new keyformat.
+    //migrate key to new key format.
     if (result?.value != null && _isOldKey(atKey)) {
       var newAtKey = _formKey(
         KeyType.groupList,
@@ -310,10 +308,10 @@ class AtContactsImpl implements AtContactsLibrary {
     list = (result?.value != null) ? jsonDecode(result?.value) : [];
     list = List<String>.from(list!);
     var groupNames = <String?>[];
-    list.forEach((group) {
+    for (var group in list) {
       var groupInfo = AtGroupBasicInfo.fromJson(jsonDecode(group));
       groupNames.add(groupInfo.atGroupName);
-    });
+    }
     return groupNames;
   }
 
@@ -333,7 +331,7 @@ class AtContactsImpl implements AtContactsLibrary {
       atKey = _formKey(KeyType.groupList, isOld: true);
       result = await _get(atKey);
     }
-    //migrate key to new keyformat.
+    //migrate key to new key format.
     if (result?.value != null && _isOldKey(atKey)) {
       var newAtKey = _formKey(KeyType.groupList);
       await atClient!.put(newAtKey, result?.value);
@@ -348,10 +346,10 @@ class AtContactsImpl implements AtContactsLibrary {
     list = (result?.value != null) ? jsonDecode(result?.value) : [];
     list = List<String>.from(list!);
     var groupIds = <String?>[];
-    list.forEach((group) {
+    for (var group in list) {
       var groupInfo = AtGroupBasicInfo.fromJson(jsonDecode(group));
       groupIds.add(groupInfo.atGroupId);
-    });
+    }
     return groupIds;
   }
 
@@ -384,7 +382,7 @@ class AtContactsImpl implements AtContactsLibrary {
       atKey = _formKey(KeyType.group, key: groupId, isOld: true);
       atValue = await _get(atKey);
     }
-    //migrate key to new keyformat.
+    //migrate key to new key format.
     if (atValue?.value != null && _isOldKey(atKey)) {
       var newAtKey = _formKey(KeyType.group, key: groupId);
       await atClient!.put(newAtKey, atValue?.value);
@@ -418,11 +416,11 @@ class AtContactsImpl implements AtContactsLibrary {
     }
     var atKey = _formKey(KeyType.group, key: atGroup.groupId!);
     // Add all contacts in atContacts from atGroup
-    atContacts.forEach((contact) {
+    for (var contact in atContacts) {
       if (!isMember(contact, atGroup)) {
         atGroup.members!.add(contact);
       }
-    });
+    }
     atGroup.updatedBy = AtUtils.fixAtSign(atSign);
     atGroup.updatedOn = DateTime.now();
     var json = atGroup.toJson();
@@ -475,6 +473,7 @@ class AtContactsImpl implements AtContactsLibrary {
         : preference!.namespace != null
             ? '.${preference.namespace}'
             : '';
+    // ignore: prefer_typing_uninitialized_variables
     var modifiedKey;
     switch (keyType) {
       case KeyType.contact:
@@ -554,10 +553,10 @@ class AtContactsImpl implements AtContactsLibrary {
     result = await _get(atKey);
     //check for old key if new key data is not present.
     if (result?.value == null) {
-      var oldatKey = _formKey(KeyType.groupList, isOld: true);
-      result = await _get(oldatKey);
+      var oldAtKey = _formKey(KeyType.groupList, isOld: true);
+      result = await _get(oldAtKey);
     }
-    //migrate key to new keyformat.
+    //migrate key to new key format.
     if (result?.value != null && _isOldKey(atKey)) {
       var newAtKey = _formKey(KeyType.groupList);
       await atClient!.put(newAtKey, result?.value);
@@ -575,7 +574,8 @@ class AtContactsImpl implements AtContactsLibrary {
 
   ///Adds a group to group list
   Future<bool> _deleteFromGroupList(AtGroupBasicInfo atGroupBasicInfo) async {
-    if (atGroupBasicInfo.atGroupId == null) ;
+    // gkc commented out the next line as it is an empty statement
+    // if (atGroupBasicInfo.atGroupId == null) ;
     var groupId = atGroupBasicInfo.atGroupId;
     var atKey = _formKey(KeyType.groupList, isGet: true);
     if (_regexType == RegexType.all) {

--- a/packages/at_contact/lib/src/at_contacts_impl.dart
+++ b/packages/at_contact/lib/src/at_contacts_impl.dart
@@ -416,7 +416,7 @@ class AtContactsImpl implements AtContactsLibrary {
     }
     var atKey = _formKey(KeyType.group, key: atGroup.groupId!);
     // Add all contacts in atContacts from atGroup
-    for (var contact in atContacts) {
+    for (final contact in atContacts) {
       if (!isMember(contact, atGroup)) {
         atGroup.members!.add(contact);
       }

--- a/packages/at_contact/lib/src/model/at_contact.dart
+++ b/packages/at_contact/lib/src/model/at_contact.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'package:at_contact/src/service/util_service.dart';
 
 class AtContact {

--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -29,7 +29,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
 
 dev_dependencies:

--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.0.7
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   intl: ^0.17.0
@@ -15,17 +15,22 @@ dependencies:
   at_utils: ^3.0.10
   uuid: ^3.0.4
 
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
-#  at_utils:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_utils
-#      ref: trunk
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_client
+      ref: dart-3
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -15,23 +15,6 @@ dependencies:
   at_utils: ^3.0.10
   uuid: ^3.0.4
 
-dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_client
-      ref: dart-3
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.15.4

--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -2,7 +2,7 @@ name: at_contact
 description: A Dart library for managing contact data that developers can use
   for their applications.
 documentation: https://docs.atsign.com/
-version: 3.0.7
+version: 3.0.8
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 environment:

--- a/packages/at_contact/test/at_contact_tests.dart
+++ b/packages/at_contact/test/at_contact_tests.dart
@@ -1,6 +1,5 @@
 import 'package:at_client/at_client.dart';
 import 'package:at_contact/at_contact.dart';
-import 'package:at_contact/src/model/at_contact.dart';
 import 'package:test/test.dart';
 
 import 'test_util.dart';

--- a/packages/at_contact/test/at_group_test.dart
+++ b/packages/at_contact/test/at_group_test.dart
@@ -14,7 +14,7 @@ Future<void> main() async {
   try {
     var atClientManager = await AtClientManager.getInstance()
         .setCurrentAtSign(atSign, 'me', preference);
-    atClientManager.syncService.sync();
+    atClientManager.atClient.syncService.sync();
     atContactsImpl = await AtContactsImpl.getInstance(atSign);
     // set contact details
     atGroup = AtGroup(atSign, description: 'test', displayName: 'test1');

--- a/packages/at_lookup/example/pubspec.yaml
+++ b/packages/at_lookup/example/pubspec.yaml
@@ -11,22 +11,5 @@ dependencies:
   at_commons: ^3.0.2
   at_lookup: ^3.0.5
 
-dependency_overrides:
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_lookup
-      ref: dart-3
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.0

--- a/packages/at_lookup/example/pubspec.yaml
+++ b/packages/at_lookup/example/pubspec.yaml
@@ -3,13 +3,30 @@ description: An example application to demostrate the at_lookup package usage.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.14.4 <3.0.0'
+  sdk: '>=2.14.4 <4.0.0'
 
 
 dependencies:
   at_utils: ^3.0.2
   at_commons: ^3.0.2
   at_lookup: ^3.0.5
+
+dependency_overrides:
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_lookup
+      ref: dart-3
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.0

--- a/packages/at_lookup/example/pubspec.yaml
+++ b/packages/at_lookup/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
 
 dev_dependencies:

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -25,6 +25,7 @@ class AtLookupImpl implements AtLookUp {
 
   OutboundConnection? get connection => _connection;
 
+  @override
   late SecondaryAddressFinder secondaryAddressFinder;
 
   late String _currentAtSign;

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -19,23 +19,6 @@ dependencies:
   meta: ^1.8.0
   at_chops: ^1.0.3
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_chops
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://atsign.com
 documentation: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   path: ^1.8.0
@@ -18,6 +18,23 @@ dependencies:
   mocktail: ^0.3.0
   meta: ^1.8.0
   at_chops: ^1.0.3
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_chops
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -28,7 +28,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
   at_chops:
     git:

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://atsign.com
 documentation: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
   path: ^1.8.0

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -247,7 +247,7 @@ void main() {
       unawaited(outboundMessageListener
           .read(transientWaitTimeMillis: 50)
           .whenComplete(() => {})
-          .then((value) => {response = value}));
+          .then((value) => response = value));
       await outboundMessageListener.messageHandler('data:'.codeUnits);
       await Future.delayed(Duration(milliseconds: 25));
       await outboundMessageListener.messageHandler('12'.codeUnits);

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -36,7 +36,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
   at_chops:
     git:

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -27,38 +27,6 @@ dependencies:
   args: ^2.3.1
   http: ^0.13.5
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_chops
-      ref: dart-3
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_lookup
-      ref: dart-3
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_client
-      ref: dart-3
-  at_server_status:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_server_status
-      ref: dart-3
-
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.22.1

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -6,48 +6,58 @@ homepage: https://atsign.com
 documentation: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: '>=2.15.1 <4.0.0'
 
 executables:
   at_register: register_cli
   at_activate: activate_cli
 
 dependencies:
-   at_utils: ^3.0.12
-   at_client: ^3.0.58
-   at_lookup: ^3.0.36
-   zxing2: ^0.1.0
-   image: ^3.1.1
-   crypton: ^2.0.3
-   at_commons: ^3.0.44
-   encrypt: ^5.0.1
-   at_server_status: ^1.0.3
-   path: ^1.8.1
-   args: ^2.3.1
-   http: ^0.13.5
-   at_chops: ^1.0.3
+  at_commons: ^3.0.44
+  at_utils: ^3.0.12
+  at_chops: ^1.0.3
+  at_lookup: ^3.0.36
+  at_client: ^3.0.58
+  at_server_status: ^1.0.3
+  zxing2: ^0.1.0
+  image: ^3.1.1
+  crypton: ^2.0.3
+  encrypt: ^5.0.1
+  path: ^1.8.1
+  args: ^2.3.1
+  http: ^0.13.5
 
-#dependency_overrides:
-#  at_client:
-#    git:
-#      url: https://github.com/atsign-foundation/at_client_sdk.git
-#      path: packages/at_client
-##      ref: gkc-inject-atChops-into-RemoteSecondary
-#  at_lookup:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_lookup
-#      ref: integrate_pkam_secure_element
-#  at_chops:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_chops
-#      ref: integrate_pkam_secure_element
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_chops
+      ref: dart-3
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_lookup
+      ref: dart-3
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_client
+      ref: dart-3
+  at_server_status:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_server_status
+      ref: dart-3
 
 dev_dependencies:
   lints: ^2.0.1

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -6,13 +6,30 @@ documentation: https://docs.atsign.com/
 version: 1.0.3
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
-  at_lookup: ^3.0.2
-  at_utils: ^3.0.0
   at_commons: ^3.0.0
+  at_utils: ^3.0.0
+  at_lookup: ^3.0.2
   uuid: ^3.0.4
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_lookup
+      ref: dart-3
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -23,7 +23,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
   at_lookup:
     git:

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -14,23 +14,6 @@ dependencies:
   at_lookup: ^3.0.2
   uuid: ^3.0.4
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_lookup
-      ref: dart-3
-
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.1

--- a/packages/base2e15/pubspec.yaml
+++ b/packages/base2e15/pubspec.yaml
@@ -1,6 +1,6 @@
 name: base2e15
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 description: >
   binary-to-text encoding schemes that represent binary data in an unicode string format, each unicode character represent 15 bits of binary data.
 version: 0.3.0-null-safety

--- a/packages/dart_utf7/pubspec.yaml
+++ b/packages/dart_utf7/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/michaelspiss/dart-utf7
 author: Michael Spiss <michaelspiss.dev@mailbox.org>
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 #dependencies:
 #  path: ^1.6.0

--- a/packages/redis-dart/pubspec.yaml
+++ b/packages/redis-dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/ra1u/redis-dart
 issue_tracker: https://github.com/ra1u/redis-dart/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dev_dependencies:
   lints: ^1.0.1

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -4,22 +4,37 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.14.4 <3.0.0'
+  sdk: '>=2.14.4 <4.0.0'
 
 dependencies:
   at_onboarding_cli:
     path: ../../packages/at_onboarding_cli
-  at_client: ^3.0.58
-  at_lookup: ^3.0.36
   at_commons: ^3.0.44
   at_utils: ^3.0.12
+  at_lookup: ^3.0.36
+  at_client: ^3.0.58
 
-#dependency_overrides:
-#  at_chops:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_chops
-#      ref: integrate_pkam_secure_element
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_utils:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: dart-3
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_lookup
+      ref: dart-3
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk.git
+      path: packages/at_client
+      ref: dart-3
 
 
 dev_dependencies:

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -23,7 +23,7 @@ dependency_overrides:
   at_utils:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
+      path: packages/at_utils
       ref: dart-3
   at_lookup:
     git:

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -14,29 +14,6 @@ dependencies:
   at_lookup: ^3.0.36
   at_client: ^3.0.58
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: dart-3
-  at_utils:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_utils
-      ref: dart-3
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_lookup
-      ref: dart-3
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk.git
-      path: packages/at_client
-      ref: dart-3
-
-
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.2


### PR DESCRIPTION
**- What I did**
**Note:** No errors flagged by Dart 3 in code; none of the packages here _have_ to be republished; however at_contacts probably ought to be
build: Modify max dart version in pubspecs to <4.0.0
build: update minimum dart SDK version to 2.15.0 in order to pick up the `unawaited` function
feat: removed usages of deprecated `formatAtSign` method from at_contacts_impl.dart
style: changed several for loops to change `for (var foo in <collection>)` to `for (final foo in <collection>)`
build: Updated package version and CHANGELOG for at_contact in prep for publishing a new version