### PR TITLE
feat: at_chops changes for at_auth package

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.5
+- feat: Changes for at_auth package
+- chore: fixed analyzer issues
 ## 1.0.4
 - feat: Deprecated symmetric key pair in AtChopsKeys and introduced selfEncryptionKey and apkamSymmetricKey
 - chore: Upgrade at_commons to 3.0.53 and at_util to 3.0.15

--- a/packages/at_chops/lib/src/algorithm/aes_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/aes_encryption_algo.dart
@@ -29,6 +29,7 @@ class AESEncryptionAlgo implements SymmetricEncryptionAlgorithm {
     if (ivBytes != null) {
       return IV(ivBytes);
     }
-    return null;
+    // From the bad old days when we weren't setting IVs
+    return IV(Uint8List(16));
   }
 }

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -10,9 +10,11 @@ import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
 import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_chops/src/at_chops_base.dart';
+import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/impl/aes_key.dart';
 import 'package:at_chops/src/key/impl/at_chops_keys.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
+import 'package:at_chops/src/key/key_names.dart';
 import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_chops/src/metadata/at_signing_input.dart';
 import 'package:at_chops/src/metadata/encryption_metadata.dart';
@@ -274,9 +276,9 @@ class AtChopsImpl extends AtChops {
         // TODO: Handle this case.
         break;
       case EncryptionKeyType.aes128:
-        return AESEncryptionAlgo(atChopsKeys.symmetricKey! as AESKey);
+        return AESEncryptionAlgo(_getSymmetricKey(keyName)! as AESKey);
       case EncryptionKeyType.aes256:
-        return AESEncryptionAlgo(atChopsKeys.symmetricKey! as AESKey);
+        return AESEncryptionAlgo(_getSymmetricKey(keyName)! as AESKey);
       default:
         throw AtEncryptionException(
             'Cannot find encryption algorithm for encryption key type $encryptionKeyType');
@@ -289,6 +291,15 @@ class AtChopsImpl extends AtChops {
       return atChopsKeys.atEncryptionKeyPair!;
     }
     // #TODO plugin implementation for different keyNames
+    return null;
+  }
+
+  SymmetricKey? _getSymmetricKey(String? keyName) {
+    if (keyName == null || keyName == KeyNames.selfEncryptionKey) {
+      return atChopsKeys.selfEncryptionKey!;
+    } else if (keyName == KeyNames.apkamSymmetricKey) {
+      return atChopsKeys.apkamSymmetricKey!;
+    }
     return null;
   }
 

