### PR TITLE
feat: APKAM onboarding changes

### DIFF
--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -101,12 +101,13 @@ jobs:
         working-directory: tests/${{ matrix.package }}
         run: dart run check_docker_readiness.dart
 
-      - name: run pkamLoad on docker-image
-        run: sudo docker exec at_onboarding_cli_functional_tests_virtualenv_1 supervisorctl start pkamLoad
+#      commented since onboarding tests throw atsign already activated exception
+#      - name: run pkamLoad on docker-image
+#        run: sudo docker exec at_onboarding_cli_functional_tests_virtualenv_1 supervisorctl start pkamLoad
 
-      - name: Check test environment readiness
-        working-directory: tests/${{ matrix.package }}
-        run: dart run check_test_env.dart
+#      - name: Check test environment readiness
+#        working-directory: tests/${{ matrix.package }}
+#        run: dart run check_test_env.dart
 
       - name: run tests
         working-directory: tests/${{ matrix.package }}

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.41
+version: 3.0.38
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/example/README.md
+++ b/packages/at_onboarding_cli/example/README.md
@@ -1,0 +1,29 @@
+List of steps to run the examples for checking apkam enrollment
+
+1. Onboard an atsign which has privilege to approve/deny enrollments
+   dart example/onboard.dart <atsign> <path_store_keys_file>
+   e.g. dart example/onboard.dart @alice🛠 /home/alice/.atsign/@alice🛠_wavikey.atKeys
+2. Authenticate using the onboarded atsign
+   dart example/apkam_authenticate.dart <atsign> <path_of_keys_file_from_#1>
+   e.g. dart example/apkam_authenticate.dart @alice🛠 /home/alice/.atsign/@alice🛠_wavikey.atKeys
+3. Run client to approve enrollments
+   dart example/enroll_app_listen.dart <atsign> <path_of_keys_file_from_#1>
+   e.g dart example/enroll_app_listen.dart @alice🛠 /home/alice/.atsign/@alice🛠_wavikey.atKeys
+4. Get OTP for enrollment
+    - 4.1 Pkam through ssl client
+      pkam:enrollmentId:<enrollmentId>:<pkamSignature>
+      enrollmentId - get from the .atKeys file
+      pkamChallenge - generate using the below commnd
+      at_tools/packages/at_pkam>
+      dart bin/main.dart -p <keys_file_path> <from_response>
+      e.g dart bin/main.dart -p /home/alice/.atsign/@alice🛠_wavikey.atKeys -r _70138292-07b5-4e47-8c94-e02e38220775@alice🛠:883ea0aa-c526-400a-926e-48cae9281de9
+    - 4.2 Once authenticated run otp:get
+5. Request enrollment
+    - 5.1 Submit enrollment from new client
+      dart example/apkam_enroll.dart <atsign> <path_to_store_keys_file> <otp>
+      e.g. dart example/apkam_enroll.dart @alice🛠 /home/alice/.atsign/@alice🛠_buzzkey.atKeys DY4UT4
+    - 5.2 Approve the enrollment from the client from #3
+    - 5.3 Enrollment should be successful and keys file stored in the path specified
+6. Authenticate using the enrolled keys file
+    - 6.1 dart example/onboard.dart <atsign> <path_of_keys_file_from_#5.1>
+       

--- a/packages/at_onboarding_cli/example/apkam_authenticate.dart
+++ b/packages/at_onboarding_cli/example/apkam_authenticate.dart
@@ -1,21 +1,34 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';
 
-Future<void> main() async {
-  // final enrollIdFromServer = '867307c7-53bd-4736-8fe7-1520de58ce78';
-  AtSignLogger.root_level = 'finest';
-  final atSign = '@alice🛠';
+Future<void> main(List<String> args) async {
+  AtSignLogger.root_level = 'info';
+  final atSign = args[0];
   AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
     ..namespace =
         'wavi' // unique identifier that can be used to identify data from your app
-    ..atKeysFilePath = '/home/murali/.atsign/@alice🛠_key.atKeys'
+    ..atKeysFilePath = args[1]
     ..rootDomain = 'vip.ve.atsign.zone';
   AtOnboardingService? onboardingService = AtOnboardingServiceImpl(
-      atSign, atOnboardingPreference);
+      atSign, atOnboardingPreference,
+      enrollmentId: _getEnrollmentIdFromKeysFile(args[1]));
   await onboardingService.authenticate(); // when authenticating
-  // AtLookUp? atLookup = onboardingService.atLookUp;
-  // AtClient? client = onboardingService.atClient;
-  // print(await client?.getKeys());
-  // print(await atLookup?.scan(regex: 'publickey'));
-  // await onboardingService.close();
+  AtLookUp? atLookup = onboardingService.atLookUp;
+  AtClient? client = onboardingService.atClient;
+  print(await client?.getKeys());
+  print(await atLookup?.scan(regex: 'publickey'));
+  await onboardingService.close();
+}
+
+String _getEnrollmentIdFromKeysFile(String keysFilePath) {
+  String atAuthData = File(keysFilePath).readAsStringSync();
+  final enrollmentId = jsonDecode(atAuthData)[AtConstants.enrollmentId];
+  print('**** enrollmentId: $enrollmentId');
+  return enrollmentId;
 }

--- a/packages/at_onboarding_cli/example/apkam_authenticate.dart
+++ b/packages/at_onboarding_cli/example/apkam_authenticate.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
-import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';

--- a/packages/at_onboarding_cli/example/apkam_authenticate.dart
+++ b/packages/at_onboarding_cli/example/apkam_authenticate.dart
@@ -1,0 +1,21 @@
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_utils/at_logger.dart';
+
+Future<void> main() async {
+  // final enrollIdFromServer = '867307c7-53bd-4736-8fe7-1520de58ce78';
+  AtSignLogger.root_level = 'finest';
+  final atSign = '@alice🛠';
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace =
+        'wavi' // unique identifier that can be used to identify data from your app
+    ..atKeysFilePath = '/home/murali/.atsign/@alice🛠_key.atKeys'
+    ..rootDomain = 'vip.ve.atsign.zone';
+  AtOnboardingService? onboardingService = AtOnboardingServiceImpl(
+      atSign, atOnboardingPreference);
+  await onboardingService.authenticate(); // when authenticating
+  // AtLookUp? atLookup = onboardingService.atLookUp;
+  // AtClient? client = onboardingService.atClient;
+  // print(await client?.getKeys());
+  // print(await atLookup?.scan(regex: 'publickey'));
+  // await onboardingService.close();
+}

--- a/packages/at_onboarding_cli/example/apkam_enroll.dart
+++ b/packages/at_onboarding_cli/example/apkam_enroll.dart
@@ -11,7 +11,7 @@ Future<void> main(List<String> args) async {
     ..appName = 'buzz'
     ..deviceName = 'iphone'
     ..rootDomain = 'vip.ve.atsign.zone'
-    ..apkamAuthRetryDurationMins = 3;
+    ..apkamAuthRetryDurationMins = 1;
   AtOnboardingService? onboardingService =
       AtOnboardingServiceImpl(atSign, atOnboardingPreference);
   Map<String, String> namespaces = {"buzz": "rw"};

--- a/packages/at_onboarding_cli/example/apkam_enroll.dart
+++ b/packages/at_onboarding_cli/example/apkam_enroll.dart
@@ -1,21 +1,26 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   AtSignLogger.root_level = 'finer';
-  final atSign = '@alice';
+  final atSign = args[0];
   AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
     ..namespace =
         'buzz' // unique identifier that can be used to identify data from your app
-    ..atKeysFilePath = '/home/user/atsign/alice_buzzkey.atKeys'
+    ..atKeysFilePath = args[1]
     ..appName = 'buzz'
     ..deviceName = 'iphone'
-    ..rootDomain = 'vip.ve.atsign.zone';
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..apkamAuthRetryDurationMins = 3;
   AtOnboardingService? onboardingService =
       AtOnboardingServiceImpl(atSign, atOnboardingPreference);
   Map<String, String> namespaces = {"buzz": "rw"};
   // run totp:get from enrolled client and pass the otp
   var enrollmentResponse =
-      await onboardingService.enroll('buzz', 'iphone', "068881", namespaces);
+      await onboardingService.enroll('buzz', 'iphone', args[2], namespaces);
   print('enrollmentResponse: $enrollmentResponse');
 }

--- a/packages/at_onboarding_cli/example/apkam_enroll.dart
+++ b/packages/at_onboarding_cli/example/apkam_enroll.dart
@@ -1,0 +1,21 @@
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_utils/at_logger.dart';
+
+Future<void> main() async {
+  AtSignLogger.root_level = 'finer';
+  final atSign = '@alice';
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace =
+        'buzz' // unique identifier that can be used to identify data from your app
+    ..atKeysFilePath = '/home/user/atsign/alice_buzzkey.atKeys'
+    ..appName = 'buzz'
+    ..deviceName = 'iphone'
+    ..rootDomain = 'vip.ve.atsign.zone';
+  AtOnboardingService? onboardingService =
+      AtOnboardingServiceImpl(atSign, atOnboardingPreference);
+  Map<String, String> namespaces = {"buzz": "rw"};
+  // run totp:get from enrolled client and pass the otp
+  var enrollmentResponse =
+      await onboardingService.enroll('buzz', 'iphone', "068881", namespaces);
+  print('enrollmentResponse: $enrollmentResponse');
+}

--- a/packages/at_onboarding_cli/example/apkam_enroll.dart
+++ b/packages/at_onboarding_cli/example/apkam_enroll.dart
@@ -1,7 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:at_client/at_client.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';
 

--- a/packages/at_onboarding_cli/example/atsign_preference.dart
+++ b/packages/at_onboarding_cli/example/atsign_preference.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:at_client/src/preference/at_client_preference.dart';
+import 'package:at_onboarding_cli/src/util/home_directory_util.dart';
+import 'dart:io';
+import 'package:crypto/crypto.dart';
+
+class AtSignPreference {
+  static AtClientPreference getAlicePreference(
+      String atSign, String enrollmentId) {
+    var preference = AtClientPreference();
+    preference.hiveStoragePath = HomeDirectoryUtil.getHiveStoragePath(atSign,
+        enrollmentId: enrollmentId);
+    preference.commitLogPath =
+        HomeDirectoryUtil.getCommitLogPath(atSign, enrollmentId: enrollmentId);
+    preference.isLocalStoreRequired = true;
+    preference.rootDomain = 'vip.ve.atsign.zone';
+    var hashFile = _getShaForAtSign(atSign);
+    preference.keyStoreSecret =
+        _getKeyStoreSecret('${preference.hiveStoragePath}/$hashFile.hash');
+    return preference;
+  }
+
+  static List<int> _getKeyStoreSecret(String filePath) {
+    var hiveSecretString = File(filePath).readAsStringSync();
+    var secretAsUint8List = Uint8List.fromList(hiveSecretString.codeUnits);
+    return secretAsUint8List;
+  }
+
+  static String _getShaForAtSign(String atsign) {
+    var bytes = utf8.encode(atsign);
+    return sha256.convert(bytes).toString();
+  }
+}

