### PR TITLE
fix: do not store pkamPublicKey, encryptionPublicKey on LocalSecondary

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 1.3.1
+- feat: make namespace mandatory for authentication
 ## 1.3.0
-- feat: Introduced verification-code based activation of atsigns
+- feat: Introduced verification-code based activation of atsign's
 - fix: deprecate qr_code based activation
 - feat: introduced new exceptions
 - fix: improve existing logger messages and added some

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -61,7 +61,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       logger.severe(
           'Please set namespace in AtOnboardingPreferences.'
               ' Cannot create at_client instance without namespace.');
-      throw AtOnboardingException('namespace cannot be null');
+      throw AtOnboardingException('namespace cannot be empty');
     }
     await atClientManager.setCurrentAtSign(
         _atSign, atOnboardingPreference.namespace, atOnboardingPreference,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -5,18 +5,18 @@ import 'dart:io';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
+import 'package:at_commons/at_builders.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_onboarding_cli/src/factory/service_factories.dart';
 import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_server_status/at_server_status.dart';
 import 'package:at_utils/at_utils.dart';
-import 'package:at_commons/at_builders.dart';
-import 'package:at_onboarding_cli/src/factory/service_factories.dart';
-import 'package:at_lookup/at_lookup.dart';
-import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
-import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
+import 'package:zxing2/qrcode.dart';
 
 import '../util/home_directory_util.dart';
 import '../util/onboarding_util.dart';
@@ -56,6 +56,12 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     AtClientManager atClientManager = AtClientManager.getInstance();
     if (atOnboardingPreference.skipSync == true) {
       atServiceFactory = ServiceFactoryWithNoOpSyncService();
+    }
+    if (atOnboardingPreference.namespace == null) {
+      logger.severe(
+          'Please set namespace in AtOnboardingPreferences.'
+              ' Cannot create at_client instance without namespace.');
+      throw AtOnboardingException('namespace cannot be null');
     }
     await atClientManager.setCurrentAtSign(
         _atSign, atOnboardingPreference.namespace, atOnboardingPreference,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -273,23 +273,16 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     //when authenticating keys need to be fetched from atKeys file
     Map<String, String> atKeysMap = await _decryptAtKeysFile(
         (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
-    //backup keys into local secondary
-    bool? response = await _atClient
-        ?.getLocalSecondary()
-        ?.putValue(AT_PKAM_PUBLIC_KEY, atKeysMap[AuthKeyType.pkamPublicKey]!);
-    logger.finer('PkamPublicKey persist to localSecondary: status $response');
-    // save pkam private key only when auth mode is keyFile. if auth mode is sim/any other secure element private key cannot be read and hence will not be part of keys file
+    bool? response;
+    // save pkam private key only when auth mode is keyFile.
+    // if auth mode is sim/any other secure element private key cannot be
+    // read and hence will not be part of keys file
     if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
       response = await _atClient?.getLocalSecondary()?.putValue(
           AT_PKAM_PRIVATE_KEY, atKeysMap[AuthKeyType.pkamPrivateKey]!);
       logger
           .finer('PkamPrivateKey persist to localSecondary: status $response');
     }
-    response = await _atClient?.getLocalSecondary()?.putValue(
-        '$AT_ENCRYPTION_PUBLIC_KEY$_atSign',
-        atKeysMap[AuthKeyType.encryptionPublicKey]!);
-    logger.finer(
-        'EncryptionPublicKey persist to localSecondary: status $response');
     response = await _atClient?.getLocalSecondary()?.putValue(
         AT_ENCRYPTION_PRIVATE_KEY,
         atKeysMap[AuthKeyType.encryptionPrivateKey]!);

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -57,12 +57,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     if (atOnboardingPreference.skipSync == true) {
       atServiceFactory = ServiceFactoryWithNoOpSyncService();
     }
-    if (atOnboardingPreference.namespace == null) {
-      logger.severe(
-          'Please set namespace in AtOnboardingPreferences.'
-              ' Cannot create at_client instance without namespace.');
-      throw AtOnboardingException('namespace cannot be empty');
-    }
     await atClientManager.setCurrentAtSign(
         _atSign, atOnboardingPreference.namespace, atOnboardingPreference,
         atChops: atChops, serviceFactory: atServiceFactory);

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tool to authenticate, onboard and perform complex operations on atSign seccondaries from command-line-interface.
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -13,13 +13,13 @@ executables:
   at_activate: activate_cli
 
 dependencies:
-   at_utils: ^3.0.12
-   at_client: ^3.0.59
-   at_lookup: ^3.0.36
+   at_utils: ^3.0.15
+   at_client: ^3.0.62
+   at_lookup: ^3.0.38
    zxing2: ^0.2.0
    image: ^4.0.17
    crypton: ^2.0.3
-   at_commons: ^3.0.45
+   at_commons: ^3.0.52
    encrypt: ^5.0.1
    at_server_status: ^1.0.3
    path: ^1.8.1

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -97,15 +97,8 @@ void main() {
       expect(at_demos.pkamPrivateKeyMap[atSign],
           await atClient?.getLocalSecondary()?.getPrivateKey());
 
-      expect(at_demos.pkamPublicKeyMap[atSign],
-          await atClient?.getLocalSecondary()?.getPublicKey());
-
       expect(at_demos.encryptionPrivateKeyMap[atSign],
           await atClient?.getLocalSecondary()?.getEncryptionPrivateKey());
-
-      String? encryptionPublicKey =
-          await atClient?.getLocalSecondary()?.getEncryptionPublicKey(atSign);
-      expect(at_demos.encryptionPublicKeyMap[atSign], encryptionPublicKey);
     });
 
     tearDown(() async {

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -165,6 +165,7 @@ AtOnboardingPreference getPreferences(String atSign) {
     ..rootDomain = 'vip.ve.atsign.zone'
     ..isLocalStoreRequired = true
     ..hiveStoragePath = 'storage/hive/client'
+    ..namespace = 'functional_tests'
     ..commitLogPath = 'storage/hive/client/commit'
     ..privateKey = null
     ..cramSecret = at_demos.cramKeyMap[atSign]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
partially resolves https://github.com/atsign-foundation/at_client_sdk/issues/1075

**- What I did**
- Resolve sync conflict caused by encryptionPublicKey
- Make namespace mandatory for authentication

**- How I did it**
- do not insert pkamPublicKey and encryptionPublicKey into LocalSecondary
- throw an exception when namespace is not provided during authentication

**- How to verify it**
- test yet to come

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Make namespace mandatory for authentication