### PR TITLE
fix: Updated to regex to include emoji

### DIFF
--- a/packages/at_commons/lib/src/verb/keys_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/keys_verb_builder.dart
@@ -45,7 +45,7 @@ class KeysVerbBuilder implements VerbBuilder {
       ..write(_getValueWithParamName('encryptionKeyName', encryptionKeyName))
       ..write(_getValueWithParamName('keyName', keyName))
       ..write(
-          _getValue(value)) //value is prepended with a whitespace as per regexs
+          _getValue(value)) //value is prepended with a whitespace as per regex
       ..write('\n');
 
     return sb.toString();
@@ -53,7 +53,7 @@ class KeysVerbBuilder implements VerbBuilder {
 
   String _getValue(String? paramValue) {
     if (paramValue != null && paramValue.isNotEmpty && paramValue != 'null') {
-      return ' $paramValue'; //value is prepended with a whitespace as per regexs
+      return ' $paramValue'; //value is prepended with a whitespace as per regex
     }
     return '';
   }

--- a/packages/at_commons/lib/src/verb/keys_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/keys_verb_builder.dart
@@ -20,7 +20,7 @@ class KeysVerbBuilder implements VerbBuilder {
   String? appName;
 
   /// name of the device which requested this key operation
-  String? device;
+  String? deviceName;
 
   /// Encryption key type e.g rsa2048,aes256, ecdsa
   String? keyType;
@@ -37,14 +37,15 @@ class KeysVerbBuilder implements VerbBuilder {
   String buildCommand() {
     var sb = StringBuffer("keys:")
       ..write(operation)
-      ..write(_getValue(visibility))
-      ..write(_getValueWithParamName('keyName', keyName))
+      ..write(':$visibility')
       ..write(_getValueWithParamName('namespace', namespace))
       ..write(_getValueWithParamName('appName', appName))
-      ..write(_getValueWithParamName('device', device))
+      ..write(_getValueWithParamName('deviceName', deviceName))
       ..write(_getValueWithParamName('keyType', keyType))
       ..write(_getValueWithParamName('encryptionKeyName', encryptionKeyName))
-      ..write(_getValue(value))
+      ..write(_getValueWithParamName('keyName', keyName))
+      ..write(
+          _getValue(value)) //value is prepended with a whitespace as per regexs
       ..write('\n');
 
     return sb.toString();
@@ -52,7 +53,7 @@ class KeysVerbBuilder implements VerbBuilder {
 
   String _getValue(String? paramValue) {
     if (paramValue != null && paramValue.isNotEmpty && paramValue != 'null') {
-      return ':$paramValue';
+      return ' $paramValue'; //value is prepended with a whitespace as per regexs
     }
     return '';
   }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -143,6 +143,6 @@ class VerbSyntax {
       r'((deviceName:(?<deviceName>[a-zA-Z0-9_]+):)?)'
       r'(((keyType:(?<keyType>[a-zA-Z0-9_-]+))(:))?)'
       r'((encryptionKeyName:(?<encryptionKeyName>[a-zA-Z0-9_\-]+)(:))?)'
-      r'(keyName:(?<keyName>[a-zA-Z0-9_.:@\-]+)( )?)?'
+      r'(keyName:(?<keyName>\S+)( )?)?'
       r'((?<keyValue>.*))?$';
 }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -136,13 +136,24 @@ class VerbSyntax {
       r'(?:totp:(?<totp>[0-9]+):)?'
       r'(?:apkamPublicKey:(?<apkamPublicKey>.*)))?$';
   static const totp = r'^totp:(?<operation>get|validate)(:(?<totp>[0-9]+))?$';
-  static const keys = r'^keys:(?<operation>put|get|delete):'
-      r'(((?<visibility>public|private|self)(:)?)?)'
-      r'((namespace:(?<namespace>[a-zA-Z0-9_]+):)?)'
-      r'((appName:(?<appName>[a-zA-Z0-9_]+):)?)'
-      r'((deviceName:(?<deviceName>[a-zA-Z0-9_]+):)?)'
-      r'(((keyType:(?<keyType>[a-zA-Z0-9_-]+))(:))?)'
-      r'((encryptionKeyName:(?<encryptionKeyName>[a-zA-Z0-9_\-]+)(:))?)'
-      r'(keyName:(?<keyName>\S+)( )?)?'
-      r'((?<keyValue>.*))?$';
+  static const keys = r'^keys:((?<operation>put|get|delete):?)'
+      r'(?:(?<visibility>public|private|self):?)?'
+      r'(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?'
+      r'(?:appName:(?<appName>[a-zA-Z0-9_]+):?)?'
+      r'(?:deviceName:(?<deviceName>[a-zA-Z0-9_]+):?)?'
+      r'(?:keyType:(?<keyType>[a-zA-Z0-9_-]+):?)?'
+      r'(?:encryptionKeyName:(?<encryptionKeyName>[a-zA-Z0-9_\-]+):?)?'
+      r'(?:keyName:(?<keyName>\S+) ?)?'
+      r'(?<keyValue>.*)?$';
 }
+
+      
+
+// keys:((?<operation>put|get|delete):?)
+//(?:(?<visibility>public|private|self):?)?
+//(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?
+//(?:appName:(?<appName>[a-zA-Z0-9_]+):?)?
+//(?:deviceName:(?<deviceName>[a-zA-Z0-9_]+):?)?
+//(?:keyType:(?<keyType>[a-zA-Z0-9_-]+):?)?
+//(?:encryptionKeyName:(?<encryptionKeyName>[a-zA-Z0-9_\-]+):?)?
+//(?:keyName:(?<keyName>\S+) ?)?(?<keyValue>.*)?$

--- a/packages/at_commons/test/keys_verb_builder_test.dart
+++ b/packages/at_commons/test/keys_verb_builder_test.dart
@@ -51,7 +51,7 @@ void main() {
         ..keyType = 'rsa2048'
         ..value = 'abcd1234';
       expect(keysVerbBuilder.buildCommand(),
-          'keys:put:public:keyName:encryptionPublicKey:namespace:__global:keyType:rsa2048:abcd1234\n');
+          'keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryptionPublicKey abcd1234\n');
     });
 
     test('test put private key', () {
@@ -62,7 +62,7 @@ void main() {
         ..keyType = 'aes256'
         ..value = 'abcd1234';
       expect(keysVerbBuilder.buildCommand(),
-          'keys:put:private:keyName:secretKey:namespace:__private:keyType:aes256:abcd1234\n');
+          'keys:put:private:namespace:__private:keyType:aes256:keyName:secretKey abcd1234\n');
     });
 
     test('test put self key', () {
@@ -74,7 +74,7 @@ void main() {
         ..encryptionKeyName = 'firstKey'
         ..value = 'zcsfsdff';
       expect(keysVerbBuilder.buildCommand(),
-          'keys:put:self:keyName:selfkey:namespace:__global:keyType:aes256:encryptionKeyName:firstKey:zcsfsdff\n');
+          'keys:put:self:namespace:__global:keyType:aes256:encryptionKeyName:firstKey:keyName:selfkey zcsfsdff\n');
     });
   });
 }