--- a/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
+++ b/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
@@ -17,7 +17,7 @@ class AtChopsKeys {
   SymmetricKey? get symmetricKey => selfEncryptionKey;
 
   @Deprecated('Use selfEncryptionKey')
-  void set symmetricKey(SymmetricKey? sk) => selfEncryptionKey = sk;
+  set symmetricKey(SymmetricKey? sk) => selfEncryptionKey = sk;
 
   /// Default self encryption key
   SymmetricKey? selfEncryptionKey;

--- a/packages/at_chops/lib/src/key/key_names.dart
+++ b/packages/at_chops/lib/src/key/key_names.dart
@@ -1,0 +1,4 @@
+class KeyNames {
+  static const String selfEncryptionKey = 'selfEncryptionKey';
+  static const String apkamSymmetricKey = 'apkamSymmetricKey';
+}

--- a/packages/at_chops/lib/src/metadata/at_signing_input.dart
+++ b/packages/at_chops/lib/src/metadata/at_signing_input.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/default_signing_algo.dart';

--- a/packages/at_chops/lib/src/util/at_chops_util.dart
+++ b/packages/at_chops/lib/src/util/at_chops_util.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/impl/aes_key.dart';
@@ -10,9 +12,17 @@ import 'package:encrypt/encrypt.dart';
 class AtChopsUtil {
   /// Generates a random initialisation vector from a given length
   /// Length must be 0 to 16
-  /// #TODO explain about implications of changing length
-  static InitialisationVector generateIV(int length) {
+  static InitialisationVector generateRandomIV(int length) {
     final iv = IV.fromSecureRandom(length);
+    return InitialisationVector(iv.bytes);
+  }
+
+  static InitialisationVector generateIVLegacy() {
+    return InitialisationVector(IV(Uint8List(16)).bytes);
+  }
+
+  static InitialisationVector generateIVFromBase64String(String ivBase64) {
+    final iv = IV.fromBase64(ivBase64);
     return InitialisationVector(iv.bytes);
   }
 

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:
@@ -21,3 +21,4 @@ dependencies:
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.16.0
+  collection: ^1.18.0

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
@@ -41,9 +40,9 @@ void main() {
     test('Test symmetric encrypt/decrypt bytes with initialisation vector', () {
       String data = 'Hello World';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
@@ -71,9 +70,9 @@ void main() {
     test('Test symmetric encrypt/decrypt bytes with emoji char', () {
       String data = 'Hello World🛠';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
@@ -101,9 +100,9 @@ void main() {
     test('Test symmetric encrypt/decrypt bytes with special chars', () {
       String data = 'Hello World🛠';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
           utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
@@ -132,9 +131,9 @@ void main() {
         () {
       String data = 'Hello World';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);
@@ -161,9 +160,9 @@ void main() {
     test('Test symmetric encrypt/decrypt string with special chars', () {
       String data = 'Hello``*+%';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);
@@ -190,9 +189,9 @@ void main() {
     test('Test symmetric encrypt/decrypt string with emoji', () {
       String data = 'Hello World🛠';
       final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
-      final atChopsKeys = AtChopsKeys.createSymmetric(aesKey);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
       final atChops = AtChopsImpl(atChopsKeys);
-      final iv = AtChopsUtil.generateIV(16);
+      final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult =
           atChops.encryptString(data, EncryptionKeyType.aes256, iv: iv);

--- a/packages/at_chops/test/at_chops_util_test.dart
+++ b/packages/at_chops/test/at_chops_util_test.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:at_chops/src/util/at_chops_util.dart';
+import 'package:encrypt/encrypt.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests for AtChopsUtil', () {
+    test('Test generate randomIV length', () {
+      var iv = AtChopsUtil.generateRandomIV(16);
+      expect(iv.ivBytes.length, 16);
+    });
+
+    test('Test generate randomIV - two different IVs', () {
+      var iv1 = AtChopsUtil.generateRandomIV(16);
+      var iv2 = AtChopsUtil.generateRandomIV(16);
+      expect(IV(iv1.ivBytes).base64 != IV(iv2.ivBytes).base64, true);
+    });
+
+    test('Test generate legacy IV length', () {
+      var iv = AtChopsUtil.generateIVLegacy();
+      expect(iv.ivBytes.length, 16);
+    });
+    test('Test generate legacy IV value', () {
+      var iv = AtChopsUtil.generateIVLegacy();
+      List<int> allZeroesList = [];
+      for (int i = 0; i < 16; i++) {
+        allZeroesList.add(0);
+      }
+
+      expect(ListEquality().equals(iv.ivBytes, allZeroesList), true);
+    });
+
+    test('Test generate IV from base64String', () {
+      var random = Random();
+      List<int> randomBytes =
+          List<int>.generate(16, (i) => random.nextInt(256));
+      var iv =
+          AtChopsUtil.generateIVFromBase64String(base64.encode(randomBytes));
+      expect(ListEquality().equals(iv.ivBytes, randomBytes), true);
+    });
+  });
+}

--- a/packages/at_chops/test/default_signing_algo_test.dart
+++ b/packages/at_chops/test/default_signing_algo_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
-import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 

--- a/packages/at_chops/test/pkam_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_signing_algo_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
-import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
**- What I did**
- made changes in at_chops for new at_auth package
**- How I did it**
- introduced few methods in at_chops_util.dart for IV generation
- in aes_encryption_algo returned IV will all zeroes(if input is null) to mimic old code behavior. Otherwise encryption will fail since IV is null
- removed callls to deprecated methods in at_chops_impl
- introduced keys_names.dart constant file and made change in at_chops_impl to return SymmetricKey based on keyName
**- How to verify it**
- run the unit tests
