### PR TITLE
fix: Update totp verb

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.54
 - fix: Modify "totp" verb regex to include alpha-numeric characters
+- feat: Introduce "EnrollResponse" class which represents the enrollment response.
 ## 3.0.53
 - feat: Modify "enroll" verb regex.
 - feat: Introduce "EnrollParams" class to encapsulate enrollment attributes.

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.54
+- fix: Modify "totp" verb regex to include alpha-numeric characters
 ## 3.0.53
 - feat: Modify "enroll" verb regex.
 - feat: Introduce "EnrollParams" class to encapsulate enrollment attributes.

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -36,5 +36,6 @@ export 'package:at_commons/src/verb/update_json.dart';
 export 'package:at_commons/src/verb/verb_util.dart';
 export 'package:at_commons/src/auth/auth_mode.dart';
 export 'package:at_commons/src/verb/enroll_params.dart';
+export 'package:at_commons/src/enroll/enrollment.dart';
 @experimental
 export 'package:at_commons/src/telemetry/at_telemetry.dart';

--- a/packages/at_commons/lib/src/enroll/enrollment.dart
+++ b/packages/at_commons/lib/src/enroll/enrollment.dart
@@ -1,0 +1,28 @@
+class EnrollResponse {
+  String enrollmentId;
+  EnrollStatus enrollStatus;
+
+  EnrollResponse(this.enrollmentId, this.enrollStatus);
+
+  @override
+  String toString() {
+    return 'EnrollResponse{enrollmentId: $enrollmentId, enrollStatus: $enrollStatus}';
+  }
+}
+
+enum EnrollStatus { pending, approved, denied, revoked }
+
+EnrollStatus getEnrollStatusFromString(String value) {
+  switch (value) {
+    case 'approved':
+      return EnrollStatus.approved;
+    case 'denied':
+      return EnrollStatus.denied;
+    case 'pending':
+      return EnrollStatus.pending;
+    case 'revoked':
+      return EnrollStatus.revoked;
+    default:
+      throw ArgumentError('Unknown enroll status string: $value');
+  }
+}

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -7,7 +7,7 @@ class EnrollParams {
   String? appName;
   String? deviceName;
   Map<String, String>? namespaces;
-  String? totp;
+  String? otp;
   String? encryptedDefaultEncryptedPrivateKey;
   String? encryptedDefaultSelfEncryptionKey;
   String? encryptedAPKAMSymmetricKey;

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -14,7 +14,7 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..namespaces = (json['namespaces'] as Map<String, dynamic>?)?.map(
     (k, e) => MapEntry(k, e as String),
   )
-  ..totp = json['totp']
+  ..otp = json['otp'] as String?
   ..encryptedDefaultEncryptedPrivateKey =
       json['encryptedDefaultEncryptedPrivateKey'] as String?
   ..encryptedDefaultSelfEncryptionKey =
@@ -28,7 +28,7 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'appName': instance.appName,
       'deviceName': instance.deviceName,
       'namespaces': instance.namespaces,
-      'totp': instance.totp,
+      'otp': instance.otp,
       'encryptedDefaultEncryptedPrivateKey':
           instance.encryptedDefaultEncryptedPrivateKey,
       'encryptedDefaultSelfEncryptionKey':

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -22,9 +22,9 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// Public key of an asymmetric key pair generated on the app or client.
   String? apkamPublicKey;
 
-  /// totp for the enroll request. totp must be fetched from an already enrolled app.
+  /// otp for the enroll request. otp must be fetched from an already enrolled app.
   @experimental
-  String? totp;
+  String? otp;
 
   Map<String, String>? namespaces;
 
@@ -43,7 +43,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
           ..appName = appName
           ..deviceName = deviceName
           ..apkamPublicKey = apkamPublicKey
-          ..totp = totp
+          ..otp = otp
           ..namespaces = namespaces
           ..encryptedDefaultEncryptedPrivateKey =
               encryptedDefaultEncryptedPrivateKey
@@ -66,7 +66,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
         deviceName != null &&
         namespaces != null &&
         namespaces!.isNotEmpty &&
-        totp != null &&
+        otp != null &&
         apkamPublicKey != null;
   }
 }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -129,7 +129,7 @@ class VerbSyntax {
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
       r'^enroll:(?<operation>(?:list$|(request|approve|deny|revoke)))(?::)?(?<enrollParams>.+)?$';
-  static const totp = r'^totp:(?<operation>get|validate)(:(?<totp>[0-9]+))?$';
+  static const totp = r'^totp:(?<operation>get|validate)(:(?<otp>\w+))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'
       r'(?:(?<visibility>public|private|self):?)?'
       r'(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?'

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -129,7 +129,7 @@ class VerbSyntax {
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
       r'^enroll:(?<operation>(?:list$|(request|approve|deny|revoke)))(?::)?(?<enrollParams>.+)?$';
-  static const totp = r'^totp:(?<operation>get|validate)(:(?<otp>\w+))?$';
+  static const otp = r'^otp:(?<operation>get|validate)(:(?<otp>\w+))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'
       r'(?:(?<visibility>public|private|self):?)?'
       r'(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.53
+version: 3.0.54
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -92,7 +92,7 @@ void main() {
           'dummy_encrypted_private_key';
       enrollParamsMap['encryptedDefaultSelfEncryptionKey'] =
           'dummy_self_encryption_key';
-      enrollParamsMap['totp'] = '123';
+      enrollParamsMap['otp'] = '123';
 
       var enrollParams = EnrollParams.fromJson(enrollParamsMap);
       expect(enrollParams.appName, 'wavi');
@@ -104,7 +104,7 @@ void main() {
           'dummy_encrypted_private_key');
       expect(enrollParams.encryptedDefaultSelfEncryptionKey,
           'dummy_self_encryption_key');
-      expect(enrollParams.totp, '123');
+      expect(enrollParams.otp, '123');
       expect(enrollParams.namespaces, {'wavi': 'rw', '__manage': 'r'});
     });
   });

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -300,18 +300,18 @@ void main() {
     });
   });
 
