### PR TITLE
fix: deprecate/replace encryptedDefaultEncryptedPrivateKey with encryptedDefaultEncryptionPrivateKey

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.58
+- fix: Deprecate encryptedDefaultEncryptedPrivateKey in EnrollParams and introduce encryptedDefaultEncryptedPrivateKey for readability
+- fix: Replace encryptedDefaultEncryptedPrivateKey with encryptedDefaultEncryptionPrivateKey in EnrollVerbBuilder
 ## 3.0.57
 - feat: Introduced TTL(Time to Live) for OTP verb to configure OTP expiry
 ## 3.0.56

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -8,7 +8,9 @@ class EnrollParams {
   String? deviceName;
   Map<String, String>? namespaces;
   String? otp;
+  @Deprecated('Use encryptedDefaultEncryptionPrivateKey')
   String? encryptedDefaultEncryptedPrivateKey;
+  String? encryptedDefaultEncryptionPrivateKey;
   String? encryptedDefaultSelfEncryptionKey;
   String? encryptedAPKAMSymmetricKey;
   String? apkamPublicKey;

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -1,6 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // dart run build_runner build to generate this file
-
 part of 'enroll_params.dart';
 
 // **************************************************************************
@@ -17,6 +16,8 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..otp = json['otp'] as String?
   ..encryptedDefaultEncryptedPrivateKey =
       json['encryptedDefaultEncryptedPrivateKey'] as String?
+  ..encryptedDefaultEncryptionPrivateKey =
+      json['encryptedDefaultEncryptionPrivateKey'] as String?
   ..encryptedDefaultSelfEncryptionKey =
       json['encryptedDefaultSelfEncryptionKey'] as String?
   ..encryptedAPKAMSymmetricKey = json['encryptedAPKAMSymmetricKey'] as String?
@@ -31,6 +32,8 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'otp': instance.otp,
       'encryptedDefaultEncryptedPrivateKey':
           instance.encryptedDefaultEncryptedPrivateKey,
+      'encryptedDefaultEncryptionPrivateKey':
+          instance.encryptedDefaultEncryptionPrivateKey,
       'encryptedDefaultSelfEncryptionKey':
           instance.encryptedDefaultSelfEncryptionKey,
       'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -28,7 +28,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
 
   Map<String, String>? namespaces;
 
-  String? encryptedDefaultEncryptedPrivateKey;
+  String? encryptedDefaultEncryptionPrivateKey;
   String? encryptedDefaultSelfEncryptionKey;
   String? encryptedAPKAMSymmetricKey;
 
@@ -45,8 +45,8 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
           ..apkamPublicKey = apkamPublicKey
           ..otp = otp
           ..namespaces = namespaces
-          ..encryptedDefaultEncryptedPrivateKey =
-              encryptedDefaultEncryptedPrivateKey
+          ..encryptedDefaultEncryptionPrivateKey =
+              encryptedDefaultEncryptionPrivateKey
           ..encryptedDefaultSelfEncryptionKey =
               encryptedDefaultSelfEncryptionKey
           ..encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey)

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.57
+version: 3.0.58
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('A group of tests related to enroll verb', () {
     test('A test to verify enroll request params', () {
       String command =
-          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptedPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
       command = command.replaceAll('enroll:request:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '1234');
@@ -14,7 +14,7 @@ void main() {
       expect(enrollParams['deviceName'], 'pixel');
       expect(enrollParams['namespaces']['wavi'], 'rw');
       expect(enrollParams['namespaces']['__manage'], 'r');
-      expect(enrollParams['encryptedDefaultEncryptedPrivateKey'],
+      expect(enrollParams['encryptedDefaultEncryptionPrivateKey'],
           'dummy_encrypted_private_key');
       expect(enrollParams['encryptedDefaultSelfEncryptionKey'],
           'dummy_self_encryption_key');
@@ -24,14 +24,14 @@ void main() {
 
     test('A test to verify enroll approve params', () {
       String command =
-          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
       command = command.replaceAll('enroll:approve:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '123');
       expect(enrollParams['appName'], 'wavi');
       expect(enrollParams['deviceName'], 'pixel');
       expect(enrollParams['namespaces']['wavi'], 'rw');
-      expect(enrollParams['encryptedDefaultEncryptedPrivateKey'],
+      expect(enrollParams['encryptedDefaultEncryptionPrivateKey'],
           'dummy_encrypted_private_key');
       expect(enrollParams['encryptedDefaultSelfEncryptionKey'],
           'dummy_self_encryption_key');
@@ -63,7 +63,7 @@ void main() {
         ..apkamPublicKey = 'abcd1234'
         ..enrollmentId = '1234'
         ..encryptedAPKAMSymmetricKey = 'dummy_pkam_sym_key'
-        ..encryptedDefaultEncryptedPrivateKey = 'dummy_encrypted_private_key'
+        ..encryptedDefaultEncryptionPrivateKey = 'dummy_encrypted_private_key'
         ..encryptedDefaultSelfEncryptionKey = 'dummy_self_encryption_key';
 
       Map<String, dynamic> enrollParamsMap = enrollParams.toJson();
@@ -74,7 +74,7 @@ void main() {
       expect(enrollParamsMap['enrollmentId'], '1234');
       expect(
           enrollParamsMap['encryptedAPKAMSymmetricKey'], 'dummy_pkam_sym_key');
-      expect(enrollParamsMap['encryptedDefaultEncryptedPrivateKey'],
+      expect(enrollParamsMap['encryptedDefaultEncryptionPrivateKey'],
           'dummy_encrypted_private_key');
       expect(enrollParamsMap['encryptedDefaultSelfEncryptionKey'],
           'dummy_self_encryption_key');
@@ -88,7 +88,7 @@ void main() {
       enrollParamsMap['apkamPublicKey'] = 'abcd1234';
       enrollParamsMap['enrollmentId'] = '1234';
       enrollParamsMap['encryptedAPKAMSymmetricKey'] = 'dummy_pkam_sym_key';
-      enrollParamsMap['encryptedDefaultEncryptedPrivateKey'] =
+      enrollParamsMap['encryptedDefaultEncryptionPrivateKey'] =
           'dummy_encrypted_private_key';
       enrollParamsMap['encryptedDefaultSelfEncryptionKey'] =
           'dummy_self_encryption_key';
@@ -100,7 +100,7 @@ void main() {
       expect(enrollParams.apkamPublicKey, 'abcd1234');
       expect(enrollParams.enrollmentId, '1234');
       expect(enrollParams.encryptedAPKAMSymmetricKey, 'dummy_pkam_sym_key');
-      expect(enrollParams.encryptedDefaultEncryptedPrivateKey,
+      expect(enrollParams.encryptedDefaultEncryptionPrivateKey,
           'dummy_encrypted_private_key');
       expect(enrollParams.encryptedDefaultSelfEncryptionKey,
           'dummy_self_encryption_key');

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -13,11 +13,11 @@ void main() {
         ..apkamPublicKey = 'abcd1234'
         ..enrollmentId = '1234'
         ..encryptedAPKAMSymmetricKey = 'dummy_pkam_sym_key'
-        ..encryptedDefaultEncryptedPrivateKey = 'dummy_encrypted_private_key'
+        ..encryptedDefaultEncryptionPrivateKey = 'dummy_encrypted_private_key'
         ..encryptedDefaultSelfEncryptionKey = 'dummy_self_encryption_key';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptedPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
+          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
     });
 
     test('A test to verify enroll approve operation', () {
@@ -29,11 +29,11 @@ void main() {
         ..namespaces = {'wavi': 'rw'}
         ..apkamPublicKey = 'abcd1234'
         ..encryptedAPKAMSymmetricKey = 'dummy_pkam_sym_key'
-        ..encryptedDefaultEncryptedPrivateKey = 'dummy_encrypted_private_key'
+        ..encryptedDefaultEncryptionPrivateKey = 'dummy_encrypted_private_key'
         ..encryptedDefaultSelfEncryptionKey = 'dummy_self_encryption_key';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptedPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
+          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
     });
 
     test('A test to verify enroll deny operation', () {


### PR DESCRIPTION
**- What I did**
- Replaced encryptedDefaultEncryptedPrivateKey with encryptedDefaultEncryptionPrivateKey for readability
**- How I did it**
- in EnrollParams deprecated encryptedDefaultEncryptedPrivateKey since this is used in server 
- in EnrollVerbBuilder replaced encryptedDefaultEncryptedPrivateKey with encryptedDefaultEncryptionPrivateKey. Corresponding changes will be done in at_auth
**- How to verify it**
- run the unit tests
- before publishing, point to trunk branch of at_commons and run tests for at_client, server and at_onboarding_cli
