### PR TITLE
fix: Remove LoggingType and add LoggingHandler as optional argument t…

### DIFF
--- a/packages/at_utils/CHANGELOG.md
+++ b/packages/at_utils/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.15
+- fix: Replace "LoggingType" with "LoggingHandler" in "AtSignLogger" constructor to enable custom logging
 ## 3.0.14
 - chore: Moved this package to a new repo & updated repository URL
 ## 3.0.13

--- a/packages/at_utils/lib/at_logger.dart
+++ b/packages/at_utils/lib/at_logger.dart
@@ -1,3 +1,4 @@
 library at_logger;
 
+export 'package:at_utils/src/logging/handlers.dart';
 export 'package:at_utils/src/logging/atsignlogger.dart';

--- a/packages/at_utils/lib/src/atsign_util.dart
+++ b/packages/at_utils/lib/src/atsign_util.dart
@@ -48,7 +48,7 @@ class AtUtils {
       throw InvalidAtSignException(AtMessage.noAtSign.text);
     }
     // reconstruct @sign
-    atSign = left + '@' + right;
+    atSign = '$left@$right';
     // Some Characters are reserved
     // If found the @sign should be rejected
     if (atSign.contains(RegExp(r"[\!\*\'`\(\)\;\:\&\=\+\$\,\/\?\#\[\]\{\}]"))) {

--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -11,13 +11,15 @@ class AtSignLogger {
   static String _root_level = 'info';
   bool _hierarchicalLoggingEnabled = false;
 
-  static final ConsoleLoggingHandler _consoleLoggingHandler =
+  static final ConsoleLoggingHandler consoleLoggingHandler =
       ConsoleLoggingHandler();
+  static final StdErrLoggingHandler stdErrLoggingHandler =
+      StdErrLoggingHandler();
 
   /// The default logging handler to log events.
   ///
   /// Defaults to [ConsoleLoggingHandler] which writes log events to console.
-  static LoggingHandler defaultLoggingHandler = _consoleLoggingHandler;
+  static LoggingHandler defaultLoggingHandler = consoleLoggingHandler;
 
   /// The AtSignLogger is a wrapper on the Logger to log events.
   ///
@@ -44,7 +46,7 @@ class AtSignLogger {
   /// ```
   AtSignLogger(String name, {LoggingHandler? loggingHandler}) {
     logger = logging.Logger.detached(name);
-    loggingHandler ??= _consoleLoggingHandler;
+    loggingHandler ??= consoleLoggingHandler;
     logger.onRecord.listen(loggingHandler);
     level = _root_level;
   }

--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -13,19 +13,38 @@ class AtSignLogger {
 
   static final ConsoleLoggingHandler _consoleLoggingHandler =
       ConsoleLoggingHandler();
-  static final StdErrLoggingHandler _stdErrLoggingHandler =
-      StdErrLoggingHandler();
+
+  /// The default logging handler to log events.
+  ///
+  /// Defaults to [ConsoleLoggingHandler] which writes log events to console.
+  static LoggingHandler defaultLoggingHandler = _consoleLoggingHandler;
 
   /// The AtSignLogger is a wrapper on the Logger to log events.
   ///
   /// * name: Accepts String as input which represents the name of the AtSignLogger instance.
   ///
-  /// * loggingType: This is an optionally parameter which specifies where to log
-  /// the events. Supported types are Console and StandardError.
-  /// The default loggingType is set to console which writes log messages to console.
-  AtSignLogger(String name, {LoggingType loggingType = LoggingType.console}) {
-    LoggingHandler loggingHandler = _getLoggingHandler(loggingType);
+  /// * loggingHandler  This is an optional parameter that determines the destination for logging events.
+  ///
+  /// The loggingHandler defaults to the value of [defaultLoggingHandler].
+  ///
+  /// To customize the logging behavior based on your specific requirements, create an
+  /// instance of a class that implements the [LoggingHandler] interface and pass this
+  /// instance to the loggingHandler argument
+  ///
+  /// ```dart
+  /// class MyLoggingHandler implements LoggingHandler {
+  ///   @override
+  ///   void call(LogRecord record) {
+  ///     // Custom implementation of logging behavior
+  ///     print('Logging: ${record.message}');
+  ///   }
+  /// }
+  ///
+  /// AtSignLogger('myLogger', loggingHandler: MyLoggingHandler())
+  /// ```
+  AtSignLogger(String name, {LoggingHandler? loggingHandler}) {
     logger = logging.Logger.detached(name);
+    loggingHandler ??= _consoleLoggingHandler;
     logger.onRecord.listen(loggingHandler);
     level = _root_level;
   }
@@ -65,30 +84,7 @@ class AtSignLogger {
     return _root_level;
   }
 
-  /// Returns an instance of Logging Handler basing on the [LoggingType]
-  static LoggingHandler _getLoggingHandler(LoggingType loggingType) {
-    switch (loggingType) {
-      case LoggingType.console:
-        return _consoleLoggingHandler;
-      case LoggingType.stdErr:
-        return _stdErrLoggingHandler;
-      default:
-        return _consoleLoggingHandler;
-    }
-  }
-
-//  static set rootLogFilePath(String path) {
-//    _rootLogFilePath = path;
-//    if (_rootLogFilePath != null) {
-//      logging.Logger.root.onRecord.listen(FileLoggingHandler(_rootLogFilePath));
-//    }
-//  }
-//
-//  void setLogFilePath(String path) {
-//    logger.onRecord.listen(FileLoggingHandler(path));
-//  }
-
-//log methods
+  //log methods
   void shout(message, [Object? error, StackTrace? stackTrace]) =>
       logger.shout(message, error, stackTrace);
 
@@ -119,8 +115,3 @@ class LogLevel {
     'all': logging.Level.ALL
   };
 }
-
-/// Enum to represent supported logging types.
-/// console: Writes the log output to the user screen
-/// standardError: Writes the log output to the standard error stream
-enum LoggingType { console, stdErr }

--- a/packages/at_utils/pubspec.yaml
+++ b/packages/at_utils/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_utils
 description: A Dart library that contains various utility classes such as atSign, atmetadata, configuration, and logger.
-version: 3.0.14
+version: 3.0.15
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/
@@ -17,6 +17,6 @@ dependencies:
   collection: ^1.15.0
 
 dev_dependencies:
-  lints: ^1.0.1
-  test: ^1.17.0
+  lints: ^2.1.1
+  test: ^1.24.4
   test_process: ^2.0.0

--- a/packages/at_utils/test/fix_at_sign_test.dart
+++ b/packages/at_utils/test/fix_at_sign_test.dart
@@ -75,7 +75,7 @@ void main() {
     });
 
     test('reserved characters with ascii codes - InvalidAtsignException', () {
-      var atSign = '@U' + String.fromCharCode(43);
+      var atSign = '@U${String.fromCharCode(43)}';
       expect(
           () => AtUtils.fixAtSign(atSign),
           throwsA(predicate((dynamic e) =>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Replace the `LoggingType` enum in `AtSignLogger` constructor with `LoggingHandler` to enable custom logging.
* In AtSignLogger, add static variable `defaultLoggingHandler` and default it to instance of `ConsoleLoggingHandler`
* Export `handlers.dart` file in at_loggers.dart for custom logging classes to extend `LoggingHandler` class
* Resolve dart analyze issues in `atsign_util.dart` and `fix_at_sign_test.dart`
* Remove the code related to `LoggingType` enum and commented code.
* Update the version of lints and test packages

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->