### PR TITLE
fix: AtSignLogger: use the defaultLoggingHandler if none is supplied

### DIFF
--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -46,7 +46,7 @@ class AtSignLogger {
   /// ```
   AtSignLogger(String name, {LoggingHandler? loggingHandler}) {
     logger = logging.Logger.detached(name);
-    loggingHandler ??= consoleLoggingHandler;
+    loggingHandler ??= defaultLoggingHandler;
     logger.onRecord.listen(loggingHandler);
     level = _root_level;
   }

--- a/packages/at_utils/test/logging_test.dart
+++ b/packages/at_utils/test/logging_test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:at_utils/at_logger.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';

--- a/packages/at_utils/test/logging_test.dart
+++ b/packages/at_utils/test/logging_test.dart
@@ -7,7 +7,7 @@ void main() {
     AtSignLogger.defaultLoggingHandler = AtSignLogger.consoleLoggingHandler;
   });
 
-  group('A group of fixAtSign tests', () {
+  group('A group of AtSignLogger tests', () {
     test('Test logging handler', () {
       var records = <LogRecord>[];
       var testLogger = AtSignLogger('test_console_logging');

--- a/packages/at_utils/test/logging_test.dart
+++ b/packages/at_utils/test/logging_test.dart
@@ -4,22 +4,71 @@ import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
+  setUp(() {
+    AtSignLogger.defaultLoggingHandler = AtSignLogger.consoleLoggingHandler;
+  });
+
   group('A group of fixAtSign tests', () {
-    test('Test file logging', () => testConsoleLogging());
+    test('Test logging handler', () {
+      var records = <LogRecord>[];
+      var testLogger = AtSignLogger('test_console_logging');
+      testLogger.logger.onRecord.listen(records.add);
+      testLogger.info('hello');
+      expect(records[0].message, 'hello');
+    });
+
+    test('Test default logging handler', () {
+      var lh1 = MyLoggingHandler(AtSignLogger.consoleLoggingHandler);
+      AtSignLogger.defaultLoggingHandler = lh1;
+      var l1 = AtSignLogger('console');
+
+      l1.info('testing 1');
+      expect(lh1.lastLogRecord!.message, 'testing 1');
+
+      var lh2 = MyLoggingHandler(AtSignLogger.stdErrLoggingHandler);
+      AtSignLogger.defaultLoggingHandler = lh2;
+      var l2 = AtSignLogger('stderr');
+      l2.info('testing 2');
+      expect(lh2.lastLogRecord!.message, 'testing 2');
+    });
+
+    test('Test override logging handler for instance', () {
+      var testDefaultLH = MyLoggingHandler(ConsoleLoggingHandler());
+      AtSignLogger.defaultLoggingHandler = testDefaultLH;
+
+      expect(AtSignLogger.defaultLoggingHandler, testDefaultLH);
+      var lh1 = NullLoggingHandler();
+      var l1 = AtSignLogger('null handler', loggingHandler: lh1);
+
+      expect(AtSignLogger.defaultLoggingHandler, testDefaultLH);
+      var l2 = AtSignLogger('console'); // should use the defaultLoggingHandler
+
+      l1.info('testing per-instance logging handler');
+      expect(lh1.lastLogRecord!.message, 'testing per-instance logging handler');
+      expect(testDefaultLH.lastLogRecord, null);
+
+      l2.info('testing with default logging handler');
+      expect(lh1.lastLogRecord!.message, 'testing per-instance logging handler');
+      expect(testDefaultLH.lastLogRecord!.message, 'testing with default logging handler');
+    });
   });
 }
 
-void deleteFile(filename) {
-  var file = File(filename);
-  if (file.existsSync()) {
-    file.deleteSync();
+class MyLoggingHandler implements LoggingHandler {
+  final LoggingHandler delegate;
+  MyLoggingHandler(this.delegate);
+  LogRecord? lastLogRecord;
+  @override
+  void call(LogRecord record) {
+    lastLogRecord = record;
+    delegate.call(record);
   }
 }
 
-void testConsoleLogging() {
-  var records = <LogRecord>[];
-  var testLogger = AtSignLogger('test_console_logging');
-  testLogger.logger.onRecord.listen(records.add);
-  testLogger.info('hello');
-  expect(records[0].message, 'hello');
+class NullLoggingHandler implements LoggingHandler {
+  LogRecord? lastLogRecord;
+  @override
+  void call(LogRecord record) {
+    lastLogRecord = record;
+  }
 }

--- a/packages/at_utils/test/logging_test.dart
+++ b/packages/at_utils/test/logging_test.dart
@@ -43,12 +43,15 @@ void main() {
       var l2 = AtSignLogger('console'); // should use the defaultLoggingHandler
 
       l1.info('testing per-instance logging handler');
-      expect(lh1.lastLogRecord!.message, 'testing per-instance logging handler');
+      expect(
+          lh1.lastLogRecord!.message, 'testing per-instance logging handler');
       expect(testDefaultLH.lastLogRecord, null);
 
       l2.info('testing with default logging handler');
-      expect(lh1.lastLogRecord!.message, 'testing per-instance logging handler');
-      expect(testDefaultLH.lastLogRecord!.message, 'testing with default logging handler');
+      expect(
+          lh1.lastLogRecord!.message, 'testing per-instance logging handler');
+      expect(testDefaultLH.lastLogRecord!.message,
+          'testing with default logging handler');
     });
   });
 }


### PR DESCRIPTION
**- What I did**
fix: In the AtSignLogger constructor, use `AtSignLogger.defaultLoggingHandler` if none is supplied (constructor was still defaulting to the consoleLoggingHandler)
test: add a couple of unit tests for AtSignLogger and default logging handler

**- How to verify it**
Tests pass

