### PR TITLE
fix: In at_lookup OutboundMessageListener, wrap call to socket.listen in runZonedGuarded to ensure no uncaught exceptions

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.38
+- fix: wrap socket.listen in runZonedGuarded to ensure weird network errors are
+  always caught
 ## 3.0.37
 - fix: ensure outbound sockets are cleaned up properly
 ## 3.0.36

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.37
+version: 3.0.38
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
fix: In OutboundMessageListener, wrap socket.listen in runZonedGuarded to ensure no uncaught exceptions

**- How I did it**

**- How to verify it**
- [x] at_client test pack should succeed. See https://github.com/atsign-foundation/at_client_sdk/pull/1087

