### PR TITLE
feat: at_lookup apkam changes

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.39
+- feat: Changes for apkam
+- chore: Upgraded at_commons to 3.0.53 and at_utils to 3.0.15
 ## 3.0.38
 - fix: wrap socket.listen in runZonedGuarded to ensure weird network errors are
   always caught

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -26,9 +26,13 @@ abstract class AtLookUp {
 
   Future<String?> executeVerb(VerbBuilder builder, {bool sync = false});
 
+  Future<String?> executeCommand(String command, {bool auth = false});
+
   /// performs a PKAM authentication using private key on the client side and public key on secondary server
+  /// Pkam private key should be set in  [atChops.atChopsKeys]
   /// Default signing algorithm for pkam signature is [SigningAlgoType.rsa2048] and default hashing algorithm is [HashingAlgoType.sha256]
-  Future<bool> pkamAuthenticate();
+  /// Optionally pass enrollmentId if the client is enrolled using APKAM
+  Future<bool> pkamAuthenticate({String? enrollmentId});
 
   /// set an instance of  [AtChops] for signing and verification operations.
   set atChops(AtChops? atChops);
@@ -48,4 +52,9 @@ abstract class AtLookUp {
   set hashingAlgoType(HashingAlgoType hashingAlgoType);
 
   HashingAlgoType get hashingAlgoType;
+
+  /// EnrollmentId has to be set for clients that are enrolled through APKAM.
+  set enrollmentId(String? enrollmentId);
+
+  String? get enrollmentId;
 }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.38
+version: 3.0.39
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -12,12 +12,20 @@ dependencies:
   path: ^1.8.0
   crypton: ^2.0.1
   crypto: ^3.0.1
-  at_utils: ^3.0.12
-  at_commons: ^3.0.43
+  at_utils: ^3.0.15
+  at_commons: ^3.0.53
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
   at_chops: ^1.0.3
+
+dependency_overrides:
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_chops
+      ref: atchops_apkam_changes
+
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -17,15 +17,7 @@ dependencies:
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
-  at_chops: ^1.0.3
-
-dependency_overrides:
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_chops
-      ref: atchops_apkam_changes
-
+  at_chops: ^1.0.4
 
 dev_dependencies:
   lints: ^1.0.1

--- a/packages/at_lookup/test/at_lookup_test.dart
+++ b/packages/at_lookup/test/at_lookup_test.dart
@@ -1,0 +1,305 @@
+import 'dart:io';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:at_utils/at_logger.dart';
+
+import 'connection_management_test.dart';
+
+class MockOutboundConnectionImpl extends Mock
+    implements OutboundConnectionImpl {}
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+class MockOutboundMessageListener extends Mock
+    implements OutboundMessageListener {}
+
+late int mockSocketNumber;
+
+class MockSecureSocket extends Mock implements SecureSocket {
+  bool destroyed = false;
+  int mockNumber = mockSocketNumber++;
+}
+
+class MockSecureSocketFactory extends Mock
+    implements AtLookupSecureSocketFactory {}
+
+class MockSecureSocketListenerFactory extends Mock
+    implements AtLookupSecureSocketListenerFactory {}
+
+class MockOutboundConnectionFactory extends Mock
+    implements AtLookupOutboundConnectionFactory {}
+
+class MockAtChops extends Mock implements AtChopsImpl {}
+
+class FakeAtSigningInput extends Fake implements AtSigningInput {}
+
+SecureSocket createMockSecureSocket() {
+  SecureSocket mss = MockSecureSocket();
+  when(() => mss.destroy()).thenAnswer((invocation) {
+    (mss as MockSecureSocket).destroyed = true;
+  });
+  when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
+  when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
+  when(() => mss.remotePort).thenReturn(12345);
+  when(() => mss.listen(any(),
+      onError: any(named: "onError"),
+      onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());
+  return mss;
+}
+
+void main() {
+  AtSignLogger.root_level = 'finest';
+  mockSocketNumber = 1;
+  late OutboundConnection mockOutBoundConnection;
+  late SecondaryAddressFinder mockSecondaryAddressFinder;
+  late OutboundMessageListener mockOutboundListener;
+  late AtLookupSecureSocketFactory mockSocketFactory;
+  late AtLookupSecureSocketListenerFactory mockSecureSocketListenerFactory;
+  late AtLookupOutboundConnectionFactory mockOutboundConnectionFactory;
+
+  late AtChops mockAtChops;
+  late SecureSocket mockSecureSocket;
+
+  setUp(() {
+    mockOutBoundConnection = MockOutboundConnectionImpl();
+    mockSecondaryAddressFinder = MockSecondaryAddressFinder();
+    mockOutboundListener = MockOutboundMessageListener();
+    mockSocketFactory = MockSecureSocketFactory();
+    mockSecureSocketListenerFactory = MockSecureSocketListenerFactory();
+    mockOutboundConnectionFactory = MockOutboundConnectionFactory();
+    mockAtChops = MockAtChops();
+    registerFallbackValue(SecureSocketConfig());
+    mockSecureSocket = createMockSecureSocket();
+
+    when(() => mockSecondaryAddressFinder.findSecondary('@alice'))
+        .thenAnswer((_) async {
+      return SecondaryAddress('127.0.0.1', 12345);
+    });
+    when(() => mockSocketFactory.createSocket('127.0.0.1', '12345', any()))
+        .thenAnswer((invocation) {
+      print('Mock SecureSocketFactory returning mock socket');
+      return Future<SecureSocket>.value(mockSecureSocket);
+    });
+    when(() => mockOutboundConnectionFactory
+        .createOutboundConnection(mockSecureSocket)).thenAnswer((invocation) {
+      print('Creating mock outbound connection');
+      return mockOutBoundConnection;
+    });
+    when(() => mockSecureSocketListenerFactory
+        .createListener(mockOutBoundConnection)).thenAnswer((invocation) {
+      print('creating mock outbound listener');
+      return mockOutboundListener;
+    });
+    when(() => mockOutBoundConnection.write('from:@alice\n'))
+        .thenAnswer((invocation) {
+      mockSecureSocket.write('from:@alice\n');
+      return Future.value();
+    });
+  });
+
+  group('A group of tests to verify atlookup pkam authentication', () {
+    test('pkam auth without enrollmentId - auth success', () async {
+      final pkamSignature =
+          'MbNbIwCSxsHxm4CHyakSE2yLqjjtnmzpSLPcGG7h+4M/GQAiJkklQfd/x9z58CSJfuSW8baIms26SrnmuYePZURfp5oCqtwRpvt+l07Gnz8aYpXH0k5qBkSR34SBk4nb+hdAjsXXgfWWC56gROPMwpOEbuDS6esU7oku+a7Rdr10xrFlk1Tf2eRwPOMWyuKwOvLwSgyq/INAFRYav5RmLFiecQhPME6ssc1jW92wztylKBtuZT4rk8787b6Z9StxT4dPZzWjfV1+oYDLaqu2PcQS2ZthH+Wj8NgoogDxSP+R7BE1FOVJKnavpuQWeOqNWeUbKkSVP0B0DN6WopAdsg==';
+
+      AtSigningResult mockSigningResult = AtSigningResult()
+        ..result = 'mock_signing_result';
+      registerFallbackValue(FakeAtSigningInput());
+      when(() => mockAtChops.sign(any())).thenAnswer((_) => mockSigningResult);
+
+      when(() => mockAtChops.sign(any()))
+          .thenReturn(AtSigningResult()..result = pkamSignature);
+      when(() => mockOutboundListener.read())
+          .thenAnswer((_) => Future.value('data:success'));
+
+      when(() => mockOutBoundConnection.getMetaData())
+          .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
+      when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+
+      when(() => mockOutBoundConnection.write(
+              'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:$pkamSignature\n'))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(
+            'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:$pkamSignature\n');
+        return Future.value();
+      });
+
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      var result = await atLookup.pkamAuthenticate();
+      expect(result, true);
+    });
+
+    test('pkam auth without enrollmentId - auth failed', () async {
+      final pkamSignature =
+          'MbNbIwCSxsHxm4CHyakSE2yLqjjtnmzpSLPcGG7h+4M/GQAiJkklQfd/x9z58CSJfuSW8baIms26SrnmuYePZURfp5oCqtwRpvt+l07Gnz8aYpXH0k5qBkSR34SBk4nb+hdAjsXXgfWWC56gROPMwpOEbuDS6esU7oku+a7Rdr10xrFlk1Tf2eRwPOMWyuKwOvLwSgyq/INAFRYav5RmLFiecQhPME6ssc1jW92wztylKBtuZT4rk8787b6Z9StxT4dPZzWjfV1+oYDLaqu2PcQS2ZthH+Wj8NgoogDxSP+R7BE1FOVJKnavpuQWeOqNWeUbKkSVP0B0DN6WopAdsg==';
+
+      AtSigningResult mockSigningResult = AtSigningResult()
+        ..result = 'mock_signing_result';
+      registerFallbackValue(FakeAtSigningInput());
+      when(() => mockAtChops.sign(any())).thenAnswer((_) => mockSigningResult);
+
+      when(() => mockAtChops.sign(any()))
+          .thenReturn(AtSigningResult()..result = pkamSignature);
+      when(() => mockOutboundListener.read()).thenAnswer((_) =>
+          Future.value('error:AT0401-Exception: pkam authentication failed'));
+
+      when(() => mockOutBoundConnection.getMetaData())
+          .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
+      when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+
+      when(() => mockOutBoundConnection.write(
+              'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:$pkamSignature\n'))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(
+            'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:$pkamSignature\n');
+        return Future.value();
+      });
+
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      expect(() async => await atLookup.pkamAuthenticate(),
+          throwsA(predicate((e) => e is UnAuthenticatedException)));
+    });
+
+    test('pkam auth with enrollmentId - auth success', () async {
+      final pkamSignature =
+          'MbNbIwCSxsHxm4CHyakSE2yLqjjtnmzpSLPcGG7h+4M/GQAiJkklQfd/x9z58CSJfuSW8baIms26SrnmuYePZURfp5oCqtwRpvt+l07Gnz8aYpXH0k5qBkSR34SBk4nb+hdAjsXXgfWWC56gROPMwpOEbuDS6esU7oku+a7Rdr10xrFlk1Tf2eRwPOMWyuKwOvLwSgyq/INAFRYav5RmLFiecQhPME6ssc1jW92wztylKBtuZT4rk8787b6Z9StxT4dPZzWjfV1+oYDLaqu2PcQS2ZthH+Wj8NgoogDxSP+R7BE1FOVJKnavpuQWeOqNWeUbKkSVP0B0DN6WopAdsg==';
+      final enrollmentIdFromServer = '5a21feb4-dc04-4603-829c-15f523789170';
+      AtSigningResult mockSigningResult = AtSigningResult()
+        ..result = 'mock_signing_result';
+      registerFallbackValue(FakeAtSigningInput());
+      when(() => mockAtChops.sign(any())).thenAnswer((_) => mockSigningResult);
+
+      when(() => mockAtChops.sign(any()))
+          .thenReturn(AtSigningResult()..result = pkamSignature);
+      when(() => mockOutboundListener.read())
+          .thenAnswer((_) => Future.value('data:success'));
+
+      when(() => mockOutBoundConnection.getMetaData())
+          .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
+      when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+
+      when(() => mockOutBoundConnection.write(
+              'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:enrollmentId:$enrollmentIdFromServer:$pkamSignature\n'))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(
+            'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:enrollmentId:$enrollmentIdFromServer:$pkamSignature\n');
+        return Future.value();
+      });
+
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      var result =
+          await atLookup.pkamAuthenticate(enrollmentId: enrollmentIdFromServer);
+      expect(result, true);
+    });
+
+    test('pkam auth with enrollmentId - auth failed', () async {
+      final pkamSignature =
+          'MbNbIwCSxsHxm4CHyakSE2yLqjjtnmzpSLPcGG7h+4M/GQAiJkklQfd/x9z58CSJfuSW8baIms26SrnmuYePZURfp5oCqtwRpvt+l07Gnz8aYpXH0k5qBkSR34SBk4nb+hdAjsXXgfWWC56gROPMwpOEbuDS6esU7oku+a7Rdr10xrFlk1Tf2eRwPOMWyuKwOvLwSgyq/INAFRYav5RmLFiecQhPME6ssc1jW92wztylKBtuZT4rk8787b6Z9StxT4dPZzWjfV1+oYDLaqu2PcQS2ZthH+Wj8NgoogDxSP+R7BE1FOVJKnavpuQWeOqNWeUbKkSVP0B0DN6WopAdsg==';
+      final enrollmentIdFromServer = '5a21feb4-dc04-4603-829c-15f523789170';
+      AtSigningResult mockSigningResult = AtSigningResult()
+        ..result = 'mock_signing_result';
+      registerFallbackValue(FakeAtSigningInput());
+      when(() => mockAtChops.sign(any())).thenAnswer((_) => mockSigningResult);
+
+      when(() => mockAtChops.sign(any()))
+          .thenReturn(AtSigningResult()..result = pkamSignature);
+      when(() => mockOutboundListener.read()).thenAnswer((_) =>
+          Future.value('error:AT0401-Exception: pkam authentication failed'));
+
+      when(() => mockOutBoundConnection.getMetaData())
+          .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
+      when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+
+      when(() => mockOutBoundConnection.write(
+              'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:enrollmentId:$enrollmentIdFromServer:$pkamSignature\n'))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(
+            'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:enrollmentId:$enrollmentIdFromServer:$pkamSignature\n');
+        return Future.value();
+      });
+
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      expect(
+          () async => await atLookup.pkamAuthenticate(
+              enrollmentId: enrollmentIdFromServer),
+          throwsA(predicate((e) =>
+              e is UnAuthenticatedException && e.message.contains('AT0401'))));
+    });
+  });
+  group('A group of tests to verify executeCommand method', () {
+    test('executeCommand - from verb - auth false', () async {
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      final fromResponse =
+          'data:_03fe0ff2-ac50-4c80-8f43-88480beba888@alice:c3d345fc-5691-4f90-bc34-17cba31f060f';
+      when(() => mockOutboundListener.read())
+          .thenAnswer((_) => Future.value(fromResponse));
+      var result = await atLookup.executeCommand('from:@alice\n');
+      expect(result, fromResponse);
+    });
+    test('executeCommand -llookup verb - auth true - auth key not set',
+        () async {
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      final fromResponse = 'data:1234';
+      when(() => mockOutboundListener.read())
+          .thenAnswer((_) => Future.value(fromResponse));
+      expect(
+          () async => await atLookup.executeCommand('llookup:phone@alice\n',
+              auth: true),
+          throwsA(predicate((e) => e is UnAuthenticatedException)));
+    });
+
+    test('executeCommand -llookup verb - auth true - at_chops set', () async {
+      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      final llookupCommand = 'llookup:phone@alice\n';
+      final llookupResponse = 'data:1234';
+      when(() => mockOutBoundConnection.write(llookupCommand))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(llookupCommand);
+        return Future.value();
+      });
+      when(() => mockOutboundListener.read())
+          .thenAnswer((_) => Future.value(llookupResponse));
+      var result = await atLookup.executeCommand(llookupCommand);
+      expect(result, llookupResponse);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
- apkam changes in at_lookup
**- How I did it**
- added an optional parameter enrollmentId to pkamAuthenticate method in at_lookup
- added getter/setter for enrollmentId in at_lookup which will be used in at_client - remote_secondary,monitor for setting enrollmentId
- introduced PkamVerbBuilder for constructing pkam command in at_lookup_impl.dart
- added executeCommand to at_lookup interface
**- How to verify it**
- added dependency overrides in at_client and verify github actions run
https://github.com/atsign-foundation/at_client_sdk/pull/1107

TODO
- Replace at_chops dependency overrides with published version