### PR TITLE
fix: cleanup outbound sockets correctly

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.37
+- fix: ensure outbound sockets are cleaned up properly
 ## 3.0.36
 - feat: changes to call at_chops.sign() method which supports different signing algorithms.
 - chore: upgrade at_commons to 3.0.43, at_utils to 3.0.12 and at_chops to 1.0.3

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -217,6 +217,11 @@ class AtLookupImpl implements AtLookUp {
 
   Future<void> createConnection() async {
     if (!isConnectionAvailable()) {
+      if (_connection != null) {
+        // Clean up the connection before creating a new one
+        logger.finer('Closing old connection');
+        await _connection!.close();
+      }
       logger.info('Creating new connection');
       //1. find secondary url for atsign from lookup library
       SecondaryAddress secondaryAddress =

--- a/packages/at_lookup/lib/src/connection/base_connection.dart
+++ b/packages/at_lookup/lib/src/connection/base_connection.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/src/connection/at_connection.dart';
+import 'package:at_utils/at_logger.dart';
 
 /// Base class for common socket operations
 abstract class BaseConnection extends AtConnection {
+  static final AtSignLogger logger = AtSignLogger('BaseConnection');
   late final Socket _socket;
   StringBuffer? buffer;
   AtConnectionMetaData? metaData;
@@ -22,14 +24,21 @@ abstract class BaseConnection extends AtConnection {
 
   @override
   Future<void> close() async {
+    if (getMetaData()!.isClosed) {
+      logger.info('close(): connection is already closed');
+      return;
+    }
+
     try {
+      var address = _socket.remoteAddress;
+      var port = _socket.remotePort;
+
+      logger.info('close(): calling socket.destroy() on connection to $address:$port');
       _socket.destroy();
-    } on Exception {
+    } catch (e) {
+      // Ignore errors or exceptions on a connection close
+      logger.info('Exception "$e" while destroying socket - ignoring');
       getMetaData()!.isStale = true;
-      // Ignore exception on a connection close
-    } on Error {
-      getMetaData()!.isStale = true;
-      // Ignore error on a connection close
     } finally {
       getMetaData()!.isClosed = true;
     }

--- a/packages/at_lookup/lib/src/connection/base_connection.dart
+++ b/packages/at_lookup/lib/src/connection/base_connection.dart
@@ -6,12 +6,13 @@ import 'package:at_utils/at_logger.dart';
 
 /// Base class for common socket operations
 abstract class BaseConnection extends AtConnection {
-  static final AtSignLogger logger = AtSignLogger('BaseConnection');
+  late final AtSignLogger logger;
   late final Socket _socket;
   StringBuffer? buffer;
   AtConnectionMetaData? metaData;
 
   BaseConnection(Socket? socket) {
+    logger = AtSignLogger(runtimeType.toString());
     buffer = StringBuffer();
     socket?.setOption(SocketOption.tcpNoDelay, true);
     _socket = socket!;
@@ -25,7 +26,7 @@ abstract class BaseConnection extends AtConnection {
   @override
   Future<void> close() async {
     if (getMetaData()!.isClosed) {
-      logger.info('close(): connection is already closed');
+      logger.finer('close(): connection is already closed');
       return;
     }
 
@@ -37,7 +38,7 @@ abstract class BaseConnection extends AtConnection {
       _socket.destroy();
     } catch (e) {
       // Ignore errors or exceptions on a connection close
-      logger.info('Exception "$e" while destroying socket - ignoring');
+      logger.finer('Exception "$e" while destroying socket - ignoring');
       getMetaData()!.isStale = true;
     } finally {
       getMetaData()!.isClosed = true;
@@ -53,7 +54,7 @@ abstract class BaseConnection extends AtConnection {
   Future<void> write(String data) async {
     if (isInValid()) {
       //# Replace with specific exception
-      throw ConnectionInvalidException('Connection is invalid');
+      throw ConnectionInvalidException('write(): Connection is invalid');
     }
     try {
       getSocket().write(data);

--- a/packages/at_lookup/lib/src/connection/base_connection.dart
+++ b/packages/at_lookup/lib/src/connection/base_connection.dart
@@ -34,7 +34,8 @@ abstract class BaseConnection extends AtConnection {
       var address = _socket.remoteAddress;
       var port = _socket.remotePort;
 
-      logger.info('close(): calling socket.destroy() on connection to $address:$port');
+      logger.info('close(): calling socket.destroy()'
+          ' on connection to $address:$port');
       _socket.destroy();
     } catch (e) {
       // Ignore errors or exceptions on a connection close

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -27,8 +27,9 @@ class OutboundMessageListener {
   void listen() {
     logger.finest('Calling listen with error handler normal again');
     // Function(Object, StackTrace) errFn = _errorHandler;
-    _connection.getSocket().listen(messageHandler,
-        onDone: onSocketDone, onError: onSocketError);
+    _connection
+        .getSocket()
+        .listen(messageHandler, onDone: onSocketDone, onError: onSocketError);
   }
 
   /// Handles messages on the inbound client's connection and calls the verb executor
@@ -158,15 +159,18 @@ class OutboundMessageListener {
     logger.finest(
         'outbound socket onError handler called - calling closeConnection - error was $error');
     await closeConnection();
-    logger.finest('outbound socket onError handler called - closeConnection complete');
+    logger.finest(
+        'outbound socket onError handler called - closeConnection complete');
   }
 
   /// Closes the [OutboundConnection]
   @visibleForTesting
   void onSocketDone() async {
-    logger.finest('outbound socket onDone handler called - calling closeConnection');
+    logger.finest(
+        'outbound socket onDone handler called - calling closeConnection');
     await closeConnection();
-    logger.finest('outbound socket onDone handler called - closeConnection complete');
+    logger.finest(
+        'outbound socket onDone handler called - closeConnection complete');
   }
 
   @visibleForTesting

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -25,6 +25,8 @@ class OutboundMessageListener {
   /// Listens to the underlying connection's socket if the connection is created.
   /// @throws [AtConnectException] if the connection is not yet created
   void listen() {
+    logger.finest('Calling listen with error handler normal again');
+    // Function(Object, StackTrace) errFn = _errorHandler;
     _connection.getSocket().listen(messageHandler,
         onDone: _finishedHandler, onError: _errorHandler);
   }
@@ -149,26 +151,28 @@ class OutboundMessageListener {
         (result.startsWith('@') && result.endsWith('@'));
   }
 
-  /// Logs the error and closes the [RemoteSecondary]
-  Future<void> _errorHandler(error) async {
+  /// Logs the error and closes the [OutboundConnection]
+  void _errorHandler(Object error) async {
+    // logger.finest('outbound error handler called - calling closeConnection - error was $error and stackTrace was\n$stackTrace');
+    logger.finest('outbound error handler called - calling closeConnection - error was $error');
     await _closeConnection();
+    logger.finest('outbound error handler called - closeConnection complete');
   }
 
   /// Closes the [OutboundConnection]
   void _finishedHandler() async {
-    logger.finest('outbound finish handler called');
+    logger.finest('outbound finish handler called - calling closeConnection');
     await _closeConnection();
+    logger.finest('outbound finish handler called - closeConnection complete');
   }
 
   @visibleForTesting
   Duration? delayBeforeClose;
 
   Future<void> _closeConnection() async {
-    if (!_connection.isInValid()) {
-      if (delayBeforeClose != null) {
-        await Future.delayed(delayBeforeClose!);
-      }
-      await _connection.close();
+    if (delayBeforeClose != null) {
+      await Future.delayed(delayBeforeClose!);
     }
+    await _connection.close();
   }
 }

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -154,7 +154,8 @@ class OutboundMessageListener {
   /// Logs the error and closes the [OutboundConnection]
   void _errorHandler(Object error) async {
     // logger.finest('outbound error handler called - calling closeConnection - error was $error and stackTrace was\n$stackTrace');
-    logger.finest('outbound error handler called - calling closeConnection - error was $error');
+    logger.finest(
+        'outbound error handler called - calling closeConnection - error was $error');
     await _closeConnection();
     logger.finest('outbound error handler called - closeConnection complete');
   }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.36
+version: 3.0.37
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -12,6 +12,108 @@ class MockOutboundConnectionImpl extends Mock
 class MockSocket extends Mock implements Socket {}
 
 void main() {
+  group('test connection close and socket cleanup', () {
+    late Socket socket;
+    late OutboundConnection oc;
+    late OutboundMessageListener oml;
+    late bool socketDestroyed;
+
+    setUp(() {
+      socket = MockSocket();
+      socketDestroyed = false;
+      when(() => socket.destroy()).thenAnswer((invocation) {
+        socketDestroyed = true;
+      });
+      when(() => socket.setOption(SocketOption.tcpNoDelay, true))
+          .thenReturn(true);
+      when(() => socket.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
+      when(() => socket.remotePort).thenReturn(56789);
+      oc = OutboundConnectionImpl(socket);
+      oml = OutboundMessageListener(oc);
+    });
+
+    test(
+        'test message listener closes connection'
+        ' when socket listener onDone is called', () async {
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, false);
+      oml.onSocketDone();
+      expect(socketDestroyed, true);
+      expect(oc.metaData?.isClosed, true);
+    });
+
+    test(
+        'test message listener closes connection'
+            ' when socket listener onError is called',
+        () async {
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, false);
+      oml.onSocketError('test');
+      expect(socketDestroyed, true);
+      expect(oc.metaData?.isClosed, true);
+    });
+
+    test('test can safely call connection.close() repeatedly', () async {
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, false);
+      await oml.closeConnection();
+      expect(socketDestroyed, true);
+      expect(oc.metaData?.isClosed, true);
+
+      socketDestroyed = false;
+      await oml.closeConnection();
+      // Since the connection was already closed above,
+      // we don't expect destroy to be called on the socket again
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, true);
+    });
+
+    test(
+        'test that OutboundMessageListener.closeConnection will call'
+            ' connection.close if the connection is idle',
+        () async {
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, false);
+
+      expect(oc.isInValid(), false);
+      // Make the connection appear 'idle'
+      oc.setIdleTime(1);
+      await Future.delayed(Duration(milliseconds: 2));
+      expect(oc.isInValid(), true);
+
+      await oml.closeConnection();
+
+      expect(socketDestroyed, true);
+      expect(oc.metaData?.isClosed, true);
+    });
+
+    test(
+        'test that OutboundMessageListener.closeConnection will not call'
+            ' connection.close if already marked closed',
+        () async {
+      expect(socketDestroyed, false);
+      oc.metaData!.isClosed = true;
+
+      await oml.closeConnection();
+
+      // socketDestroyed will be set in these tests only if socket.destroy() is called
+      expect(socketDestroyed, false);
+    });
+
+    test(
+        'test that OutboundMessageListener.closeConnection will call'
+            ' connection.close even if the connection is marked stale', () async {
+      expect(socketDestroyed, false);
+      expect(oc.metaData?.isClosed, false);
+      oc.metaData!.isStale = true;
+
+      await oml.closeConnection();
+
+      expect(socketDestroyed, true);
+      expect(oc.metaData?.isClosed, true);
+    });
+  });
+
   // In order to reduce duplicated test code, creating test functions which will be used in two ways. See test groups below.
   testOne(Duration? delayBeforeClose) async {
     Socket mockSocket = MockSocket();

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:at_commons/at_commons.dart';
@@ -9,68 +10,163 @@ import 'package:mocktail/mocktail.dart';
 class MockOutboundConnectionImpl extends Mock
     implements OutboundConnectionImpl {}
 
-class MockSocket extends Mock implements Socket {}
+late int mockSocketNumber;
+
+class MockSecureSocket extends Mock implements SecureSocket {
+  bool destroyed = false;
+  int mockNumber = mockSocketNumber++;
+}
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+class MockSecureSocketFactory extends Mock
+    implements AtLookupSecureSocketFactory {}
+
+class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
 
 void main() {
   group('test connection close and socket cleanup', () {
-    late Socket socket;
-    late OutboundConnection oc;
-    late OutboundMessageListener oml;
-    late bool socketDestroyed;
+    late SecondaryAddressFinder finder;
+    late MockSecureSocketFactory mockSocketFactory;
+
+    SecureSocket createMockSecureSocket() {
+      SecureSocket mss = MockSecureSocket();
+      when(() => mss.destroy()).thenAnswer((invocation) {
+        (mss as MockSecureSocket).destroyed = true;
+      });
+      when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
+      when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
+      when(() => mss.remotePort).thenReturn(12345);
+      when(() => mss.listen(any(),
+          onError: any(named: "onError"),
+          onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());
+      return mss;
+    }
 
     setUp(() {
-      socket = MockSocket();
-      socketDestroyed = false;
-      when(() => socket.destroy()).thenAnswer((invocation) {
-        socketDestroyed = true;
+      mockSocketNumber = 1;
+
+      finder = MockSecondaryAddressFinder();
+      when(() => finder.findSecondary(any())).thenAnswer((invocation) =>
+          Future<SecondaryAddress>.value(
+              SecondaryAddress('test.test.test', 12345)));
+
+      mockSocketFactory = MockSecureSocketFactory();
+      registerFallbackValue(SecureSocketConfig());
+      when(() =>
+              mockSocketFactory.createSocket('test.test.test', '12345', any()))
+          .thenAnswer((invocation) {
+        print('Mock SecureSocketFactory returning mock socket');
+        return Future<SecureSocket>.value(createMockSecureSocket());
       });
-      when(() => socket.setOption(SocketOption.tcpNoDelay, true))
-          .thenReturn(true);
-      when(() => socket.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
-      when(() => socket.remotePort).thenReturn(56789);
-      oc = OutboundConnectionImpl(socket);
-      oml = OutboundMessageListener(oc);
+    });
+
+    test(
+        'test AtLookupImpl will use its default SecureSocketFactory if none is provided to it',
+        () async {
+      AtLookupImpl atLookup = AtLookupImpl('@alice', 'test.test.test', 64,
+          secondaryAddressFinder: finder, secureSocketFactory: null);
+
+      expect(atLookup.socketFactory.runtimeType.toString(),
+          "AtLookupSecureSocketFactory");
+      expect(() async => await atLookup.createConnection(),
+          throwsA(predicate((dynamic e) => e is SecondaryConnectException)));
+    });
+
+    test(
+        'test AtLookupImpl closes invalid connections before creating new ones',
+        () async {
+      AtLookupImpl atLookup = AtLookupImpl('@alice', 'test.test.test', 64,
+          secondaryAddressFinder: finder,
+          secureSocketFactory: mockSocketFactory);
+      expect(atLookup.socketFactory.runtimeType.toString(),
+          "MockSecureSocketFactory");
+
+      await atLookup.createConnection();
+
+      // let's get a handle to the first socket & connection
+      OutboundConnection firstConnection = atLookup.connection!;
+      MockSecureSocket firstSocket =
+          firstConnection.getSocket() as MockSecureSocket;
+
+      expect(firstSocket.mockNumber, 1);
+      expect(firstSocket.destroyed, false);
+      expect(firstConnection.metaData!.isClosed, false);
+      expect(firstConnection.isInValid(), false);
+
+      // Make the connection appear 'idle'
+      firstConnection.setIdleTime(1);
+      await Future.delayed(Duration(milliseconds: 2));
+      expect(firstConnection.isInValid(), true);
+
+      // When we now call AtLookupImpl's createConnection again, it should:
+      // - notice that its current connection is 'idle', and close it
+      // - create a new connection
+      await atLookup.createConnection();
+
+      // has the first connection been closed, and its socket destroyed?
+      expect(firstSocket.destroyed, true);
+      expect(firstConnection.metaData!.isClosed, true);
+
+      // has a new connection been created, with a new socket?
+      OutboundConnection secondConnection = atLookup.connection!;
+      MockSecureSocket secondSocket =
+          secondConnection.getSocket() as MockSecureSocket;
+      expect(firstConnection.hashCode == secondConnection.hashCode, false);
+      expect(secondSocket.mockNumber, 2);
+      expect(secondSocket.destroyed, false);
+      expect(secondConnection.metaData!.isClosed, false);
+      expect(secondConnection.isInValid(), false);
     });
 
     test(
         'test message listener closes connection'
         ' when socket listener onDone is called', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
       oml.onSocketDone();
-      expect(socketDestroyed, true);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, true);
       expect(oc.metaData?.isClosed, true);
     });
 
     test(
         'test message listener closes connection'
         ' when socket listener onError is called', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
       oml.onSocketError('test');
-      expect(socketDestroyed, true);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, true);
       expect(oc.metaData?.isClosed, true);
     });
 
     test('test can safely call connection.close() repeatedly', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
       await oml.closeConnection();
-      expect(socketDestroyed, true);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, true);
       expect(oc.metaData?.isClosed, true);
 
-      socketDestroyed = false;
+      (oc.getSocket() as MockSecureSocket).destroyed = false;
       await oml.closeConnection();
       // Since the connection was already closed above,
       // we don't expect destroy to be called on the socket again
-      expect(socketDestroyed, false);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, true);
     });
 
     test(
         'test that OutboundMessageListener.closeConnection will call'
         ' connection.close if the connection is idle', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
 
       expect(oc.isInValid(), false);
@@ -81,39 +177,43 @@ void main() {
 
       await oml.closeConnection();
 
-      expect(socketDestroyed, true);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, true);
       expect(oc.metaData?.isClosed, true);
     });
 
     test(
         'test that OutboundMessageListener.closeConnection will not call'
         ' connection.close if already marked closed', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       oc.metaData!.isClosed = true;
 
       await oml.closeConnection();
 
       // socketDestroyed will be set in these tests only if socket.destroy() is called
-      expect(socketDestroyed, false);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
     });
 
     test(
         'test that OutboundMessageListener.closeConnection will call'
         ' connection.close even if the connection is marked stale', () async {
-      expect(socketDestroyed, false);
+      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundMessageListener oml = OutboundMessageListener(oc);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
       oc.metaData!.isStale = true;
 
       await oml.closeConnection();
 
-      expect(socketDestroyed, true);
+      expect((oc.getSocket() as MockSecureSocket).destroyed, true);
       expect(oc.metaData?.isClosed, true);
     });
   });
 
   // In order to reduce duplicated test code, creating test functions which will be used in two ways. See test groups below.
   testOne(Duration? delayBeforeClose) async {
-    Socket mockSocket = MockSocket();
+    Socket mockSocket = MockSecureSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);
@@ -143,7 +243,7 @@ void main() {
   }
 
   testTwo(Duration? delayBeforeClose) async {
-    Socket mockSocket = MockSocket();
+    Socket mockSocket = MockSecureSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);
@@ -172,7 +272,7 @@ void main() {
   }
 
   testThree(Duration? delayBeforeClose) async {
-    Socket mockSocket = MockSocket();
+    Socket mockSocket = MockSecureSocket();
     when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
         .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -44,8 +44,7 @@ void main() {
 
     test(
         'test message listener closes connection'
-            ' when socket listener onError is called',
-        () async {
+        ' when socket listener onError is called', () async {
       expect(socketDestroyed, false);
       expect(oc.metaData?.isClosed, false);
       oml.onSocketError('test');
@@ -70,8 +69,7 @@ void main() {
 
     test(
         'test that OutboundMessageListener.closeConnection will call'
-            ' connection.close if the connection is idle',
-        () async {
+        ' connection.close if the connection is idle', () async {
       expect(socketDestroyed, false);
       expect(oc.metaData?.isClosed, false);
 
@@ -89,8 +87,7 @@ void main() {
 
     test(
         'test that OutboundMessageListener.closeConnection will not call'
-            ' connection.close if already marked closed',
-        () async {
+        ' connection.close if already marked closed', () async {
       expect(socketDestroyed, false);
       oc.metaData!.isClosed = true;
 
@@ -102,7 +99,7 @@ void main() {
 
     test(
         'test that OutboundMessageListener.closeConnection will call'
-            ' connection.close even if the connection is marked stale', () async {
+        ' connection.close even if the connection is marked stale', () async {
       expect(socketDestroyed, false);
       expect(oc.metaData?.isClosed, false);
       oc.metaData!.isStale = true;

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -6,16 +6,20 @@ import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockOutboundConnectionImpl extends Mock implements OutboundConnectionImpl {}
+class MockOutboundConnectionImpl extends Mock
+    implements OutboundConnectionImpl {}
+
 class MockSocket extends Mock implements Socket {}
 
 void main() {
   // In order to reduce duplicated test code, creating test functions which will be used in two ways. See test groups below.
   testOne(Duration? delayBeforeClose) async {
     Socket mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
+        .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);
-    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(connection);
 
     // We want to set up a connection, then call read() and have it time out.
     // When read() times out, the connection should be closed BEFORE the exception is thrown
@@ -28,17 +32,24 @@ void main() {
     }
     int transientWaitTimeMillis = 50;
     try {
-      await outboundMessageListener.read(transientWaitTimeMillis: transientWaitTimeMillis);
+      await outboundMessageListener.read(
+          transientWaitTimeMillis: transientWaitTimeMillis);
     } on AtTimeoutException catch (expected) {
-      expect(expected.message, startsWith('Waited for $transientWaitTimeMillis millis. No response after'));
+      expect(
+          expected.message,
+          startsWith(
+              'Waited for $transientWaitTimeMillis millis. No response after'));
       expect(connection.isInValid(), true);
     }
   }
+
   testTwo(Duration? delayBeforeClose) async {
     Socket mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
+        .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);
-    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(connection);
 
     // We want to set up a connection, then call read() and have it time out.
     // When read() times out, the connection should be closed BEFORE the exception is thrown
@@ -51,19 +62,23 @@ void main() {
     }
     int maxWaitMilliSeconds = 50;
     try {
-      await outboundMessageListener.read(maxWaitMilliSeconds: maxWaitMilliSeconds);
+      await outboundMessageListener.read(
+          maxWaitMilliSeconds: maxWaitMilliSeconds);
       expect(false, true, reason: 'Test should not have reached this point');
     } on AtTimeoutException catch (expected) {
-      expect(expected.message, 'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
+      expect(expected.message,
+          'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
       expect(connection.isInValid(), true);
     }
   }
 
   testThree(Duration? delayBeforeClose) async {
     Socket mockSocket = MockSocket();
-    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true)).thenAnswer((_) => true);
+    when(() => mockSocket.setOption(SocketOption.tcpNoDelay, true))
+        .thenAnswer((_) => true);
     OutboundConnection connection = OutboundConnectionImpl(mockSocket);
-    OutboundMessageListener outboundMessageListener = OutboundMessageListener(connection);
+    OutboundMessageListener outboundMessageListener =
+        OutboundMessageListener(connection);
 
     // We want to set up a connection, then call read() and have it time out.
     // When read() times out, the connection should be closed BEFORE the exception is thrown
@@ -76,31 +91,34 @@ void main() {
     }
     int maxWaitMilliSeconds = 50;
     try {
-      await outboundMessageListener.read(maxWaitMilliSeconds: maxWaitMilliSeconds);
+      await outboundMessageListener.read(
+          maxWaitMilliSeconds: maxWaitMilliSeconds);
       expect(false, true, reason: 'Test should not have reached this point');
     } on AtTimeoutException catch (expected) {
-      expect(expected.message, 'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
-      expect(() async =>
-      await connection.write("hello\n"),
-          throwsA(predicate((dynamic e) =>
-          e is ConnectionInvalidException)));
+      expect(expected.message,
+          'Full response not received after $maxWaitMilliSeconds millis from remote secondary');
+      expect(() async => await connection.write("hello\n"),
+          throwsA(predicate((dynamic e) => e is ConnectionInvalidException)));
     }
   }
 
-  group('A group of tests to detect race condition in connection management', ()
-  {
+  group('A group of tests to detect race condition in connection management',
+      () {
     test(
         'Test that isInvalid is set on the OutboundConnection after transientWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
         () async {
       await testOne(Duration(milliseconds: 100));
     });
 
-    test('Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+    test(
+        'Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
         () async {
       await testTwo(Duration(milliseconds: 100));
     });
 
-    test('Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException', () async {
+    test(
+        'Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException',
+        () async {
       await testThree(Duration(milliseconds: 100));
     });
   });
@@ -111,16 +129,19 @@ void main() {
   group('Same race condition tests without the artificial delay', () {
     test(
         'Test that isInvalid is set on the OutboundConnection after transientWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
-            () async {
-          await testOne(null);
-        });
+        () async {
+      await testOne(null);
+    });
 
-    test('Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
-            () async {
-          await testTwo(null);
-        });
+    test(
+        'Test that isInvalid is set on the OutboundConnection after maxWaitTime timeout BEFORE the OutboundMessageListener.read() returns',
+        () async {
+      await testTwo(null);
+    });
 
-    test('Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException', () async {
+    test(
+        'Test that an attempt to write to an outbound connection which has had a timeout will throw a ConnectionInvalidException',
+        () async {
       await testThree(null);
     });
   });

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -58,7 +58,8 @@ void main() {
     });
 
     test('A test to validate single data comes two packets', () async {
-      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener
+          .messageHandler('data:public:phone@'.codeUnits);
       await outboundMessageListener.messageHandler('alice\n@alice@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:public:phone@alice');
@@ -124,7 +125,8 @@ void main() {
         () async {
       await outboundMessageListener
           .messageHandler('data:public:location@alice,'.codeUnits);
-      await outboundMessageListener.messageHandler('public:phone@alice\n@'.codeUnits);
+      await outboundMessageListener
+          .messageHandler('public:phone@alice\n@'.codeUnits);
       var response = await outboundMessageListener.read();
       expect(response, 'data:public:location@alice,public:phone@alice');
       await outboundMessageListener.messageHandler('data:hi\n@'.codeUnits);
@@ -204,7 +206,8 @@ void main() {
       expect(
           () async =>
               // we want to trigger the maxWaitMilliSeconds exception, so setting transient to a higher value
-              await outboundMessageListener.read(transientWaitTimeMillis: 100, maxWaitMilliSeconds: 50),
+              await outboundMessageListener.read(
+                  transientWaitTimeMillis: 100, maxWaitMilliSeconds: 50),
           throwsA(predicate((dynamic e) =>
               e is AtTimeoutException &&
               e.message.startsWith(
@@ -213,7 +216,8 @@ void main() {
     test(
         'A test to verify partial response - wait time greater than transientWaitTimeMillis',
         () async {
-      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener
+          .messageHandler('data:public:phone@'.codeUnits);
       await outboundMessageListener.messageHandler('12'.codeUnits);
       expect(
           () async =>
@@ -226,15 +230,17 @@ void main() {
     test(
         'A test to verify partial response - wait time greater than maxWaitMillis',
         () async {
-      await outboundMessageListener.messageHandler('data:public:phone@'.codeUnits);
+      await outboundMessageListener
+          .messageHandler('data:public:phone@'.codeUnits);
       await outboundMessageListener.messageHandler('12'.codeUnits);
       await outboundMessageListener.messageHandler('34'.codeUnits);
       await outboundMessageListener.messageHandler('56'.codeUnits);
       await outboundMessageListener.messageHandler('78'.codeUnits);
       expect(
           () async =>
-          // we want to trigger the maxWaitMilliSeconds exception, so setting transient to a higher value
-              await outboundMessageListener.read(transientWaitTimeMillis: 30, maxWaitMilliSeconds: 20),
+              // we want to trigger the maxWaitMilliSeconds exception, so setting transient to a higher value
+              await outboundMessageListener.read(
+                  transientWaitTimeMillis: 30, maxWaitMilliSeconds: 20),
           throwsA(predicate((dynamic e) =>
               e is AtTimeoutException &&
               e.message ==


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_client_sdk/issues/1022

**- What I did**
- fix: cleanup outbound sockets correctly
- test: Added unit tests to cover all expected behaviour

**- How I did it**
- in BaseConnection.close() - if not already closed, try to close, and set isClosed to true
- In OutboundMessageListener
  - In _closeConnection - remove the check for 'isInValid' as
    - this would always return true for connections which had been idle for longer than the configured idle time
    - and in turn this would result in the connection not being closed
    - and in turn this would result in uncaught exceptions as and when server closed idle inbound connections
  - Change method signature on _errorHandler so it matches the spec that dart streams error handlers expect
- in AtLookupImpl.createConnection - add logic to ensure that if a new connection is required, and an old (idle / stale) connection exists, then we close the old connection
- feat: Added ability to inject an 'AtLookupSecureSocketFactory' into AtLookupImpl when creating it, which AtLookupImpl then uses later on when creating new outbound connections. If a factory isn't provided to the constructor, then we use the default factory, which uses the existing mechanism of calling the static method SecureSocketUtil.createSecureSocket

**- How to verify it**
Tests pass

**- Description for the changelog**
fix: cleanup outbound sockets correctly
