### PR TITLE
feat: Add put operation to OTP syntax for SPP

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.58
+- fix: Add "put" operation to OTP verb to store semi-permanent pass codes
 ## 3.0.57
 - feat: Introduced TTL(Time to Live) for OTP verb to configure OTP expiry
 ## 3.0.56

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -129,7 +129,7 @@ class VerbSyntax {
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
       r'^enroll:(?<operation>(?:list$|(request|approve|deny|revoke|update)))(?::)?(?<enrollParams>.+)?$';
-  static const otp = r'^otp:(?<operation>get)(:(?:ttl:(?<ttl>\d+)))?$';
+  static const otp = r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'
       r'(?:(?<visibility>public|private|self):?)?'
       r'(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 3.0.57
+version: 3.0.58
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/otp_verb_test.dart
+++ b/packages/at_commons/test/otp_verb_test.dart
@@ -21,4 +21,32 @@ void main() {
       expect(verbParams['otp'], null);
     });
   });
+
+  group('A group of test to verify otp:put regex', () {
+    test('A test to verify otp:put accepts alphanumeric characters', () {
+      Map<dynamic, dynamic> verbParams =
+          getVerbParams(VerbSyntax.otp, 'otp:put:abc123');
+      expect(verbParams[AtConstants.operation], 'put');
+      expect(verbParams['otp'], 'abc123');
+      expect(verbParams['ttl'], null);
+    });
+
+    test(
+        'A test to verify otp:put throws error if otp is not 6 character length',
+        () {
+      expect(
+          () => getVerbParams(VerbSyntax.otp, 'otp:put:abc12'),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test('A test to verify otp:put with ttl', () {
+      Map<dynamic, dynamic> verbParams =
+          getVerbParams(VerbSyntax.otp, 'otp:put:abc123:ttl:123');
+      expect(verbParams[AtConstants.operation], 'put');
+      expect(verbParams['otp'], 'abc123');
+      expect(verbParams['ttl'], '123');
+    });
+  });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Enhance OTP verb syntax to accept a pass code and store in the secondary server.

**- How I did it**
- To the existing OTP verb regex, add 'put' to the operation named group, which then accepts 6 digit alpha-numeric characters.

**- How to verify it**
- Added unit tests to verify the OTP verb syntax.

**- Description for the changelog**
- Add "put" operation to OTP verb to store semi-permanent pass codes

NOTE: Following is commit for the corresponding changes in the secondary server. Will raise PR on publishing at_commons package: https://github.com/atsign-foundation/at_server/compare/trunk...semi-permanent-pass-codes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->