--- a/packages/at_onboarding_cli/example/authenticate_legacy.dart
+++ b/packages/at_onboarding_cli/example/authenticate_legacy.dart
@@ -1,0 +1,19 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+
+Future<void> main() async {
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace =
+        'wavi' // unique identifier that can be used to identify data from your app
+    ..atKeysFilePath = '/home/murali/atsign/alice_key.atKeys'
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..hiveStoragePath = 'home/murali/atsign/@alice/storage/hive'
+    ..commitLogPath = 'home/murali/atsign/@alice/storage/commitLog';
+  AtOnboardingService? onboardingService =
+      AtOnboardingServiceImpl('@alice', atOnboardingPreference);
+  await onboardingService.authenticate(); // when authenticating
+  AtClient? client = onboardingService.atClient;
+  print(await client?.getKeys());
+  // print(await atLookup?.scan(regex: 'publickey'));
+  await onboardingService.close();
+}

--- a/packages/at_onboarding_cli/example/enroll_app_listen.dart
+++ b/packages/at_onboarding_cli/example/enroll_app_listen.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/at_client.dart';
+import 'dart:io';
+import 'package:at_auth/src/auth_constants.dart' as auth_constants;
+
+import 'atsign_preference.dart';
+
+/// dart enroll_app_listen.dart <atsign> <path_to_key_file>
+void main(List<String> arguments) async {
+  var aliceAtSign = arguments[0];
+  try {
+    var atAuthKeys = _decryptAtKeysFile(await _readAtKeysFile(arguments[1]));
+    var atChops = _createAtChops(atAuthKeys);
+    final atClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(
+            aliceAtSign,
+            'wavi',
+            AtSignPreference.getAlicePreference(
+                aliceAtSign, atAuthKeys.enrollmentId!),
+            atChops: atChops,
+            enrollmentId: atAuthKeys.enrollmentId);
+
+    // alice - listen for notification
+    atClientManager.atClient.notificationService
+        .subscribe(regex: '.__manage')
+        .listen((notification) {
+      _notificationCallback(notification, atClientManager.atClient, atAuthKeys);
+    });
+  } on Exception catch (e, trace) {
+    print(e.toString());
+    print(trace);
+  }
+
+  print('end of test');
+}
+
+Future<void> _notificationCallback(AtNotification notification,
+    AtClient atClient, AtAuthKeys atAuthKeys) async {
+  print('alice enroll notification received: ${notification.toString()}');
+  final notificationKey = notification.key;
+  final enrollmentId =
+      notificationKey.substring(0, notificationKey.indexOf('.new.enrollments'));
+  print('Approve enrollmentId $enrollmentId?');
+  String? approveResponse = stdin.readLineSync();
+  print('approved?: $approveResponse');
+  var enrollRequest;
+  var enrollParamsJson = {};
+  enrollParamsJson['enrollmentId'] = enrollmentId;
+  if (approveResponse == 'yes') {
+    final encryptedApkamSymmetricKey =
+        jsonDecode(notification.value!)['encryptedApkamSymmetricKey'];
+    final apkamSymmetricKey = EncryptionUtil.decryptKey(
+        encryptedApkamSymmetricKey, atAuthKeys.defaultEncryptionPrivateKey!);
+    print('decrypted apkam symmetric key: $apkamSymmetricKey');
+    var encryptedDefaultPrivateEncKey = EncryptionUtil.encryptValue(
+        atAuthKeys.defaultEncryptionPrivateKey!, apkamSymmetricKey);
+    var encryptedDefaultSelfEncKey = EncryptionUtil.encryptValue(
+        atAuthKeys.defaultSelfEncryptionKey!, apkamSymmetricKey);
+    enrollParamsJson['encryptedDefaultEncryptedPrivateKey'] =
+        encryptedDefaultPrivateEncKey;
+    enrollParamsJson['encryptedDefaultSelfEncryptionKey'] =
+        encryptedDefaultSelfEncKey;
+    enrollRequest = 'enroll:approve:${jsonEncode(enrollParamsJson)}\n';
+  } else {
+    enrollRequest = 'enroll:deny:${jsonEncode(enrollParamsJson)}\n';
+  }
+  print('enroll request to server: $enrollRequest');
+  String? enrollResponse = await atClient
+      .getRemoteSecondary()!
+      .executeCommand(enrollRequest, auth: true);
+  print('enrollResponse: $enrollResponse');
+}
+
+AtAuthKeys _decryptAtKeysFile(Map<String, String> jsonData) {
+  var securityKeys = AtAuthKeys();
+  String decryptionKey = jsonData[auth_constants.defaultSelfEncryptionKey]!;
+  var atChops =
+      AtChopsImpl(AtChopsKeys()..selfEncryptionKey = AESKey(decryptionKey));
+  securityKeys.defaultEncryptionPublicKey = atChops
+      .decryptString(jsonData[auth_constants.defaultEncryptionPublicKey]!,
+          EncryptionKeyType.aes256,
+          keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+      .result;
+  securityKeys.defaultEncryptionPrivateKey = atChops
+      .decryptString(jsonData[auth_constants.defaultEncryptionPrivateKey]!,
+          EncryptionKeyType.aes256,
+          keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+      .result;
+  securityKeys.defaultSelfEncryptionKey = decryptionKey;
+  securityKeys.apkamPublicKey = atChops
+      .decryptString(
+          jsonData[auth_constants.apkamPublicKey]!, EncryptionKeyType.aes256,
+          keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+      .result;
+  securityKeys.apkamPrivateKey = atChops
+      .decryptString(
+          jsonData[auth_constants.apkamPrivateKey]!, EncryptionKeyType.aes256,
+          keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+      .result;
+  securityKeys.apkamSymmetricKey = jsonData[auth_constants.apkamSymmetricKey];
+  securityKeys.enrollmentId = jsonData[AtConstants.enrollmentId];
+  return securityKeys;
+}
+
+Future<Map<String, String>> _readAtKeysFile(String? atKeysFilePath) async {
+  if (atKeysFilePath == null || atKeysFilePath.isEmpty) {
+    throw AtException(
+        'atKeys filePath is empty. atKeysFile is required to authenticate');
+  }
+  if (!File(atKeysFilePath).existsSync()) {
+    throw AtException(
+        'provided keys file does not exist. Please check whether the file path $atKeysFilePath is valid');
+  }
+  String atAuthData = await File(atKeysFilePath).readAsString();
+  Map<String, String> jsonData = <String, String>{};
+  json.decode(atAuthData).forEach((String key, dynamic value) {
+    jsonData[key] = value.toString();
+  });
+  return jsonData;
+}
+
+AtChops _createAtChops(AtAuthKeys atKeysFile) {
+  final atEncryptionKeyPair = AtEncryptionKeyPair.create(
+      atKeysFile.defaultEncryptionPublicKey!,
+      atKeysFile.defaultEncryptionPrivateKey!);
+  final atPkamKeyPair = AtPkamKeyPair.create(
+      atKeysFile.apkamPublicKey!, atKeysFile.apkamPrivateKey!);
+  final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, atPkamKeyPair);
+  if (atKeysFile.apkamSymmetricKey != null) {
+    atChopsKeys.apkamSymmetricKey = AESKey(atKeysFile.apkamSymmetricKey!);
+  }
+  atChopsKeys.selfEncryptionKey = AESKey(atKeysFile.defaultSelfEncryptionKey!);
+  return AtChopsImpl(atChopsKeys);
+}

--- a/packages/at_onboarding_cli/example/onboard.dart
+++ b/packages/at_onboarding_cli/example/onboard.dart
@@ -1,15 +1,15 @@
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   AtSignLogger.root_level = 'finest';
-  final atSign = '@alice🛠';
+  final atSign = args[0];
   AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
     ..namespace =
         'wavi' // unique identifier that can be used to identify data from your app
     ..cramSecret =
         'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364'
-    ..atKeysFilePath = '/home/murali/.atsign/@alice🛠_key.atKeys'
+    ..atKeysFilePath = args[1]
     ..appName = 'wavi'
     ..deviceName = 'pixel'
     ..rootDomain = 'vip.ve.atsign.zone'

--- a/packages/at_onboarding_cli/example/onboard.dart
+++ b/packages/at_onboarding_cli/example/onboard.dart
@@ -1,0 +1,20 @@
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_utils/at_logger.dart';
+
+Future<void> main() async {
+  AtSignLogger.root_level = 'finest';
+  final atSign = '@alice🛠';
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace =
+        'wavi' // unique identifier that can be used to identify data from your app
+    ..cramSecret =
+        'b26455a907582760ebf35bc4847de549bc41c24b25c8b1c58d5964f7b4f8a43bc55b0e9a601c9a9657d9a8b8bbc32f88b4e38ffaca03c8710ebae1b14ca9f364'
+    ..atKeysFilePath = '/home/murali/.atsign/@alice🛠_key.atKeys'
+    ..appName = 'wavi'
+    ..deviceName = 'pixel'
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..enableEnrollmentDuringOnboard = true;
+  AtOnboardingService? onboardingService =
+      AtOnboardingServiceImpl(atSign, atOnboardingPreference);
+  await onboardingService.onboard();
+}

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -1,15 +1,29 @@
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:at_auth/at_auth.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 
 abstract class AtOnboardingService {
   ///perform initial one_time authentication to activate the atsign
   ///returns true if onboarded
   Future<bool> onboard();
 
-  ///authenticate into secondary server using privateKey
+  ///Authenticate into secondary server using PKAM privateKey for legacy clients
+  ///For clients that are enrolled through APKAM, pass the enrollmentId and auth is done using APKAM private key
   ///returns true if authenticated
-  Future<bool> authenticate();
+  Future<bool> authenticate({String? enrollmentId});
+
+  /// Sends an enroll request to the server. Apps that are already enrolled will receive notifications for this enroll request and can approve/deny the request
+  /// appName - application name of the client e.g wavi,buzz, atmosphere etc.,
+  /// deviceName - device identifier from the requesting application e.g iphone,any unique ID that identifies the requesting client
+  /// otp - otp retrieved from an already enrolled app
+  /// namespaces - key-value pair of namespace-access of the requesting client e.g {"wavi":"rw","contacts":"r"}
+  /// pkamRetryIntervalMins - optional param which specifies interval in mins for pkam retry for this enrollment.
+  /// The passed value will override the value in [AtOnboardingPreference]
+  Future<EnrollResponse> enroll(String appName, String deviceName, String otp,
+      Map<String, String> namespaces,
+      {int? pkamRetryIntervalMins});
 
   ///returns an authenticated instance of AtClient
   @Deprecated('use getter')
@@ -36,4 +50,8 @@ abstract class AtOnboardingService {
   set atChops(AtChops? atChops);
 
   AtChops? get atChops;
+
+  set atAuth(AtAuth? atAuth);
+
+  AtAuth? get atAuth;
 }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -48,9 +48,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
     // set default LocalStorage paths for this instance
     atOnboardingPreference.commitLogPath ??=
-        HomeDirectoryUtil.getCommitLogPath(_atSign);
+        HomeDirectoryUtil.getCommitLogPath(_atSign, enrollmentId: enrollmentId);
     atOnboardingPreference.hiveStoragePath ??=
-        HomeDirectoryUtil.getHiveStoragePath(_atSign);
+        HomeDirectoryUtil.getHiveStoragePath(_atSign,
+            enrollmentId: enrollmentId);
     atOnboardingPreference.isLocalStoreRequired = true;
     atOnboardingPreference.atKeysFilePath ??=
         HomeDirectoryUtil.getAtKeysPath(_atSign);
@@ -299,8 +300,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     } on UnAuthenticatedException catch (e) {
       if (e.message.contains('error:AT0401') ||
           e.message.contains('error:AT0026')) {
-        logger.finer('Retrying pkam auth');
-        await Future.delayed(retryInterval);
+        logger.finer('Pkam auth failed: ${e.message}');
+        return false;
       } else if (e.message.contains('error:AT0025')) {
         logger.finer(
             'enrollmentId $enrollmentIdFromServer denied.Exiting pkam retry logic');

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -1,10 +1,12 @@
 // ignore_for_file: unnecessary_null_comparison
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
+import 'package:at_auth/at_auth.dart';
 import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_server_status/at_server_status.dart';
 import 'package:at_utils/at_utils.dart';
@@ -24,12 +26,14 @@ import '../util/onboarding_util.dart';
 ///class containing service that can onboard/activate/authenticate @signs
 class AtOnboardingServiceImpl implements AtOnboardingService {
   late final String _atSign;
-  bool _isPkamAuthenticated = false;
   bool _isAtsignOnboarded = false;
   AtSignLogger logger = AtSignLogger('OnboardingCli');
   AtOnboardingPreference atOnboardingPreference;
-  AtClient? _atClient;
   AtLookUp? _atLookUp;
+
+  final StreamController<String> _pkamSuccessController =
+      StreamController<String>();
+  Stream<dynamic> get _onPkamSuccess => _pkamSuccessController.stream;
 
   /// The object which controls what types of AtClients, NotificationServices
   /// and SyncServices get created when we call [AtClientManager.setCurrentAtSign].
@@ -38,7 +42,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   AtServiceFactory? atServiceFactory;
 
   AtOnboardingServiceImpl(atsign, this.atOnboardingPreference,
-      {this.atServiceFactory}) {
+      {this.atServiceFactory, String? enrollmentId}) {
     // performs atSign format checks on the atSign
     _atSign = AtUtils.fixAtSign(atsign);
 
@@ -52,37 +56,39 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         HomeDirectoryUtil.getAtKeysPath(_atSign);
   }
 
-  Future<void> _initAtClient(AtChops atChops) async {
+  Future<void> _initAtClient(AtChops atChops, {String? enrollmentId}) async {
     AtClientManager atClientManager = AtClientManager.getInstance();
     if (atOnboardingPreference.skipSync == true) {
       atServiceFactory = ServiceFactoryWithNoOpSyncService();
     }
     await atClientManager.setCurrentAtSign(
         _atSign, atOnboardingPreference.namespace, atOnboardingPreference,
-        atChops: atChops, serviceFactory: atServiceFactory);
+        atChops: atChops,
+        serviceFactory: atServiceFactory,
+        enrollmentId: enrollmentId);
     // ??= to support mocking
     _atLookUp ??= atClientManager.atClient.getRemoteSecondary()?.atLookUp;
+    _atLookUp?.enrollmentId = enrollmentId;
     _atLookUp?.signingAlgoType = atOnboardingPreference.signingAlgoType;
     _atLookUp?.hashingAlgoType = atOnboardingPreference.hashingAlgoType;
-    _atClient ??= atClientManager.atClient;
-  }
-
-  Future<void> _init(Map<String, String> atKeysFileDataMap) async {
-    atChops ??= _createAtChops(atKeysFileDataMap);
-    await _initAtClient(atChops!);
+    atClient ??= atClientManager.atClient;
     _atLookUp!.atChops = atChops;
-    _atClient!.atChops = atChops;
-    _atClient!.getPreferences()!.useAtChops = true;
   }
 
   @override
   @Deprecated('Use getter')
   Future<AtClient?> getAtClient() async {
-    return _atClient;
+    return atClient;
   }
 
   @override
   Future<bool> onboard() async {
+    if (atOnboardingPreference.enableEnrollmentDuringOnboard &&
+        (atOnboardingPreference.appName == null ||
+            atOnboardingPreference.deviceName == null)) {
+      throw AtOnboardingException(
+          'appName and deviceName are mandatory for onboarding. Please set the params in AtOnboardingPreference');
+    }
     // cram auth doesn't use at_chops. So create at_lookup here.
     AtLookupImpl atLookUpImpl = AtLookupImpl(_atSign,
         atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
@@ -107,146 +113,263 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       throw AtActivateException('atsign is already activated');
     }
 
-    try {
-      // authenticate into secondary using cram secret
-      _isAtsignOnboarded = (await atLookUpImpl
-          .authenticate_cram(atOnboardingPreference.cramSecret));
-
-      if (_isAtsignOnboarded) {
-        logger.info('Cram authentication successful');
-        await _activateAtsign(atLookUpImpl);
-      } else {
-        throw AtActivateException(
-            'Cram authentication failed. Please check the cram key'
-            ' and try again \n(or) contact support@atsign.com');
-      }
-    } on Exception catch (e) {
-      if (e.toString().contains('Auth failed')) {
-        throw AtActivateException(
-            'Cram authentication failed. Please check the cram key'
-            ' and try again \n(or) contact support@atsign.com');
-      }
-      logger.severe('Caught exception: $e');
-    } on Error catch (e) {
-      logger.severe('Caught error: $e');
-    } finally {
-      await atLookUpImpl.close();
+    atAuth ??= AtAuthImpl();
+    var atOnboardingRequest = AtOnboardingRequest(_atSign);
+    atOnboardingRequest.rootDomain = atOnboardingPreference.rootDomain;
+    atOnboardingRequest.rootPort = atOnboardingPreference.rootPort;
+    atOnboardingRequest.enableEnrollment =
+        atOnboardingPreference.enableEnrollmentDuringOnboard;
+    atOnboardingRequest.appName = atOnboardingPreference.appName;
+    atOnboardingRequest.deviceName = atOnboardingPreference.deviceName;
+    atOnboardingRequest.publicKeyId = atOnboardingPreference.publicKeyId;
+    var atOnboardingResponse = await atAuth!
+        .onboard(atOnboardingRequest, atOnboardingPreference.cramSecret!);
+    logger.finer('Onboarding Response: $atOnboardingResponse');
+    if (atOnboardingResponse.isSuccessful) {
+      logger.finer(
+          'Onboarding successful.Generating keyfile in path: ${atOnboardingPreference.atKeysFilePath}');
+      await _generateAtKeysFile(
+          atOnboardingResponse.enrollmentId, atOnboardingResponse.atAuthKeys!);
     }
+    _isAtsignOnboarded = atOnboardingResponse.isSuccessful;
     return _isAtsignOnboarded;
   }
 
-  ///method to generate/update encryption key-pairs to activate an atsign
-  Future<void> _activateAtsign(AtLookupImpl atLookUpImpl) async {
-    //1. Generate pkam key pair(if authMode is keyFile), encryption key pair and self encryption key
-    Map<String, String> atKeysMap = await _generateKeyPairs();
+  @override
+  Future<EnrollResponse> enroll(String appName, String deviceName, String otp,
+      Map<String, String> namespaces,
+      {int? pkamRetryIntervalMins}) async {
+    if (appName == null || deviceName == null) {
+      throw AtEnrollmentException(
+          'appName and deviceName are mandatory for enrollment');
+    }
+    pkamRetryIntervalMins ??= atOnboardingPreference.apkamAuthRetryDurationMins;
+    final Duration retryInterval = Duration(minutes: pkamRetryIntervalMins);
+    logger.info('Generating apkam encryption keypair and apkam symmetric key');
+    //1. Generate new apkam key pair and apkam symmetric key
+    var apkamKeyPair = generateRsaKeypair();
+    var apkamSymmetricKey = generateAESKey();
 
-    //2. generate .atKeys file using a copy of atKeysMap
-    await _generateAtKeysFile(Map.of(atKeysMap));
+    AtLookupImpl atLookUpImpl = AtLookupImpl(_atSign,
+        atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
 
-    //3. Updating pkamPublicKey to remote secondary
-    logger.finer('Updating PkamPublicKey to remote secondary');
-    final pkamPublicKey = atKeysMap[AuthKeyType.pkamPublicKey];
-    String updateCommand = 'update:$AT_PKAM_PUBLIC_KEY $pkamPublicKey\n';
-    String? pkamUpdateResult =
-        await atLookUpImpl.executeCommand(updateCommand, auth: false);
-    logger.info('PkamPublicKey update result: $pkamUpdateResult');
+    //2. Retrieve default encryption public key and encrypt apkam symmetric key
+    var defaultEncryptionPublicKey =
+        await _retrieveEncryptionPublicKey(atLookUpImpl);
+    var encryptedApkamSymmetricKey = EncryptionUtil.encryptKey(
+        apkamSymmetricKey, defaultEncryptionPublicKey);
 
-    //4. initialise atClient and atChops and attempt a pkam auth to server.
-    await _init(atKeysMap);
-    _isPkamAuthenticated = (await _atLookUp?.pkamAuthenticate())!;
+    //3. Send enroll request to server
+    var enrollmentResponse = await _sendEnrollRequest(
+        appName,
+        deviceName,
+        otp,
+        namespaces,
+        apkamKeyPair.publicKey.toString(),
+        encryptedApkamSymmetricKey,
+        atLookUpImpl);
+    logger.finer('EnrollmentResponse from server: $enrollmentResponse');
 
-    //5. If Pkam auth is success, update encryption public key to secondary and delete cram key from server
-    if (_isPkamAuthenticated) {
-      final encryptionPublicKey = atKeysMap[AuthKeyType.encryptionPublicKey];
-      UpdateVerbBuilder updateBuilder = UpdateVerbBuilder()
-        ..atKey = 'publickey'
-        ..isPublic = true
-        ..value = encryptionPublicKey
-        ..sharedBy = _atSign;
-      String? encryptKeyUpdateResult =
-          await atLookUpImpl.executeVerb(updateBuilder);
-      logger
-          .info('Encryption public key update result $encryptKeyUpdateResult');
-      // deleting cram secret from the keystore as cram auth is complete
-      DeleteVerbBuilder deleteBuilder = DeleteVerbBuilder()
-        ..atKey = AT_CRAM_SECRET;
-      String? deleteResponse = await atLookUpImpl.executeVerb(deleteBuilder);
-      logger.info('Cram secret delete response : $deleteResponse');
-      //displays status of the atsign
-      logger.finer(await getServerStatus());
-      stdout.writeln('[Success]----------atSign activated---------');
-    } else {
-      throw UnAuthenticatedException('Unable to authenticate.'
-          ' Please provide a valid keys file');
+    //4. Create at chops instance
+    var atChopsKeys = AtChopsKeys.create(
+        null,
+        AtPkamKeyPair.create(apkamKeyPair.publicKey.toString(),
+            apkamKeyPair.privateKey.toString()));
+    atLookUpImpl.atChops = AtChopsImpl(atChopsKeys);
+
+    // Pkam auth will be attempted asynchronously until enrollment is approved/denied
+    _attemptPkamAuthAsync(
+        atLookUpImpl,
+        enrollmentResponse.enrollmentId,
+        retryInterval,
+        apkamSymmetricKey,
+        defaultEncryptionPublicKey,
+        apkamKeyPair);
+
+    // Upon successful pkam auth, callback _listenToPkamSuccessStream will  be invoked
+    _listenToPkamSuccessStream(atLookUpImpl, apkamSymmetricKey,
+        defaultEncryptionPublicKey, apkamKeyPair);
+
+    return enrollmentResponse;
+  }
+
+  void _listenToPkamSuccessStream(
+      AtLookupImpl atLookUpImpl,
+      String apkamSymmetricKey,
+      String defaultEncryptionPublicKey,
+      RSAKeypair apkamKeyPair) {
+    _onPkamSuccess.listen((enrollmentIdFromServer) async {
+      logger.finer('_listenToPkamSuccessStream invoked');
+      var decryptedEncryptionPrivateKey = EncryptionUtil.decryptValue(
+          await _getEncryptionPrivateKeyFromServer(
+              enrollmentIdFromServer, atLookUpImpl),
+          apkamSymmetricKey);
+      var decryptedSelfEncryptionKey = EncryptionUtil.decryptValue(
+          await _getSelfEncryptionKeyFromServer(
+              enrollmentIdFromServer, atLookUpImpl),
+          apkamSymmetricKey);
+
+      var atAuthKeys = AtAuthKeys()
+        ..defaultEncryptionPrivateKey = decryptedEncryptionPrivateKey
+        ..defaultEncryptionPublicKey = defaultEncryptionPublicKey
+        ..apkamSymmetricKey = apkamSymmetricKey
+        ..defaultSelfEncryptionKey = decryptedSelfEncryptionKey
+        ..apkamPublicKey = apkamKeyPair.publicKey.toString()
+        ..apkamPrivateKey = apkamKeyPair.privateKey.toString();
+      logger.finer('Generating keys file for $enrollmentIdFromServer');
+      await _generateAtKeysFile(enrollmentIdFromServer, atAuthKeys);
+    });
+  }
+
+  Future<String> _getEncryptionPrivateKeyFromServer(
+      String enrollmentIdFromServer, AtLookUp atLookUp) async {
+    var privateKeyCommand =
+        'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultEncryptionPrivateKey}.__manage$_atSign\n';
+    String encryptionPrivateKeyFromServer;
+    try {
+      var getPrivateKeyResult =
+          await atLookUp.executeCommand(privateKeyCommand, auth: true);
+      if (getPrivateKeyResult == null || getPrivateKeyResult.isEmpty) {
+        throw AtEnrollmentException('$privateKeyCommand returned null/empty');
+      }
+      getPrivateKeyResult = getPrivateKeyResult.replaceFirst('data:', '');
+      var privateKeyResultJson = jsonDecode(getPrivateKeyResult);
+      encryptionPrivateKeyFromServer = privateKeyResultJson['value'];
+    } on Exception catch (e) {
+      throw AtEnrollmentException(
+          'Exception while getting encrypted private key/self key from server: $e');
+    }
+    return encryptionPrivateKeyFromServer;
+  }
+
+  Future<String> _getSelfEncryptionKeyFromServer(
+      String enrollmentIdFromServer, AtLookUp atLookUp) async {
+    var selfEncryptionKeyCommand =
+        'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultSelfEncryptionKey}.__manage$_atSign\n';
+    String selfEncryptionKeyFromServer;
+    try {
+      var getSelfEncryptionKeyResult =
+          await atLookUp.executeCommand(selfEncryptionKeyCommand, auth: true);
+      if (getSelfEncryptionKeyResult == null ||
+          getSelfEncryptionKeyResult.isEmpty) {
+        throw AtEnrollmentException(
+            '$selfEncryptionKeyCommand returned null/empty');
+      }
+      getSelfEncryptionKeyResult =
+          getSelfEncryptionKeyResult.replaceFirst('data:', '');
+      var selfEncryptionKeyResultJson = jsonDecode(getSelfEncryptionKeyResult);
+      selfEncryptionKeyFromServer = selfEncryptionKeyResultJson['value'];
+    } on Exception catch (e) {
+      throw AtEnrollmentException(
+          'Exception while getting encrypted private key/self key from server: $e');
+    }
+    return selfEncryptionKeyFromServer;
+  }
+
+  Future<void> _attemptPkamAuthAsync(
+      AtLookupImpl atLookUpImpl,
+      String enrollmentIdFromServer,
+      Duration retryInterval,
+      String apkamSymmetricKey,
+      String defaultEncryptionPublicKey,
+      RSAKeypair apkamKeyPair) async {
+    // Pkam auth will be retried until server approves/denies/expires the enrollment
+    while (true) {
+      logger.finer('Attempting pkam for $enrollmentIdFromServer');
+      bool pkamAuthResult = await _attemptPkamAuth(
+          atLookUpImpl, enrollmentIdFromServer, retryInterval);
+      if (pkamAuthResult) {
+        logger.finer('Pkam auth successful for $enrollmentIdFromServer');
+        _pkamSuccessController.add(enrollmentIdFromServer);
+        break;
+      }
+      logger.finer('Retrying pkam after mins: $retryInterval');
+      await Future.delayed(retryInterval); // Delay and retry
     }
   }
 
-  Future<Map<String, String>> _generateKeyPairs() async {
-    // generate user encryption keypair
-    logger.info('Generating encryption keypair');
-    var encryptionKeyPair = generateRsaKeypair();
-
-    //generate selfEncryptionKey
-    var selfEncryptionKey = generateAESKey();
-
-    stdout.writeln(
-        '[Information] Generating your encryption keys and .atKeys file\n');
-    //mapping encryption keys pairs to their names
-    Map<String, String> atKeysMap = <String, String>{};
-    String pkamPublicKey;
-    //generating pkamKeyPair only if authMode is keysFile
-    if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
-      logger.info('Generating pkam keypair');
-      var pkamRsaKeypair = generateRsaKeypair();
-      atKeysMap[AuthKeyType.pkamPublicKey] =
-          pkamRsaKeypair.publicKey.toString();
-      atKeysMap[AuthKeyType.pkamPrivateKey] =
-          pkamRsaKeypair.privateKey.toString();
-      pkamPublicKey = pkamRsaKeypair.publicKey.toString();
-    } else if (atOnboardingPreference.authMode == PkamAuthMode.sim) {
-      // get the public key from secure element
-      pkamPublicKey =
-          atChops!.readPublicKey(atOnboardingPreference.publicKeyId!);
-      logger.info('pkam  public key from sim: $pkamPublicKey');
-      atKeysMap[AuthKeyType.pkamPublicKey] = pkamPublicKey;
-      // encryption key pair and self encryption symmetric key
-      // are not available to injected at_chops. Set it here
-      atChops!.atChopsKeys.atEncryptionKeyPair = AtEncryptionKeyPair.create(
-          encryptionKeyPair.publicKey.toString(),
-          encryptionKeyPair.privateKey.toString());
-      atChops!.atChopsKeys.symmetricKey = AESKey(selfEncryptionKey);
+  Future<bool> _attemptPkamAuth(AtLookUp atLookUp,
+      String enrollmentIdFromServer, Duration retryInterval) async {
+    try {
+      var pkamResult =
+          await atLookUp.pkamAuthenticate(enrollmentId: enrollmentIdFromServer);
+      if (pkamResult) {
+        return true;
+      }
+    } on UnAuthenticatedException catch (e) {
+      if (e.message.contains('error:AT0401') ||
+          e.message.contains('error:AT0026')) {
+        logger.finer('Retrying pkam auth');
+        await Future.delayed(retryInterval);
+      } else if (e.message.contains('error:AT0025')) {
+        logger.finer(
+            'enrollmentId $enrollmentIdFromServer denied.Exiting pkam retry logic');
+        throw AtEnrollmentException('enrollment denied');
+      }
     }
-    //Standard order of an atKeys file is ->
-    // pkam keypair -> encryption keypair -> selfEncryption key ->
-    // @sign: selfEncryptionKey[self encryption key again]
-    // note: "->" stands for "followed by"
-    atKeysMap[AuthKeyType.encryptionPublicKey] =
-        encryptionKeyPair.publicKey.toString();
-    atKeysMap[AuthKeyType.encryptionPrivateKey] =
-        encryptionKeyPair.privateKey.toString();
-    atKeysMap[AuthKeyType.selfEncryptionKey] = selfEncryptionKey;
-    atKeysMap[_atSign] = selfEncryptionKey;
+    return false;
+  }
 
-    return atKeysMap;
+  Future<EnrollResponse> _sendEnrollRequest(
+      String appName,
+      String deviceName,
+      String otp,
+      Map<String, String> namespaces,
+      String apkamPublicKey,
+      String encryptedApkamSymmetricKey,
+      AtLookupImpl atLookUpImpl) async {
+    var enrollVerbBuilder = EnrollVerbBuilder()
+      ..appName = appName
+      ..deviceName = deviceName
+      ..namespaces = namespaces
+      ..otp = otp
+      ..apkamPublicKey = apkamPublicKey
+      ..encryptedAPKAMSymmetricKey = encryptedApkamSymmetricKey;
+    var enrollResult =
+        await atLookUpImpl.executeCommand(enrollVerbBuilder.buildCommand());
+    if (enrollResult == null ||
+        enrollResult.isEmpty ||
+        enrollResult.startsWith('error:')) {
+      throw AtEnrollmentException(
+          'Enrollment response from server: $enrollResult');
+    }
+    enrollResult = enrollResult.replaceFirst('data:', '');
+    var enrollJson = jsonDecode(enrollResult);
+    var enrollmentIdFromServer = enrollJson[AtConstants.enrollmentId];
+    logger.finer('enrollmentIdFromServer: $enrollmentIdFromServer');
+    return EnrollResponse(enrollmentIdFromServer,
+        getEnrollStatusFromString(enrollJson['status']));
   }
 
   ///write newly created encryption keypairs into atKeys file
-  Future<void> _generateAtKeysFile(Map<String, String> atKeysMap) async {
-    //encrypting all keys with self encryption key
+  Future<void> _generateAtKeysFile(
+      String? currentEnrollmentId, AtAuthKeys atAuthKeys) async {
+    final atKeysMap = <String, String>{
+      AuthKeyType.pkamPublicKey: EncryptionUtil.encryptValue(
+        atAuthKeys.apkamPublicKey!,
+        atAuthKeys.defaultSelfEncryptionKey!,
+      ),
+      AuthKeyType.encryptionPublicKey: EncryptionUtil.encryptValue(
+        atAuthKeys.defaultEncryptionPublicKey!,
+        atAuthKeys.defaultSelfEncryptionKey!,
+      ),
+      AuthKeyType.encryptionPrivateKey: EncryptionUtil.encryptValue(
+        atAuthKeys.defaultEncryptionPrivateKey!,
+        atAuthKeys.defaultSelfEncryptionKey!,
+      ),
+      AuthKeyType.selfEncryptionKey: atAuthKeys.defaultSelfEncryptionKey!,
+      _atSign: atAuthKeys.defaultSelfEncryptionKey!,
+      AuthKeyType.apkamSymmetricKey: atAuthKeys.apkamSymmetricKey!
+    };
+
+    if (currentEnrollmentId != null) {
+      atKeysMap['enrollmentId'] = currentEnrollmentId;
+    }
+
     if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
       atKeysMap[AuthKeyType.pkamPrivateKey] = EncryptionUtil.encryptValue(
-          atKeysMap[AuthKeyType.pkamPrivateKey]!,
-          atKeysMap[AuthKeyType.selfEncryptionKey]!);
+          atAuthKeys.apkamPrivateKey!, atAuthKeys.defaultSelfEncryptionKey!);
     }
-    atKeysMap[AuthKeyType.pkamPublicKey] = EncryptionUtil.encryptValue(
-        atKeysMap[AuthKeyType.pkamPublicKey]!,
-        atKeysMap[AuthKeyType.selfEncryptionKey]!);
-    atKeysMap[AuthKeyType.encryptionPublicKey] = EncryptionUtil.encryptValue(
-        atKeysMap[AuthKeyType.encryptionPublicKey]!,
-        atKeysMap[AuthKeyType.selfEncryptionKey]!);
-    atKeysMap[AuthKeyType.encryptionPrivateKey] = EncryptionUtil.encryptValue(
-        atKeysMap[AuthKeyType.encryptionPrivateKey]!,
-        atKeysMap[AuthKeyType.selfEncryptionKey]!);
 
     if (!atOnboardingPreference.atKeysFilePath!.endsWith('.atKeys')) {
       atOnboardingPreference.atKeysFilePath =
@@ -269,81 +392,58 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   ///back-up encryption keys to local secondary
+  /// #TODO remove this method in future when all keys are read from AtChops
   Future<void> _persistKeysLocalSecondary() async {
     //when authenticating keys need to be fetched from atKeys file
-    Map<String, String> atKeysMap = await _decryptAtKeysFile(
+    AtAuthKeys atAuthKeys = _decryptAtKeysFile(
         (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
     //backup keys into local secondary
-    bool? response = await _atClient
+    bool? response = await atClient
         ?.getLocalSecondary()
-        ?.putValue(AT_PKAM_PUBLIC_KEY, atKeysMap[AuthKeyType.pkamPublicKey]!);
+        ?.putValue(AtConstants.atPkamPublicKey, atAuthKeys.apkamPublicKey!);
     logger.finer('PkamPublicKey persist to localSecondary: status $response');
     // save pkam private key only when auth mode is keyFile. if auth mode is sim/any other secure element private key cannot be read and hence will not be part of keys file
     if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
-      response = await _atClient?.getLocalSecondary()?.putValue(
-          AT_PKAM_PRIVATE_KEY, atKeysMap[AuthKeyType.pkamPrivateKey]!);
+      response = await atClient
+          ?.getLocalSecondary()
+          ?.putValue(AtConstants.atPkamPrivateKey, atAuthKeys.apkamPrivateKey!);
       logger
           .finer('PkamPrivateKey persist to localSecondary: status $response');
     }
-    response = await _atClient?.getLocalSecondary()?.putValue(
-        '$AT_ENCRYPTION_PUBLIC_KEY$_atSign',
-        atKeysMap[AuthKeyType.encryptionPublicKey]!);
+    response = await atClient?.getLocalSecondary()?.putValue(
+        '${AtConstants.atEncryptionPublicKey}$_atSign',
+        atAuthKeys.defaultEncryptionPublicKey!);
     logger.finer(
         'EncryptionPublicKey persist to localSecondary: status $response');
-    response = await _atClient?.getLocalSecondary()?.putValue(
-        AT_ENCRYPTION_PRIVATE_KEY,
-        atKeysMap[AuthKeyType.encryptionPrivateKey]!);
+    response = await atClient?.getLocalSecondary()?.putValue(
+        AtConstants.atEncryptionPrivateKey,
+        atAuthKeys.defaultEncryptionPrivateKey!);
     logger.finer(
         'EncryptionPrivateKey persist to localSecondary: status $response');
-    response = await _atClient?.getLocalSecondary()?.putValue(
-        AT_ENCRYPTION_SELF_KEY, atKeysMap[AuthKeyType.selfEncryptionKey]!);
-    logger
-        .finer('SelfEncryptionKey persist to localSecondary: status $response');
+    response = await atClient?.getLocalSecondary()?.putValue(
+        AtConstants.atEncryptionSelfKey, atAuthKeys.defaultSelfEncryptionKey!);
   }
 
   @override
-  Future<bool> authenticate() async {
-    // decrypts all the keys in .atKeysFile using the SelfEncryptionKey
-    // and stores the keys in a map
-    var atKeysFileDataMap = await _decryptAtKeysFile(
-        await _readAtKeysFile(atOnboardingPreference.atKeysFilePath));
-    var pkamPrivateKey = atKeysFileDataMap[AuthKeyType.pkamPrivateKey];
-
-    if (atOnboardingPreference.authMode == PkamAuthMode.keysFile &&
-        pkamPrivateKey == null) {
-      throw AtPrivateKeyNotFoundException(
-          'Unable to read PkamPrivateKey from provided atKeys file at path: '
-          '${atOnboardingPreference.atKeysFilePath}. Please provide a valid atKeys file',
-          exceptionScenario: ExceptionScenario.invalidValueProvided);
-    }
-    await _init(atKeysFileDataMap);
-    logger.finer('Authenticating using PKAM');
-    try {
-      _isPkamAuthenticated = (await _atLookUp?.pkamAuthenticate())!;
-    } on Exception catch (e) {
-      logger.severe('Caught exception: $e');
-      throw UnAuthenticatedException('Unable to authenticate.'
-          ' Please provide a valid keys file');
-    }
-    logger.finer(
-        'PKAM auth result: ${_isPkamAuthenticated ? 'success' : 'failed'}');
-
-    if (!_isAtsignOnboarded && atOnboardingPreference.atKeysFilePath != null) {
+  Future<bool> authenticate({String? enrollmentId}) async {
+    atAuth ??= AtAuthImpl();
+    var atAuthRequest = AtAuthRequest(_atSign)
+      ..enrollmentId = enrollmentId
+      ..atKeysFilePath = atOnboardingPreference.atKeysFilePath
+      ..authMode = atOnboardingPreference.authMode
+      ..rootDomain = atOnboardingPreference.rootDomain
+      ..rootPort = atOnboardingPreference.rootPort;
+    var atAuthResponse = await atAuth!.authenticate(atAuthRequest);
+    logger.finer('Auth response: $atAuthResponse');
+    if (atAuthResponse.isSuccessful &&
+        atOnboardingPreference.atKeysFilePath != null) {
+      logger.finer('Calling persist keys to local secondary');
+      await _initAtClient(atAuth!.atChops!,
+          enrollmentId: atAuthResponse.enrollmentId);
       await _persistKeysLocalSecondary();
     }
 
-    return _isPkamAuthenticated;
-  }
-
-  AtChops _createAtChops(Map<String, String> atKeysDataMap) {
-    final atEncryptionKeyPair = AtEncryptionKeyPair.create(
-        atKeysDataMap[AuthKeyType.encryptionPublicKey]!,
-        atKeysDataMap[AuthKeyType.encryptionPrivateKey]!);
-    final atPkamKeyPair = AtPkamKeyPair.create(
-        atKeysDataMap[AuthKeyType.pkamPublicKey]!,
-        atKeysDataMap[AuthKeyType.pkamPrivateKey]!);
-    final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, atPkamKeyPair);
-    return AtChopsImpl(atChopsKeys);
+    return atAuthResponse.isSuccessful;
   }
 
   ///method to read and return data from .atKeysFile
@@ -367,27 +467,38 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     return jsonData![AuthKeyType.selfEncryptionKey]!;
   }
 
-  ///decrypt keys using self_encryption_key
-  ///returns map containing decrypted atKeys
-  Future<Map<String, String>> _decryptAtKeysFile(
-      Map<String, String> jsonData) async {
+  AtAuthKeys _decryptAtKeysFile(Map<String, String> jsonData) {
+    var atAuthKeys = AtAuthKeys();
     String decryptionKey = _getDecryptionKey(jsonData);
-    Map<String, String> atKeysMap = <String, String>{
-      AuthKeyType.encryptionPublicKey: EncryptionUtil.decryptValue(
-          jsonData[AuthKeyType.encryptionPublicKey]!, decryptionKey),
-      AuthKeyType.encryptionPrivateKey: EncryptionUtil.decryptValue(
-          jsonData[AuthKeyType.encryptionPrivateKey]!, decryptionKey),
-      AuthKeyType.selfEncryptionKey: decryptionKey,
-    };
-    atKeysMap[AuthKeyType.pkamPublicKey] = EncryptionUtil.decryptValue(
+    atAuthKeys.defaultEncryptionPublicKey = EncryptionUtil.decryptValue(
+        jsonData[AuthKeyType.encryptionPublicKey]!, decryptionKey);
+    atAuthKeys.defaultEncryptionPrivateKey = EncryptionUtil.decryptValue(
+        jsonData[AuthKeyType.encryptionPrivateKey]!, decryptionKey);
+    atAuthKeys.defaultSelfEncryptionKey = decryptionKey;
+    atAuthKeys.apkamPublicKey = EncryptionUtil.decryptValue(
         jsonData[AuthKeyType.pkamPublicKey]!, decryptionKey);
     // pkam private key will not be saved in keyfile if auth mode is sim/any other secure element.
     // decrypt the private key only when auth mode is keysFile
     if (atOnboardingPreference.authMode == PkamAuthMode.keysFile) {
-      atKeysMap[AuthKeyType.pkamPrivateKey] = EncryptionUtil.decryptValue(
+      atAuthKeys.apkamPrivateKey = EncryptionUtil.decryptValue(
           jsonData[AuthKeyType.pkamPrivateKey]!, decryptionKey);
     }
-    return atKeysMap;
+    atAuthKeys.apkamSymmetricKey = jsonData[AuthKeyType.apkamSymmetricKey];
+    atAuthKeys.enrollmentId = jsonData[AtConstants.enrollmentId];
+    return atAuthKeys;
+  }
+
+  Future<String> _retrieveEncryptionPublicKey(AtLookUp atLookupImpl) async {
+    var lookupVerbBuilder = LookupVerbBuilder()
+      ..atKey = 'publickey'
+      ..sharedBy = _atSign;
+    var lookupResult = await atLookupImpl.executeVerb(lookupVerbBuilder);
+    if (lookupResult == null || lookupResult.isEmpty) {
+      throw AtEnrollmentException(
+          'Unable to lookup encryption public key. Server response is null/empty');
+    }
+    var defaultEncryptionPublicKey = lookupResult.replaceFirst('data:', '');
+    return defaultEncryptionPublicKey;
   }
 
   ///generates random RSA keypair
@@ -507,7 +618,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       await (_atLookUp as AtLookupImpl).close();
     }
     _atLookUp = null;
-    _atClient = null;
+    atClient = null;
     logger.info(
         'Closing current instance of at_onboarding_cli (exit code: $exitCode)');
   }
@@ -519,9 +630,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   @override
-  set atClient(AtClient? atClient) {
-    _atClient = atClient;
-  }
+  AtClient? atClient;
 
   @override
   set atLookUp(AtLookUp? atLookUp) {
@@ -529,11 +638,12 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   @override
-  AtClient? get atClient => _atClient;
-
-  @override
   AtLookUp? get atLookUp => _atLookUp;
 
   @override
+  @Deprecated('AtChops will be created in AtAuth')
   AtChops? atChops;
+
+  @override
+  AtAuth? atAuth;
 }

--- a/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
@@ -27,4 +27,12 @@ class AtOnboardingPreference extends AtClientPreference {
 
   /// the hostName of the registrar which will be used to activate the atsign
   String registrarUrl = RegistrarApiConstants.apiHostProd;
+
+  String? appName;
+
+  String? deviceName;
+
+  int apkamAuthRetryDurationMins = 30;
+
+  bool enableEnrollmentDuringOnboard = false;
 }

--- a/packages/at_onboarding_cli/lib/src/util/auth_key_type.dart
+++ b/packages/at_onboarding_cli/lib/src/util/auth_key_type.dart
@@ -4,4 +4,5 @@ class AuthKeyType {
   static const String encryptionPublicKey = 'aesEncryptPublicKey';
   static const String encryptionPrivateKey = 'aesEncryptPrivateKey';
   static const String selfEncryptionKey = 'selfEncryptionKey';
+  static const String apkamSymmetricKey = 'apkamSymmetricKey';
 }

--- a/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
@@ -27,19 +27,27 @@ class HomeDirectoryUtil {
     return path.join(homeDir!, '.atsign', 'keys', '${atsign}_key.atKeys');
   }
 
-  static String getStorageDirectory(String atsign) {
+  static String getStorageDirectory(String atsign, {String? enrollmentId}) {
     if (homeDir == null) {
       throw AtClientException.message('Could not find home directory');
+    }
+    if (enrollmentId != null) {
+      return path.join(homeDir!, '.atsign', 'at_onboarding_cli', 'storage',
+          atsign, enrollmentId);
     }
     return path.join(
         homeDir!, '.atsign', 'at_onboarding_cli', 'storage', atsign);
   }
 
-  static String getCommitLogPath(String atsign) {
-    return path.join(getStorageDirectory(atsign), 'commitLog');
+  static String getCommitLogPath(String atsign, {String? enrollmentId}) {
+    return path.join(
+        getStorageDirectory(atsign, enrollmentId: enrollmentId), 'commitLog');
   }
 
-  static String getHiveStoragePath(String atsign) {
-    return path.join(HomeDirectoryUtil.getStorageDirectory(atsign), 'hive');
+  static String getHiveStoragePath(String atsign, {String? enrollmentId}) {
+    return path.join(
+        HomeDirectoryUtil.getStorageDirectory(atsign,
+            enrollmentId: enrollmentId),
+        'hive');
   }
 }

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -24,9 +24,17 @@ dependencies:
    at_chops: ^1.0.5
    at_client: ^3.0.66
    at_commons: ^3.0.57
-   at_lookup: ^3.0.40
+   at_lookup: ^3.0.41
    at_server_status: ^1.0.3
    at_utils: ^3.0.15
+
+#TODO replace with published version
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      path: packages/at_client
+      ref: trunk
 
 dev_dependencies:
   lints: ^2.1.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -22,19 +22,11 @@ dependencies:
    zxing2: ^0.2.0
    at_auth: ^1.0.0
    at_chops: ^1.0.5
-   at_client: ^3.0.66
+   at_client: ^3.0.67
    at_commons: ^3.0.57
    at_lookup: ^3.0.41
    at_server_status: ^1.0.3
    at_utils: ^3.0.15
-
-#TODO replace with published version
-dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      path: packages/at_client
-      ref: trunk
 
 dev_dependencies:
   lints: ^2.1.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -13,19 +13,20 @@ executables:
   at_activate: activate_cli
 
 dependencies:
-   at_utils: ^3.0.12
-   at_client: ^3.0.65
-   at_lookup: ^3.0.36
-   zxing2: ^0.2.0
-   image: ^4.0.17
-   crypton: ^2.0.3
-   at_commons: ^3.0.45
-   encrypt: ^5.0.1
-   at_server_status: ^1.0.3
-   path: ^1.8.1
    args: ^2.4.1
+   crypton: ^2.0.3
+   encrypt: ^5.0.1
    http: ^0.13.6
-   at_chops: ^1.0.3
+   image: ^4.0.17
+   path: ^1.8.1
+   zxing2: ^0.2.0
+   at_auth: ^1.0.0
+   at_chops: ^1.0.5
+   at_client: ^3.0.66
+   at_commons: ^3.0.57
+   at_lookup: ^3.0.40
+   at_server_status: ^1.0.3
+   at_utils: ^3.0.15
 
 dev_dependencies:
   lints: ^2.1.0

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -1,65 +1,52 @@
 import 'dart:io';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_client/at_client.dart';
+import 'package:at_auth/at_auth.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
-import 'package:at_demo_data/at_demo_data.dart' as at_demo;
+
+class MockAtLookupImpl extends Mock implements AtLookupImpl {}
+
+class MockAtAuthImpl extends Mock implements AtAuthImpl {}
+
+class FakeAtAuthRequest extends Fake implements AtAuthRequest {}
 
 void main() {
   AtLookupImpl mockAtLookup = MockAtLookupImpl();
+  AtAuthImpl mockAtAuth = MockAtAuthImpl();
   setUp(() {
     reset(mockAtLookup);
+    reset(mockAtAuth);
+    registerFallbackValue(FakeAtAuthRequest());
   });
   group('A group of tests to verify at_chops creation in onboarding_cli', () {
     AtSignLogger.root_level = 'FINER';
-    test('A test to whether at_chops instance is set on authenticate',
-        () async {
+    test('A test to check authenticate true', () async {
       final atSign = '@alice🛠';
       AtOnboardingPreference onboardingPreference = AtOnboardingPreference()
         ..atKeysFilePath = 'test/data/@alice🛠.atKeys';
       AtOnboardingService onboardingService =
           AtOnboardingServiceImpl(atSign, onboardingPreference);
       onboardingService.atLookUp = mockAtLookup;
+      mockAtAuth.atChops = AtChopsImpl(AtChopsKeys());
+      onboardingService.atAuth = mockAtAuth;
       onboardingService.atClient =
           await AtClientImpl.create(atSign, '.wavi', getAlicePreference());
       when(() => mockAtLookup.pkamAuthenticate())
           .thenAnswer((_) => Future.value(true));
-      await onboardingService.authenticate();
-      final atChops = onboardingService.atClient?.atChops;
-      expect(atChops, isNotNull);
-      expect(atChops?.atChopsKeys, isNotNull);
+      when(() => mockAtAuth.authenticate(any())).thenAnswer(
+          (_) => Future.value(AtAuthResponse(atSign)..isSuccessful = true));
+      when(() => mockAtAuth.atChops)
+          .thenAnswer((_) => AtChopsImpl(AtChopsKeys()));
+      var authResult = await onboardingService.authenticate();
+      expect(authResult, true);
     });
-    test('A test to check whether at_chops keys are set correctly', () async {
-      final atSign = '@alice🛠';
-      AtOnboardingPreference onboardingPreference = AtOnboardingPreference()
-        ..atKeysFilePath = 'test/data/@alice🛠.atKeys';
-      AtOnboardingService onboardingService =
-          AtOnboardingServiceImpl(atSign, onboardingPreference);
-      onboardingService.atLookUp = mockAtLookup;
-      onboardingService.atClient =
-          await AtClientImpl.create(atSign, '.wavi', getAlicePreference());
-      when(() => mockAtLookup.pkamAuthenticate())
-          .thenAnswer((_) => Future.value(true));
-      await onboardingService.authenticate();
-      final atChops = onboardingService.atClient?.atChops;
-      expect(atChops, isNotNull);
-      expect(atChops!.atChopsKeys.atEncryptionKeyPair?.atPublicKey, isNotNull);
-      expect(atChops.atChopsKeys.atEncryptionKeyPair!.atPublicKey.publicKey,
-          at_demo.encryptionPublicKeyMap[atSign]);
-      expect(atChops.atChopsKeys.atEncryptionKeyPair?.atPrivateKey, isNotNull);
-      expect(atChops.atChopsKeys.atEncryptionKeyPair!.atPrivateKey.privateKey,
-          at_demo.encryptionPrivateKeyMap[atSign]);
-      expect(atChops.atChopsKeys.atPkamKeyPair?.atPublicKey, isNotNull);
-      expect(atChops.atChopsKeys.atPkamKeyPair!.atPublicKey.publicKey,
-          at_demo.pkamPublicKeyMap[atSign]);
-      expect(atChops.atChopsKeys.atPkamKeyPair?.atPrivateKey, isNotNull);
-      expect(atChops.atChopsKeys.atPkamKeyPair!.atPrivateKey.privateKey,
-          at_demo.pkamPrivateKeyMap[atSign]);
-    });
+    //#TODO add more tests
     tearDown(() async => await tearDownFunc());
   });
 }
@@ -70,8 +57,6 @@ Future<void> tearDownFunc() async {
     Directory('test/hive').deleteSync(recursive: true);
   }
 }
-
-class MockAtLookupImpl extends Mock implements AtLookupImpl {}
 
 AtClientPreference getAlicePreference() {
   var preference = AtClientPreference();

--- a/tests/at_onboarding_cli_functional_tests/README.md
+++ b/tests/at_onboarding_cli_functional_tests/README.md
@@ -1,0 +1,19 @@
+
+Please read these instructions before adding new/modifying onboarding functional tests
+
+* If a secondary server is started with demo atsigns and pkam/encryption keys loaded,onboard will
+  return an exception since the server is already in activated state.
+* In order to test onboard, we need a server with only cram key available
+* Hence pkamLoad script for onboarding functional tests is commented in .github/workflows/at_libraries.yaml
+* To test authenticate method in AtOnboardingService, we need the pkam/encryption keys updated in server.
+  This step is performed within the test before testing authenticate method. 
+  Check _createKeys() method in at_onboarding_cli_test.dart. 
+  You can use demo keys/generate keys file using demo data to test authenticate method.
+* To test onboard method in AtOnboardingService, new key pairs will be generated during onboard flow.
+  Hence demo keys cannot be used to test onboard method. 
+  Use distinct atsign per test method to test onboarding since repeated run of onboard for same atsign 
+  will fail with atsign already activated exception. 
+  Delete the .atKeys file generated during onboard at the end of the test. 
+  e.g enrollment_test.dart
+* If you are running onboarding_cli functional tests in local setup,use virtual environment without pkamLoad 
+

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -11,12 +11,18 @@ dependencies:
     path: ../../packages/at_onboarding_cli
   at_auth: ^1.0.0
   at_chops: ^1.0.5
-  at_client: ^3.0.65
-  at_commons: ^3.0.56
+  at_client: ^3.0.66
+  at_commons: ^3.0.57
   at_utils: ^3.0.15
   at_lookup: ^3.0.40
 
-
+#TODO replace with published version
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk/
+      path: packages/at_client
+      ref: trunk
 
 
 dev_dependencies:

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -11,19 +11,10 @@ dependencies:
     path: ../../packages/at_onboarding_cli
   at_auth: ^1.0.0
   at_chops: ^1.0.5
-  at_client: ^3.0.66
+  at_client: ^3.0.67
   at_commons: ^3.0.57
   at_utils: ^3.0.15
   at_lookup: ^3.0.40
-
-#TODO replace with published version
-dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk/
-      path: packages/at_client
-      ref: trunk
-
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -9,10 +9,15 @@ environment:
 dependencies:
   at_onboarding_cli:
     path: ../../packages/at_onboarding_cli
-  at_commons: ^3.0.44
-  at_utils: ^3.0.12
-  at_lookup: ^3.0.36
-  at_client: ^3.0.58
+  at_auth: ^1.0.0
+  at_chops: ^1.0.5
+  at_client: ^3.0.65
+  at_commons: ^3.0.56
+  at_utils: ^3.0.15
+  at_lookup: ^3.0.40
+
+
+
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -5,21 +5,37 @@ import 'package:at_client/at_client.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
-    as activate_cli;
 import 'package:at_utils/at_utils.dart';
 import 'package:test/test.dart';
 
 final String atKeysFilePath = '${Platform.environment['HOME']}/.atsign/keys';
-
+Map<String, bool> keysCreatedMap = {};
 void main() {
   AtSignLogger.root_level = 'finest';
+  // These group of tests run on docker container with only cram key available on secondary
+  // Perform cram auth and update keys manually.
+  Future<void> _createKeys(String atSign) async {
+    if (keysCreatedMap.containsKey(atSign)) {
+      return;
+    }
+    var atLookup = AtLookupImpl(atSign, 'vip.ve.atsign.zone', 64);
+    await atLookup.authenticate_cram(at_demos.cramKeyMap[atSign]);
+    var command =
+        'update:privatekey:at_pkam_publickey ${at_demos.pkamPublicKeyMap[atSign]}\n';
+    var response = await atLookup.executeCommand(command, auth: true);
+    expect(response, 'data:-1');
+    command =
+        'update:public:publickey${atSign} ${at_demos.encryptionPublicKeyMap[atSign]}\n';
+    await atLookup.executeCommand(command, auth: true);
+    keysCreatedMap[atSign] = true;
+    await atLookup.close();
+  }
+
   group('A group of tests to assert on authenticate functionality', () {
     test('A test to verify authentication is successful with .atKeys file',
         () async {
-      // Intentionally '@' is not prefixed.
-      // AtOnboardingServiceImpl call's fixAtSign which prefixes '@'
-      String atSign = 'alice🛠';
+      String atSign = '@alice🛠';
+      await _createKeys(atSign);
       AtOnboardingPreference preference = getPreferences(atSign);
       await generateAtKeysFile(atSign, preference.atKeysFilePath!);
       AtOnboardingService atOnboardingService =
@@ -32,6 +48,7 @@ void main() {
         'A test to verify update and llookup verbs with authenticated atLookup instance',
         () async {
       String atSign = '@alice🛠';
+      await _createKeys(atSign);
       AtOnboardingPreference preference = getPreferences(atSign);
       await generateAtKeysFile(atSign, preference.atKeysFilePath!);
       AtOnboardingService atOnboardingService =
@@ -49,6 +66,7 @@ void main() {
         'A test to authenticate and atSign and invoke AtClient put and get methods',
         () async {
       String atSign = '@eve🛠';
+      await _createKeys(atSign);
       AtOnboardingPreference preference = getPreferences(atSign);
       await generateAtKeysFile(atSign, preference.atKeysFilePath!);
       AtOnboardingService onboardingService =
@@ -70,8 +88,8 @@ void main() {
       preference.atKeysFilePath = null;
       AtOnboardingServiceImpl(atSign, preference);
       expect(preference.atKeysFilePath, '$atKeysFilePath/${atSign}_key.atKeys');
-
     });
+
     tearDown(() async {
       await tearDownFunc();
     });
@@ -90,6 +108,7 @@ void main() {
         'A test to authenticate atSign and verify PKAM keys and encryption keys are updated to local secondary',
         () async {
       await generateAtKeysFile(atSign, atOnboardingPreference.atKeysFilePath!);
+      await _createKeys(atSign);
       bool status = await atOnboardingService.authenticate();
       atClient = await atOnboardingService.atClient;
       expect(true, status);
@@ -130,37 +149,9 @@ void main() {
 
       /// Assert .atKeys file is generated for the atSign
       expect(await File(atOnboardingPreference.atKeysFilePath!).exists(), true);
-    }, skip: true);
+    });
 
     tearDown(() async {
-      await tearDownFunc();
-    });
-  });
-
-  group('A group of tests to verify activate_cli', () {
-    String atSign = '@colin🛠';
-    test(
-        'A test to verify atSign is activated and .atKeys file is generated using activate_cli',
-        () async {
-      List<String> args = [
-        '-a',
-        atSign,
-        '-c',
-        at_demos.cramKeyMap[atSign]!,
-        '-r',
-        'vip.ve.atsign.zone'
-      ];
-      await activate_cli.main(args);
-      expect(await File('$atKeysFilePath/${atSign}_key.atKeys').exists(), true);
-
-      // Authenticate atSign with the .atKeys file generated via the activate_cli tool.
-      AtOnboardingPreference atOnboardingPreference = getPreferences(atSign);
-      AtOnboardingService onboardingService =
-          AtOnboardingServiceImpl(atSign, atOnboardingPreference);
-      expect(await onboardingService.authenticate(), true);
-    }, skip: true);
-
-    tearDownAll(() async {
       await tearDownFunc();
     });
   });
@@ -176,7 +167,9 @@ AtOnboardingPreference getPreferences(String atSign) {
     ..privateKey = null
     ..cramSecret = at_demos.cramKeyMap[atSign]
     ..atKeysFilePath = '$atKeysFilePath/${atSign}_key.atKeys'
-    ..downloadPath = atKeysFilePath;
+    ..downloadPath = atKeysFilePath
+    ..appName = 'wavi'
+    ..deviceName = 'pixel';
 
   return atOnboardingPreference;
 }

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -1,0 +1,308 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_demo_data/at_demo_data.dart' as at_demos;
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_utils/at_utils.dart';
+import 'package:test/test.dart';
+import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
+
+var pkamPublicKey;
+var pkamPrivateKey;
+var encryptionPublicKey;
+var encryptionPrivateKey;
+var selfEncryptionKey;
+void main() {
+  AtSignLogger.root_level = 'info';
+  final logger = AtSignLogger('OnboardingEnrollmentTest');
+  group('A group of tests to assert on authenticate functionality', () {
+    test(
+        'A test to verify send enroll request, approve enrollment and auth by enrollmentId',
+        () async {
+      // if onboard is testing use distinct demo atsign per test,
+      // since cram keys get deleted on server for already onboarded atsign
+      String atSign = '@naresh🛠';
+      //1. Onboard first client
+      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
+      preference_1..enableEnrollmentDuringOnboard = true;
+      AtOnboardingService? onboardingService_1 =
+          AtOnboardingServiceImpl(atSign, preference_1);
+      bool status = await onboardingService_1.onboard();
+      expect(status, true);
+      preference_1.privateKey = pkamPrivateKey;
+
+      //2. authenticate first client
+      await onboardingService_1.authenticate();
+      await _setLastReceivedNotificationDateTime(
+          onboardingService_1.atClient!, atSign);
+
+      //3. run otp:get from first client
+      String? totp = await onboardingService_1.atClient!
+          .getRemoteSecondary()!
+          .executeCommand('otp:get\n', auth: true);
+      totp = totp!.replaceFirst('data:', '');
+      totp = totp.trim();
+      logger.finer('otp: $totp');
+      Map<String, String> namespaces = {"buzz": "rw"};
+
+      //4. enroll second client
+      AtOnboardingPreference enrollPreference_2 =
+          getPreferenceForEnroll(atSign);
+      final onboardingService_2 =
+          AtOnboardingServiceImpl(atSign, enrollPreference_2);
+      var enrollResponse =
+          await onboardingService_2.enroll('buzz', 'iphone', totp, namespaces);
+      logger.finer('enroll response $enrollResponse');
+      // enrollment id from the response
+      var enrollmentId = enrollResponse.enrollmentId;
+      var completer = Completer<void>(); // Create a Completer
+
+      //5. listen for notification from first client and invoke callback which approves the enrollment
+      onboardingService_1.atClient!.notificationService
+          .subscribe(regex: '.__manage')
+          .listen(expectAsync1((notification) async {
+            logger.finer('got enroll notification');
+            await _notificationCallback(
+                notification, onboardingService_1.atClient!, 'approve');
+            completer.complete();
+          }, count: 1, max: -1));
+      await completer.future;
+
+      //6. assert that the keys file is created for enrolled app
+      final enrolledClientKeysFile = File(enrollPreference_2.atKeysFilePath!);
+      while (!await enrolledClientKeysFile.exists()) {
+        await Future.delayed(Duration(seconds: 10));
+      }
+      expect(await enrolledClientKeysFile.exists(), true);
+      //  Authenticate now with the approved enrollmentID
+      // assert that authentication is successful
+      bool authResultWithEnrollment =
+          await onboardingService_2.authenticate(enrollmentId: enrollmentId);
+      expect(authResultWithEnrollment, true);
+      enrolledClientKeysFile.deleteSync();
+    }, timeout: Timeout(Duration(minutes: 3)));
+
+    test(
+        'A test to verify pkam authentication is successful when enableEnrollmentDuringOnboard flag is set to false',
+        () async {
+      // if onboard is testing use distinct demo atsign per test,
+      // since cram keys get deleted on server for already onboarded atsign
+      String atSign = '@ashish🛠';
+      //1. Onboard first client
+      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
+      preference_1.enableEnrollmentDuringOnboard = false;
+      AtOnboardingService? onboardingService_1 =
+          AtOnboardingServiceImpl(atSign, preference_1);
+      bool status = await onboardingService_1.onboard();
+      expect(status, true);
+      preference_1.privateKey = pkamPrivateKey;
+
+      //2. authenticate first client
+      var authStatus = await onboardingService_1.authenticate();
+      expect(authStatus, true);
+    }, timeout: Timeout(Duration(minutes: 10)));
+
+    test(
+        'A test to verify an onboarding exception is thrown when enableEnrollmentDuringOnboard is set to true and deviceName and appName are not passed',
+        () async {
+      // if onboard is testing use distinct demo atsign per test,
+      // since cram keys get deleted on server for already onboarded atsign
+      String atSign = '@colin🛠';
+      // preference without appName and deviceName
+      AtOnboardingPreference preference_1 = AtOnboardingPreference()
+        ..rootDomain = 'vip.ve.atsign.zone'
+        ..isLocalStoreRequired = true
+        ..hiveStoragePath = 'storage/hive/client'
+        ..commitLogPath = 'storage/hive/client/commit'
+        ..cramSecret = at_demos.cramKeyMap[atSign]
+        ..namespace =
+            'wavi' // unique identifier that can be used to identify data from your app
+        ..rootDomain = 'vip.ve.atsign.zone'
+        ..enableEnrollmentDuringOnboard = true;
+
+      AtOnboardingService? onboardingService_1 =
+          AtOnboardingServiceImpl(atSign, preference_1);
+      expect(
+          () async => await onboardingService_1.onboard(),
+          throwsA(predicate((dynamic e) =>
+              e is AtOnboardingException &&
+              e.message ==
+                  'appName and deviceName are mandatory for onboarding. Please set the params in AtOnboardingPreference')));
+    }, timeout: Timeout(Duration(minutes: 10)));
+
+    tearDown(() async {
+      await tearDownFunc();
+    });
+  });
+
+  test(
+      'A test to verify send enroll request, deny enrollment and auth by enrollmentId should fail',
+      () async {
+    // if onboard is testing use distinct demo atsign per test,
+    // since cram keys get deleted on server for already onboarded atsign
+    String atSign = '@purnima🛠';
+    //1. Onboard first client
+    AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
+    preference_1.enableEnrollmentDuringOnboard = true;
+    AtOnboardingService? onboardingService_1 =
+        AtOnboardingServiceImpl(atSign, preference_1);
+    bool status = await onboardingService_1.onboard();
+    expect(status, true);
+    preference_1.privateKey = pkamPrivateKey;
+
+    //2. authenticate first client
+    await onboardingService_1.authenticate();
+    await _setLastReceivedNotificationDateTime(
+        onboardingService_1.atClient!, atSign);
+
+    //3. run otp:get from first client
+    String? totp = await onboardingService_1.atClient!
+        .getRemoteSecondary()!
+        .executeCommand('otp:get\n', auth: true);
+    totp = totp!.replaceFirst('data:', '');
+    totp = totp.trim();
+    logger.finer('otp: $totp');
+    Map<String, String> namespaces = {"buzz": "rw"};
+
+    //4. enroll second client
+    AtOnboardingPreference enrollPreference_2 = getPreferenceForEnroll(atSign);
+    final onboardingService_2 =
+        AtOnboardingServiceImpl(atSign, enrollPreference_2);
+
+    var enrollResponse =
+        await onboardingService_2.enroll('buzz', 'iphone', totp, namespaces);
+    logger.finer('enroll response $enrollResponse');
+
+    var completer = Completer<void>(); // Create a Completer
+
+    //5. listen for notification from first client and invoke callback which denies the enrollment
+    onboardingService_1.atClient!.notificationService
+        .subscribe(regex: '.__manage')
+        .listen(expectAsync1((notification) async {
+          logger.finer('got enroll notification');
+          await _notificationCallback(
+              notification, onboardingService_1.atClient!, 'deny');
+          completer.complete();
+        }, count: 1, max: -1));
+    await completer.future;
+  }, timeout: Timeout(Duration(minutes: 5)));
+}
+
+Future<void> _notificationCallback(
+    AtNotification notification, AtClient atClient, String response) async {
+  print('enroll notification received: ${notification.toString()}');
+  final notificationKey = notification.key;
+  final enrollmentId =
+      notificationKey.substring(0, notificationKey.indexOf('.new.enrollments'));
+  var enrollRequest;
+  var enrollParamsJson = {};
+  enrollParamsJson['enrollmentId'] = enrollmentId;
+  final encryptedApkamSymmetricKey =
+      jsonDecode(notification.value!)['encryptedApkamSymmetricKey'];
+  var encryptionPrivateKey =
+      await atClient.getLocalSecondary()!.getEncryptionPrivateKey()!;
+  var selfEncryptionKey =
+      await atClient.getLocalSecondary()!.getEncryptionSelfKey();
+  final apkamSymmetricKey = EncryptionUtil.decryptKey(
+      encryptedApkamSymmetricKey, encryptionPrivateKey);
+  var encryptedDefaultPrivateEncKey =
+      EncryptionUtil.encryptValue(encryptionPrivateKey, apkamSymmetricKey);
+  var encryptedDefaultSelfEncKey =
+      EncryptionUtil.encryptValue(selfEncryptionKey!, apkamSymmetricKey);
+  enrollParamsJson['encryptedDefaultEncryptedPrivateKey'] =
+      encryptedDefaultPrivateEncKey;
+  enrollParamsJson['encryptedDefaultSelfEncryptionKey'] =
+      encryptedDefaultSelfEncKey;
+  if (response == 'approve') {
+    enrollRequest = 'enroll:approve:${jsonEncode(enrollParamsJson)}\n';
+    print('enroll approval request to server: $enrollRequest');
+  } else {
+    enrollRequest = 'enroll:deny:${jsonEncode(enrollParamsJson)}\n';
+    print('enroll denial request $enrollRequest');
+  }
+  String? enrollResponse = await atClient
+      .getRemoteSecondary()!
+      .executeCommand(enrollRequest, auth: true);
+  print('enroll Response from server: $enrollResponse');
+}
+
+Future<void> _setLastReceivedNotificationDateTime(
+    AtClient atClient, String atSign) async {
+  var lastReceivedNotificationAtKey = AtKey.local(
+          'lastreceivednotification', atClient.getCurrentAtSign()!,
+          namespace: atClient.getPreferences()!.namespace)
+      .build();
+
+  var atNotification = AtNotification(
+      '124',
+      '@bob🛠:testnotificationkey',
+      atSign,
+      '@bob🛠',
+      DateTime.now().millisecondsSinceEpoch,
+      MessageTypeEnum.text.toString(),
+      true);
+
+  await atClient.put(
+      lastReceivedNotificationAtKey, jsonEncode(atNotification.toJson()));
+}
+
+AtOnboardingPreference getPreferenceForAuth(String atSign) {
+  atSign = AtUtils.fixAtSign(atSign);
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..isLocalStoreRequired = true
+    ..hiveStoragePath = 'storage/hive/client'
+    ..commitLogPath = 'storage/hive/client/commit'
+    ..cramSecret = at_demos.cramKeyMap[atSign]
+    ..namespace =
+        'wavi' // unique identifier that can be used to identify data from your app
+    ..atKeysFilePath =
+        '${Platform.environment['HOME']}/.atsign/keys/${atSign}_key.atKeys'
+    ..appName = 'wavi'
+    ..deviceName = 'pixel'
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..useAtChops = true;
+
+  return atOnboardingPreference;
+}
+
+AtOnboardingPreference getPreferenceForEnroll(String atSign) {
+  atSign = AtUtils.fixAtSign(atSign);
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace =
+        'buzz' // unique identifier that can be used to identify data from your app
+    ..atKeysFilePath =
+        '${Platform.environment['HOME']}/.atsign/keys/${atSign}_buzzkey.atKeys'
+    ..appName = 'buzz'
+    ..deviceName = 'iphone'
+    ..rootDomain = 'vip.ve.atsign.zone'
+    ..apkamAuthRetryDurationMins = 1
+    ..useAtChops = true;
+  return atOnboardingPreference;
+}
+
+Future<void> getAtKeys(String atSign) async {
+  AtOnboardingPreference preference = getPreferenceForAuth(atSign);
+  String? filePath = preference.atKeysFilePath;
+  var fileContents = File(filePath!).readAsStringSync();
+  var keysJSON = json.decode(fileContents);
+  selfEncryptionKey = keysJSON['selfEncryptionKey'];
+
+  pkamPublicKey = EncryptionUtil.decryptValue(
+      keysJSON['aesPkamPublicKey'], selfEncryptionKey);
+  pkamPrivateKey = EncryptionUtil.decryptValue(
+      keysJSON['aesPkamPrivateKey'], selfEncryptionKey);
+  encryptionPublicKey = EncryptionUtil.decryptValue(
+      keysJSON['aesEncryptPublicKey'], selfEncryptionKey);
+  encryptionPrivateKey = EncryptionUtil.decryptValue(
+      keysJSON['aesEncryptPrivateKey'], selfEncryptionKey);
+}
+
+Future<void> tearDownFunc() async {
+  bool isExists = await Directory('storage/').exists();
+  if (isExists) {
+    Directory('storage/').deleteSync(recursive: true);
+  }
+}

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -202,11 +202,11 @@ Future<void> _notificationCallback(
   final encryptedApkamSymmetricKey =
       jsonDecode(notification.value!)['encryptedApkamSymmetricKey'];
   var encryptionPrivateKey =
-      await atClient.getLocalSecondary()!.getEncryptionPrivateKey()!;
+      await atClient.getLocalSecondary()!.getEncryptionPrivateKey();
   var selfEncryptionKey =
       await atClient.getLocalSecondary()!.getEncryptionSelfKey();
   final apkamSymmetricKey = EncryptionUtil.decryptKey(
-      encryptedApkamSymmetricKey, encryptionPrivateKey);
+      encryptedApkamSymmetricKey, encryptionPrivateKey!);
   var encryptedDefaultPrivateEncKey =
       EncryptionUtil.encryptValue(encryptionPrivateKey, apkamSymmetricKey);
   var encryptedDefaultSelfEncKey =
@@ -262,8 +262,7 @@ AtOnboardingPreference getPreferenceForAuth(String atSign) {
         '${Platform.environment['HOME']}/.atsign/keys/${atSign}_key.atKeys'
     ..appName = 'wavi'
     ..deviceName = 'pixel'
-    ..rootDomain = 'vip.ve.atsign.zone'
-    ..useAtChops = true;
+    ..rootDomain = 'vip.ve.atsign.zone';
 
   return atOnboardingPreference;
 }
@@ -278,8 +277,7 @@ AtOnboardingPreference getPreferenceForEnroll(String atSign) {
     ..appName = 'buzz'
     ..deviceName = 'iphone'
     ..rootDomain = 'vip.ve.atsign.zone'
-    ..apkamAuthRetryDurationMins = 1
-    ..useAtChops = true;
+    ..apkamAuthRetryDurationMins = 1;
   return atOnboardingPreference;
 }
 


### PR DESCRIPTION
**- What I did**
- apkam changes for at_onboarding_cli
**- How I did it**
- Introduced enroll method in AtOnboardingService. Clients/apps can used this method to place an enrollment request
- Added enrollmentId as an optional param to authenticate method. After enrollment, clients must pass enrollmentId for apkam auth
- onboarding changes. 
    - added a flag enableEnrollmentDuringOnboard=false in AtOnboardingPreference. Clients/apps needing privileges to approve enrollments have to set this flag to true 
    - onboard method will thrown an exception if enableEnrollmentDuringOnboard=true and appName or deviceName is not set in OnboardingPreference. Both the params are required for enrolling the app on server
    - onboarding logic is delegated to AtAuth --> onboard method
- enroll method impl
    -  generate new apkam key pair and apkam symmetric key
    - retrieve encryption private key from server and use it to encrypt  apkam symmetric key
    - send enroll request to server with appName, deviceName,otp, encrypted apkam symmetric key and apkam public key from apkam key pair
    - asynchronously attempt apkam to server until enrollment is approved or denied
    - once apkam auth is success then add enrollmentId to _pkamSuccessController. This will trigger the method _listenToPkamSuccessStream which will save the security keys to .atKeys file

- _activateAtsign changes
    - encrypt default encryption key and self encryption key with first client's apkam symmetric key.
    - send enroll request to server which gets auto approved
    - if enroll request is approved, attempt pkam with enrollmentId. if pkam is success then update encryption public key to server, delete cram secret, generate keys file, persist keys to local secondary 
- changes to local hive storage path
    - if hive storage path is not in set in preferences, default path will include enrollmentId (if available). This will ensure two clients enrolled from same machine do not have the same hive storage path.

**- How to verify it**
- run the functional tests in at_onboarding_cli
- run the examples for APKAM in example/. Check README.md in example/