--- a/packages/at_commons/test/keys_verb_builder_test.dart
+++ b/packages/at_commons/test/keys_verb_builder_test.dart
@@ -31,18 +31,42 @@ void main() {
           keysVerbBuilder.buildCommand(), 'keys:get:private:keyName:mykey\n');
     });
 
+      test('test get private key by keyname with emoji', () {
+      final keysVerbBuilder = KeysVerbBuilder('get')
+        ..visibility = 'private'
+        ..keyName = 'mykey🛠';
+      expect(
+          keysVerbBuilder.buildCommand(), 'keys:get:private:keyName:mykey🛠\n');
+    });
+
     test('test get self key by keyname', () {
       final keysVerbBuilder = KeysVerbBuilder('get')
         ..visibility = 'self'
         ..keyName = 'mykey';
       expect(keysVerbBuilder.buildCommand(), 'keys:get:self:keyName:mykey\n');
     });
+
+     test('test get self key by keyname with emoji', () {
+      final keysVerbBuilder = KeysVerbBuilder('get')
+        ..visibility = 'self'
+        ..keyName = 'mykey🛠';
+      expect(keysVerbBuilder.buildCommand(), 'keys:get:self:keyName:mykey🛠\n');
+    });
+
     test('test get public key by keyname', () {
       final keysVerbBuilder = KeysVerbBuilder('get')
         ..visibility = 'public'
         ..keyName = 'mykey';
       expect(keysVerbBuilder.buildCommand(), 'keys:get:public:keyName:mykey\n');
     });
+
+    test('test get public key by keyname with emoji', () {
+      final keysVerbBuilder = KeysVerbBuilder('get')
+        ..visibility = 'public'
+        ..keyName = 'mykey🛠';
+      expect(keysVerbBuilder.buildCommand(), 'keys:get:public:keyName:mykey🛠\n');
+    });
+
     test('test put public key', () {
       final keysVerbBuilder = KeysVerbBuilder('put')
         ..visibility = 'public'

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -150,11 +150,18 @@ void main() {
       expect(verbParams[visibility], 'public');
     });
 
-    test('keys verb - get  key by name', () {
+    test('keys verb - get key by name', () {
       var command = 'keys:get:keyName:firstKey';
       var verbParams = getVerbParams(VerbSyntax.keys, command);
       expect(verbParams[AT_OPERATION], 'get');
       expect(verbParams[keyName], 'firstKey');
+    });
+
+    test('keys verb - get key by name with emoji', () {
+      var command = 'keys:get:keyName:firstKey🛠';
+      var verbParams = getVerbParams(VerbSyntax.keys, command);
+      expect(verbParams[AT_OPERATION], 'get');
+      expect(verbParams[keyName], 'firstKey🛠');
     });
   });
 


### PR DESCRIPTION

**- What I did**
- Updated the keys verb regex. 
- modified keys verb builder

**- How I did it**
- Changed the regex to support emoji in the keyname
- modified keys verb builder to match ordering of param in syntax
**- How to verify it**
syntax_test.dart and keys_verb_builder_test.dart should pass
keys_verb_test.dart in the at_server function test should pass.
https://github.com/atsign-foundation/at_server/pull/1463

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->