### PR TITLE
feat: introduce cramAuthenticate and close into atLookup interface

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.41
+- feat: introduce methods cramAuthenticate and close into the AtLookup interface
+- deprecate: authenticate_cram() from AtLookupImpl. [cramAuthenticate should be used instead]
 ## 3.0.40
 - feat: make `SecondaryUrlFinder` (atServer address lookup) resilient to 
   transient failures to reach an atDirectory

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.41
 - feat: introduce methods cramAuthenticate and close into the AtLookup interface
 - deprecate: authenticate_cram() from AtLookupImpl. [cramAuthenticate should be used instead]
+- build(deps): Upgrade at_commons to v3.0.57 and at_chops to v1.0.5
 ## 3.0.40
 - feat: make `SecondaryUrlFinder` (atServer address lookup) resilient to 
   transient failures to reach an atDirectory

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -39,7 +39,7 @@ abstract class AtLookUp {
 
   /// Generates digest using from verb response and [secret] and performs a
   /// CRAM authentication to secondary server
-  Future<bool> cramAuthenticate(var secret);
+  Future<bool> cramAuthenticate(String secret);
 
   /// Terminates the underlying connection to the atServer
   /// used by this instance of AtLookup

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -28,11 +28,22 @@ abstract class AtLookUp {
 
   Future<String?> executeCommand(String command, {bool auth = false});
 
-  /// performs a PKAM authentication using private key on the client side and public key on secondary server
+  /// Performs a PKAM authentication using private key on the client side and public key on secondary server
+  ///
   /// Pkam private key should be set in  [atChops.atChopsKeys]
+  ///
   /// Default signing algorithm for pkam signature is [SigningAlgoType.rsa2048] and default hashing algorithm is [HashingAlgoType.sha256]
+  ///
   /// Optionally pass enrollmentId if the client is enrolled using APKAM
   Future<bool> pkamAuthenticate({String? enrollmentId});
+
+  /// Generates digest using from verb response and [secret] and performs a
+  /// CRAM authentication to secondary server
+  Future<bool> cramAuthenticate(var secret);
+
+  /// Terminates the underlying connection to the atServer
+  /// used by this instance of AtLookup
+  Future<void> close();
 
   /// set an instance of  [AtChops] for signing and verification operations.
   set atChops(AtChops? atChops);

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -493,11 +493,7 @@ class AtLookupImpl implements AtLookUp {
   final Mutex _cramAuthenticationMutex = Mutex();
 
   @override
-  Future<bool> cramAuthenticate(var secret) async {
-    secret ??= cramSecret;
-    if (secret == null) {
-      throw UnAuthenticatedException('Cram secret not passed');
-    }
+  Future<bool> cramAuthenticate(String secret) async {
     await createConnection();
     try {
       await _cramAuthenticationMutex.acquire();
@@ -534,8 +530,13 @@ class AtLookupImpl implements AtLookUp {
 
   @Deprecated('use AtLookup().cramAuthenticate()')
   // ignore: non_constant_identifier_names
-  Future<bool> authenticate_cram(var secret) async =>
-      await cramAuthenticate(secret);
+  Future<bool> authenticate_cram(var secret) async {
+    secret ??= cramSecret;
+    if (secret == null) {
+      throw UnAuthenticatedException('Cram secret not passed');
+    }
+    return await cramAuthenticate(secret);
+  }
 
   Future<String> _plookup(PLookupVerbBuilder builder) async {
     var atCommand = builder.buildCommand();
@@ -576,7 +577,7 @@ class AtLookupImpl implements AtLookUp {
           logger.finer('calling pkam without atchops');
           await authenticate(privateKey);
         } else if (cramSecret != null) {
-          await cramAuthenticate(cramSecret);
+          await cramAuthenticate(cramSecret!);
         } else {
           throw UnAuthenticatedException(
               'Unable to perform atLookup auth. Private key/cram secret is not set');

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -333,7 +333,7 @@ class AtLookupImpl implements AtLookUp {
 
   Future<String> _update(UpdateVerbBuilder builder) async {
     String atCommand;
-    if (builder.operation == UPDATE_META) {
+    if (builder.operation == AtConstants.updateMeta) {
       atCommand = builder.buildCommandForMeta();
     } else {
       atCommand = builder.buildCommand();
@@ -492,10 +492,8 @@ class AtLookupImpl implements AtLookUp {
 
   final Mutex _cramAuthenticationMutex = Mutex();
 
-  /// Generates digest using from verb response and [secret] and performs a CRAM authentication to
-  /// secondary server
-  // ignore: non_constant_identifier_names
-  Future<bool> authenticate_cram(var secret) async {
+  @override
+  Future<bool> cramAuthenticate(var secret) async {
     secret ??= cramSecret;
     if (secret == null) {
       throw UnAuthenticatedException('Cram secret not passed');
@@ -533,6 +531,11 @@ class AtLookupImpl implements AtLookUp {
       _cramAuthenticationMutex.release();
     }
   }
+
+  @Deprecated('use AtLookup().cramAuthenticate()')
+  // ignore: non_constant_identifier_names
+  Future<bool> authenticate_cram(var secret) async =>
+      await cramAuthenticate(secret);
 
   Future<String> _plookup(PLookupVerbBuilder builder) async {
     var atCommand = builder.buildCommand();
@@ -573,7 +576,7 @@ class AtLookupImpl implements AtLookUp {
           logger.finer('calling pkam without atchops');
           await authenticate(privateKey);
         } else if (cramSecret != null) {
-          await authenticate_cram(cramSecret);
+          await cramAuthenticate(cramSecret);
         } else {
           throw UnAuthenticatedException(
               'Unable to perform atLookup auth. Private key/cram secret is not set');
@@ -622,6 +625,7 @@ class AtLookupImpl implements AtLookUp {
     return _connection!.isInValid();
   }
 
+  @override
   Future<void> close() async {
     await _connection!.close();
   }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.40
+version: 3.0.41
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -13,11 +13,11 @@ dependencies:
   crypton: ^2.0.1
   crypto: ^3.0.1
   at_utils: ^3.0.15
-  at_commons: ^3.0.53
+  at_commons: ^3.0.57
   mutex: ^3.0.0
   mocktail: ^0.3.0
   meta: ^1.8.0
-  at_chops: ^1.0.4
+  at_chops: ^1.0.5
 
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/421
**- What I did**
- Introduce cramAuthenticate() and close() into AtLookup interface
- Deprecate method authenticate_cram from AtlookupImpl
- Upgrade dependencies at_commons to v3.0.57 and at_chops to v1.0.5

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: introduce cramAuthenticate and close into atLookup interface