### PR TITLE
feat: make atServer address lookup resilient to transient failures to reach atDirectory

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.40
+- feat: make atServer address lookup resilient to transient failures to reach
+  atDirectory
 ## 3.0.39
 - feat: Changes for apkam
 - chore: Upgraded at_commons to 3.0.53 and at_utils to 3.0.15

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 3.0.40
-- feat: make atServer address lookup resilient to transient failures to reach
-  atDirectory
+- feat: make `SecondaryUrlFinder` (atServer address lookup) resilient to 
+  transient failures to reach an atDirectory
+- feat: made `retryDelaysMillis` a public static variable
+  in `SecondaryUrlFinder`; this allows clients to control
+  - (1) how many retries are done and
+  - (2) the delay after each subsequent retry
 ## 3.0.39
 - feat: Changes for apkam
 - chore: Upgraded at_commons to 3.0.53 and at_utils to 3.0.15

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -19,9 +19,8 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
 
   CacheableSecondaryAddressFinder(this._rootDomain, this._rootPort,
       {SecondaryUrlFinder? secondaryFinder}) {
-    _secondaryFinder = secondaryFinder ??
-        SecondaryUrlFinder(
-            _rootDomain, _rootPort, AtLookupSecureSocketFactory());
+    _secondaryFinder =
+        secondaryFinder ?? SecondaryUrlFinder(_rootDomain, _rootPort);
   }
 
   bool cacheContains(String atSign) {
@@ -129,9 +128,11 @@ class SecondaryAddressCacheEntry {
 class SecondaryUrlFinder {
   final String _rootDomain;
   final int _rootPort;
-  final AtLookupSecureSocketFactory socketFactory;
+  late final AtLookupSecureSocketFactory _socketFactory;
 
-  SecondaryUrlFinder(this._rootDomain, this._rootPort, this.socketFactory);
+  SecondaryUrlFinder(this._rootDomain, this._rootPort, {AtLookupSecureSocketFactory? socketFactory}) {
+    _socketFactory = socketFactory ?? AtLookupSecureSocketFactory();
+  }
 
   final _logger = AtSignLogger('SecondaryUrlFinder');
 
@@ -184,7 +185,7 @@ class SecondaryUrlFinder {
       var prompt = false;
       var once = true;
 
-      socket = await socketFactory.createSocket(
+      socket = await _socketFactory.createSocket(
           _rootDomain, '$_rootPort', SecureSocketConfig());
 
       // listen to the received data event stream

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.39
+version: 3.0.40
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_lookup/test/at_lookup_test.dart
+++ b/packages/at_lookup/test/at_lookup_test.dart
@@ -24,6 +24,9 @@ void main() {
   late AtChops mockAtChops;
   late SecureSocket mockSecureSocket;
 
+  String atServerHost = '127.0.0.1';
+  int atServerPort = 12345;
+
   setUp(() {
     mockOutBoundConnection = MockOutboundConnectionImpl();
     mockSecondaryAddressFinder = MockSecondaryAddressFinder();
@@ -33,15 +36,14 @@ void main() {
     mockOutboundConnectionFactory = MockOutboundConnectionFactory();
     mockAtChops = MockAtChops();
     registerFallbackValue(SecureSocketConfig());
-    mockSecureSocket = createMockSecureSocket();
+    mockSecureSocket = createMockAtServerSocket(atServerHost, atServerPort);
 
     when(() => mockSecondaryAddressFinder.findSecondary('@alice'))
         .thenAnswer((_) async {
-      return SecondaryAddress('127.0.0.1', 12345);
+      return SecondaryAddress(atServerHost, atServerPort);
     });
-    when(() => mockSocketFactory.createSocket('127.0.0.1', '12345', any()))
+    when(() => mockSocketFactory.createSocket(atServerHost, '12345', any()))
         .thenAnswer((invocation) {
-      print('Mock SecureSocketFactory returning mock socket');
       return Future<SecureSocket>.value(mockSecureSocket);
     });
     when(() => mockOutboundConnectionFactory
@@ -88,7 +90,7 @@ void main() {
         return Future.value();
       });
 
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -124,7 +126,7 @@ void main() {
         return Future.value();
       });
 
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -160,7 +162,7 @@ void main() {
         return Future.value();
       });
 
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -197,7 +199,7 @@ void main() {
         return Future.value();
       });
 
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -212,7 +214,7 @@ void main() {
   });
   group('A group of tests to verify executeCommand method', () {
     test('executeCommand - from verb - auth false', () async {
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -226,7 +228,7 @@ void main() {
     });
     test('executeCommand -llookup verb - auth true - auth key not set',
         () async {
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,
@@ -241,7 +243,7 @@ void main() {
     });
 
     test('executeCommand -llookup verb - auth true - at_chops set', () async {
-      final atLookup = AtLookupImpl('@alice', '127.0.0.1', 64,
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
           secondaryAddressFinder: mockSecondaryAddressFinder,
           secureSocketFactory: mockSocketFactory,
           socketListenerFactory: mockSecureSocketListenerFactory,

--- a/packages/at_lookup/test/at_lookup_test.dart
+++ b/packages/at_lookup/test/at_lookup_test.dart
@@ -8,54 +8,12 @@ import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:at_utils/at_logger.dart';
 
-import 'connection_management_test.dart';
-
-class MockOutboundConnectionImpl extends Mock
-    implements OutboundConnectionImpl {}
-
-class MockSecondaryAddressFinder extends Mock
-    implements SecondaryAddressFinder {}
-
-class MockOutboundMessageListener extends Mock
-    implements OutboundMessageListener {}
-
-late int mockSocketNumber;
-
-class MockSecureSocket extends Mock implements SecureSocket {
-  bool destroyed = false;
-  int mockNumber = mockSocketNumber++;
-}
-
-class MockSecureSocketFactory extends Mock
-    implements AtLookupSecureSocketFactory {}
-
-class MockSecureSocketListenerFactory extends Mock
-    implements AtLookupSecureSocketListenerFactory {}
-
-class MockOutboundConnectionFactory extends Mock
-    implements AtLookupOutboundConnectionFactory {}
-
-class MockAtChops extends Mock implements AtChopsImpl {}
+import 'at_lookup_test_utils.dart';
 
 class FakeAtSigningInput extends Fake implements AtSigningInput {}
 
-SecureSocket createMockSecureSocket() {
-  SecureSocket mss = MockSecureSocket();
-  when(() => mss.destroy()).thenAnswer((invocation) {
-    (mss as MockSecureSocket).destroyed = true;
-  });
-  when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
-  when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
-  when(() => mss.remotePort).thenReturn(12345);
-  when(() => mss.listen(any(),
-      onError: any(named: "onError"),
-      onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());
-  return mss;
-}
-
 void main() {
   AtSignLogger.root_level = 'finest';
-  mockSocketNumber = 1;
   late OutboundConnection mockOutBoundConnection;
   late SecondaryAddressFinder mockSecondaryAddressFinder;
   late OutboundMessageListener mockOutboundListener;

--- a/packages/at_lookup/test/at_lookup_test_utils.dart
+++ b/packages/at_lookup/test/at_lookup_test_utils.dart
@@ -37,14 +37,14 @@ class MockAtChops extends Mock implements AtChopsImpl {}
 class MockOutboundConnectionImpl extends Mock
     implements OutboundConnectionImpl {}
 
-SecureSocket createMockSecureSocket() {
+SecureSocket createMockAtServerSocket(String address, int port) {
   SecureSocket mss = MockSecureSocket();
   when(() => mss.destroy()).thenAnswer((invocation) {
     (mss as MockSecureSocket).destroyed = true;
   });
   when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
-  when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
-  when(() => mss.remotePort).thenReturn(12345);
+  when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.66'));
+  when(() => mss.remotePort).thenReturn(port);
   when(() => mss.listen(any(),
       onError: any(named: "onError"),
       onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());

--- a/packages/at_lookup/test/at_lookup_test_utils.dart
+++ b/packages/at_lookup/test/at_lookup_test_utils.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+import 'package:mocktail/mocktail.dart';
+
+int mockSocketNumber = 1;
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+class MockSecondaryUrlFinder extends Mock implements SecondaryUrlFinder {}
+
+class MockSecureSocketFactory extends Mock
+    implements AtLookupSecureSocketFactory {}
+
+class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
+
+class MockSecureSocket extends Mock implements SecureSocket {
+  bool destroyed = false;
+  int mockNumber = mockSocketNumber++;
+}
+
+class MockSecureSocketListenerFactory extends Mock
+    implements AtLookupSecureSocketListenerFactory {}
+
+class MockOutboundConnectionFactory extends Mock
+    implements AtLookupOutboundConnectionFactory {}
+
+class MockOutboundMessageListener extends Mock
+    implements OutboundMessageListener {}
+
+class MockAtChops extends Mock implements AtChopsImpl {}
+
+class MockOutboundConnectionImpl extends Mock
+    implements OutboundConnectionImpl {}
+
+SecureSocket createMockSecureSocket() {
+  SecureSocket mss = MockSecureSocket();
+  when(() => mss.destroy()).thenAnswer((invocation) {
+    (mss as MockSecureSocket).destroyed = true;
+  });
+  when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
+  when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
+  when(() => mss.remotePort).thenReturn(12345);
+  when(() => mss.listen(any(),
+      onError: any(named: "onError"),
+      onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());
+  return mss;
+}

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -30,8 +30,7 @@ void main() {
       when(() =>
               mockSocketFactory.createSocket('test.test.test', '12345', any()))
           .thenAnswer((invocation) {
-        print('Mock SecureSocketFactory returning mock socket');
-        return Future<SecureSocket>.value(createMockSecureSocket());
+        return Future<SecureSocket>.value(createMockAtServerSocket('test.test.test', 12345));
       });
     });
 
@@ -96,7 +95,7 @@ void main() {
     test(
         'test message listener closes connection'
         ' when socket listener onDone is called', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
@@ -108,7 +107,7 @@ void main() {
     test(
         'test message listener closes connection'
         ' when socket listener onError is called', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
@@ -118,7 +117,7 @@ void main() {
     });
 
     test('test can safely call connection.close() repeatedly', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
@@ -137,7 +136,7 @@ void main() {
     test(
         'test that OutboundMessageListener.closeConnection will call'
         ' connection.close if the connection is idle', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);
@@ -157,7 +156,7 @@ void main() {
     test(
         'test that OutboundMessageListener.closeConnection will not call'
         ' connection.close if already marked closed', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       oc.metaData!.isClosed = true;
@@ -171,7 +170,7 @@ void main() {
     test(
         'test that OutboundMessageListener.closeConnection will call'
         ' connection.close even if the connection is marked stale', () async {
-      OutboundConnection oc = OutboundConnectionImpl(createMockSecureSocket());
+      OutboundConnection oc = OutboundConnectionImpl(createMockAtServerSocket('test.test.test', 12345));
       OutboundMessageListener oml = OutboundMessageListener(oc);
       expect((oc.getSocket() as MockSecureSocket).destroyed, false);
       expect(oc.metaData?.isClosed, false);

--- a/packages/at_lookup/test/connection_management_test.dart
+++ b/packages/at_lookup/test/connection_management_test.dart
@@ -7,42 +7,15 @@ import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'at_lookup_test_utils.dart';
+
 class MockOutboundConnectionImpl extends Mock
     implements OutboundConnectionImpl {}
-
-late int mockSocketNumber;
-
-class MockSecureSocket extends Mock implements SecureSocket {
-  bool destroyed = false;
-  int mockNumber = mockSocketNumber++;
-}
-
-class MockSecondaryAddressFinder extends Mock
-    implements SecondaryAddressFinder {}
-
-class MockSecureSocketFactory extends Mock
-    implements AtLookupSecureSocketFactory {}
-
-class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
 
 void main() {
   group('test connection close and socket cleanup', () {
     late SecondaryAddressFinder finder;
     late MockSecureSocketFactory mockSocketFactory;
-
-    SecureSocket createMockSecureSocket() {
-      SecureSocket mss = MockSecureSocket();
-      when(() => mss.destroy()).thenAnswer((invocation) {
-        (mss as MockSecureSocket).destroyed = true;
-      });
-      when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
-      when(() => mss.remoteAddress).thenReturn(InternetAddress('127.0.0.1'));
-      when(() => mss.remotePort).thenReturn(12345);
-      when(() => mss.listen(any(),
-          onError: any(named: "onError"),
-          onDone: any(named: "onDone"))).thenReturn(MockStreamSubscription());
-      return mss;
-    }
 
     setUp(() {
       mockSocketNumber = 1;

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -6,8 +6,7 @@ import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockOutboundConnectionImpl extends Mock
-    implements OutboundConnectionImpl {}
+import 'at_lookup_test_utils.dart';
 
 void main() {
   OutboundConnection mockOutBoundConnection = MockOutboundConnectionImpl();

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -1,10 +1,11 @@
 import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/cache/cacheable_secondary_address_finder.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockSecondaryFinder extends Mock implements SecondaryUrlFinder {}
+import 'at_lookup_test_utils.dart';
 
 void main() async {
   group('this should be moved to functional tests', () {
@@ -22,7 +23,7 @@ void main() async {
     String rootDomain = 'root.atsign.unit.tests';
     int rootPort = 64;
 
-    SecondaryUrlFinder mockSecondaryFinder = MockSecondaryFinder();
+    SecondaryUrlFinder mockSecondaryFinder = MockSecondaryUrlFinder();
 
     String _addressFromAtSign(String atSign) {
       if (atSign.startsWith('@')) {
@@ -116,6 +117,19 @@ void main() async {
 //      await cache.findSecondary(atSign, refreshCacheNow: true);
 //      expect(cache.cacheContains(atSign), true);
 //    });
+  });
+
+  group('some cache tests with a real SecondaryUrlFinder non-existent or mocked root server', () {
+    test('test lookup of @alice on non-existent atDirectory', () async {
+      String atSign = '@alice';
+      CacheableSecondaryAddressFinder cache = CacheableSecondaryAddressFinder('root.no.no.no', 64);
+      expect(() async => await cache.findSecondary(atSign),
+          throwsA(predicate((e) => e is RootServerConnectivityException)));
+    });
+
+    test('test lookup of @alice with mocked atDirectory', () async {
+
+    });
   });
 
   group(

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -164,7 +164,7 @@ void main() async {
       cachingAtServerFinder = CacheableSecondaryAddressFinder(
           mockAtDirectoryHost, 64,
           secondaryFinder:
-          SecondaryUrlFinder(mockAtDirectoryHost, 64, mockSocketFactory));
+          SecondaryUrlFinder(mockAtDirectoryHost, 64, socketFactory: mockSocketFactory));
 
       numSocketCreateCalls = 0;
       when(() =>


### PR DESCRIPTION
closes #368 

**- What I did**
- feat: Added retry behaviour to `SecondaryUrlFinder`. If root lookup fails with an exception, the lookup will be retried up to four times, with default delays of 50, 100, 150 and 200 after each failure.
- feat: made `retryDelaysMillis` a public static variable in `SecondaryUrlFinder`; this allows clients to control (1) how many retries are done and (2) the delay after each subsequent retry

**- How I did it**
Note to reviewers: the 'real' changes are in `cacheable_secondary_address_finder.dart` and `secondary_address_cache_test.dart`. Changes to other test files are just the results of refactoring of some shared test code.

- modified `SecondaryUrlFinder` so that it will retry up to 4 (number of retries is configurable) times with delays of [50, 100, 150, 200] milliseconds respectively (these delays are configurable) in the event of some exception while creating a connection to the atDirectory
- modified `SecondaryUrlFinder` to allow injection of a socket factory, so we can test in unit tests
- add unit tests for atDirectory retry behaviour
  - full lookup on a non-existent atDirectory
  - lookup on a mocked atDirectory with 0, 1, 2, 3, 4 or 5 simulated failures
- docs: added some docs for SecondaryUrlFinder
- feat: made `retryDelaysMillis` a public static varaiable in SecondaryUrlFinder; this allows clients to control (1) how many retries are done and (2) the delay after each subsequent retry
- refactor unit tests
  - extract shared mock definitions into new file at_lookup_test_utils.dart
  - remove duplicates of the `createMockSecureSocket` function and moved into at_lookup_test_utils.dart
- refactor: more refactoring and tidying of shared test code

**- How to verify it**
- [x] Existing and new at_lookup tests pass
- at_client_sdk and at_server tests pass when using this at_lookup branch
  - [x] [at_client_sdk](https://github.com/atsign-foundation/at_client_sdk/pull/1115)
  - [x] [at_server](https://github.com/atsign-foundation/at_server/pull/1528)