-  group('A group of tests related to totp verb', () {
-    test('A test to verify totp verb for get operation', () {
-      String command = 'totp:get\n';
+  group('A group of tests related to otp verb', () {
+    test('A test to verify otp verb for get operation', () {
+      String command = 'otp:get\n';
       var enrollVerbParams =
-          VerbUtil.getVerbParam(VerbSyntax.totp, command.trim())!;
+          VerbUtil.getVerbParam(VerbSyntax.otp, command.trim())!;
       expect(enrollVerbParams['operation'], 'get');
     });
 
-    test('A test to verify totp verb for validate operation', () {
-      String command = 'totp:validate:ABC123\n';
+    test('A test to verify otp verb for validate operation', () {
+      String command = 'otp:validate:ABC123\n';
       var enrollVerbParams =
-          VerbUtil.getVerbParam(VerbSyntax.totp, command.trim());
+          VerbUtil.getVerbParam(VerbSyntax.otp, command.trim());
       expect(enrollVerbParams!['operation'], 'validate');
       expect(enrollVerbParams['otp'], 'ABC123');
     });

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -299,6 +299,23 @@ void main() {
               e.message == 'command does not match the regex')));
     });
   });
+
+  group('A group of tests related to totp verb', () {
+    test('A test to verify totp verb for get operation', () {
+      String command = 'totp:get\n';
+      var enrollVerbParams =
+          VerbUtil.getVerbParam(VerbSyntax.totp, command.trim())!;
+      expect(enrollVerbParams['operation'], 'get');
+    });
+
+    test('A test to verify totp verb for validate operation', () {
+      String command = 'totp:validate:ABC123\n';
+      var enrollVerbParams =
+          VerbUtil.getVerbParam(VerbSyntax.totp, command.trim());
+      expect(enrollVerbParams!['operation'], 'validate');
+      expect(enrollVerbParams['otp'], 'ABC123');
+    });
+  });
 }
 
 Map getVerbParams(String regex, String command) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Update the "TOTP" regex to include alpha-numeric characters in the OTP named group.
- Add "EnrollResponse" class to represent the enrollment response.

**- How I did it**
- Replace the `[0-9]` with `\w` to include alpha-numeric characters.

**- How to verify it**
- The unit tests should pass.

**- Description for the changelog**
- Update "TOTP" verb regex.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->