### PR TITLE
feat: enrollment code changes for reusability between at_client_mobile and at_onboarding_cli

### DIFF
--- a/packages/at_auth/lib/at_auth.dart
+++ b/packages/at_auth/lib/at_auth.dart
@@ -13,3 +13,5 @@ export 'src/enroll/at_enrollment_base.dart';
 export 'src/enroll/at_enrollment_impl.dart';
 export 'src/enroll/at_enrollment_response.dart';
 export 'src/enroll/at_enrollment_request.dart';
+export 'src/enroll/at_initial_enrollment_request.dart';
+export 'src/enroll/at_new_enrollment_request.dart';

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -223,6 +223,7 @@ class AtAuthImpl implements AtAuth {
             encryptionAlgorithm: symmetricEncryptionAlgo,
             iv: AtChopsUtil.generateIVLegacy())
         .result;
+    _logger.finer('apkamPublicKey: ${atAuthKeys.apkamPublicKey}');
     var enrollRequestBuilder = AtInitialEnrollmentRequestBuilder()
       ..setAppName(atOnboardingRequest.appName)
       ..setDeviceName(atOnboardingRequest.deviceName)
@@ -230,7 +231,8 @@ class AtAuthImpl implements AtAuth {
           encryptedDefaultEncryptionPrivateKey)
       ..setEncryptedDefaultSelfEncryptionKey(encryptedDefaultSelfEncryptionKey)
       ..setApkamPublicKey(atAuthKeys.apkamPublicKey)
-      ..setAtAuthKeys(atAuthKeys);
+      ..setAtAuthKeys(atAuthKeys)
+      ..setEnrollOperationEnum(EnrollOperationEnum.request);
     atEnrollmentBase ??= AtEnrollmentImpl(atOnboardingRequest.atSign);
     AtEnrollmentResponse enrollmentResponse;
     try {

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -6,6 +6,7 @@ import 'package:at_auth/src/at_auth_base.dart';
 import 'package:at_auth/src/auth/cram_authenticator.dart';
 import 'package:at_auth/src/auth/pkam_authenticator.dart';
 import 'package:at_auth/src/enroll/at_enrollment_base.dart';
+import 'package:at_auth/src/enroll/at_initial_enrollment_request.dart';
 import 'package:at_auth/src/keys/at_auth_keys.dart';
 import 'package:at_auth/src/onboard/at_onboarding_request.dart';
 import 'package:at_auth/src/onboard/at_onboarding_response.dart';
@@ -222,13 +223,14 @@ class AtAuthImpl implements AtAuth {
             encryptionAlgorithm: symmetricEncryptionAlgo,
             iv: AtChopsUtil.generateIVLegacy())
         .result;
-    var enrollRequestBuilder = AtEnrollmentRequest.request()
+    var enrollRequestBuilder = AtInitialEnrollmentRequestBuilder()
       ..setAppName(atOnboardingRequest.appName)
       ..setDeviceName(atOnboardingRequest.deviceName)
       ..setEncryptedDefaultEncryptionPrivateKey(
           encryptedDefaultEncryptionPrivateKey)
       ..setEncryptedDefaultSelfEncryptionKey(encryptedDefaultSelfEncryptionKey)
-      ..setApkamPublicKey(atAuthKeys.apkamPublicKey);
+      ..setApkamPublicKey(atAuthKeys.apkamPublicKey)
+      ..setAtAuthKeys(atAuthKeys);
     atEnrollmentBase ??= AtEnrollmentImpl(atOnboardingRequest.atSign);
     AtEnrollmentResponse enrollmentResponse;
     try {

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 
 import 'package:at_auth/at_auth.dart';
 import 'package:at_auth/src/enroll/at_enrollment_notification_request.dart';
-import 'package:at_auth/src/enroll/at_initial_enrollment_request.dart';
-import 'package:at_auth/src/enroll/at_new_enrollment_request.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
@@ -42,9 +40,11 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
   Future<AtEnrollmentResponse> initialClientEnrollment(
       AtInitialEnrollmentRequest atInitialEnrollmentRequest,
       AtLookUp atLookUp) async {
+    _logger.finer('inside initialClientEnrollment');
     final atAuthKeys = atInitialEnrollmentRequest.atAuthKeys;
     var enrollVerbBuilder = createEnrollVerbBuilder(atInitialEnrollmentRequest);
     var enrollResult = await _executeEnrollCommand(enrollVerbBuilder, atLookUp);
+    _logger.finer('enrollResult: $enrollResult');
     var enrollJson = jsonDecode(enrollResult);
     var enrollmentIdFromServer = enrollJson[AtConstants.enrollmentId];
     var enrollStatus = getEnrollStatusFromString(enrollJson['status']);
@@ -207,7 +207,8 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
         ..encryptedDefaultEncryptionPrivateKey =
             request.encryptedDefaultEncryptionPrivateKey
         ..encryptedDefaultSelfEncryptionKey =
-            request.encryptedDefaultSelfEncryptionKey;
+            request.encryptedDefaultSelfEncryptionKey
+        ..apkamPublicKey = request.apkamPublicKey;
     } else if (request is AtNewEnrollmentRequest) {
       enrollVerbBuilder
         ..otp = request.otp

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -193,7 +193,6 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
   }
 
   @visibleForTesting
-
   /// Creates a verb builder instance based on the [request] type
   EnrollVerbBuilder createEnrollVerbBuilder(
     AtEnrollmentRequest request, {

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -25,10 +25,10 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
       AtEnrollmentRequest atEnrollmentRequest, AtLookUp atLookUp) async {
     switch (atEnrollmentRequest.runtimeType) {
       case AtInitialEnrollmentRequest:
-        return await initialClientEnrollment(
+        return await _initialClientEnrollment(
             atEnrollmentRequest as AtInitialEnrollmentRequest, atLookUp);
       case AtNewEnrollmentRequest:
-        return await newClientEnrollment(
+        return await _newClientEnrollment(
             atEnrollmentRequest as AtNewEnrollmentRequest, atLookUp);
       default:
         throw AtEnrollmentException(
@@ -36,8 +36,7 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
     }
   }
 
-  @visibleForTesting
-  Future<AtEnrollmentResponse> initialClientEnrollment(
+  Future<AtEnrollmentResponse> _initialClientEnrollment(
       AtInitialEnrollmentRequest atInitialEnrollmentRequest,
       AtLookUp atLookUp) async {
     _logger.finer('inside initialClientEnrollment');
@@ -53,8 +52,7 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
       ..atAuthKeys = atAuthKeys;
   }
 
-  @visibleForTesting
-  Future<AtEnrollmentResponse> newClientEnrollment(
+  Future<AtEnrollmentResponse> _newClientEnrollment(
       AtNewEnrollmentRequest atNewEnrollmentRequest, AtLookUp atLookUp) async {
     _logger.info('Generating APKAM encryption keypair and APKAM symmetric key');
     AtPkamKeyPair atPkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
@@ -112,8 +110,11 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
       AtEnrollmentRequest atEnrollmentRequest, AtLookUp atLookUp) {
     switch (atEnrollmentRequest.enrollOperationEnum) {
       case EnrollOperationEnum.approve:
-        return _handleApproveOperation(
-            atEnrollmentRequest as AtEnrollmentNotificationRequest, atLookUp);
+        if (atEnrollmentRequest is! AtEnrollmentNotificationRequest) {
+          throw AtEnrollmentException(
+              'Invalid atEnrollmentRequest type: $atEnrollmentRequest. Please pass AtEnrollmentNotificationRequest');
+        }
+        return _handleApproveOperation(atEnrollmentRequest, atLookUp);
       case EnrollOperationEnum.deny:
         return _handleDenyOperation(atEnrollmentRequest, atLookUp);
       default:
@@ -192,6 +193,8 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
   }
 
   @visibleForTesting
+
+  /// Creates a verb builder instance based on the [request] type
   EnrollVerbBuilder createEnrollVerbBuilder(
     AtEnrollmentRequest request, {
     AtPkamKeyPair? atPkamKeyPair,

--- a/packages/at_auth/lib/src/enroll/at_enrollment_notification_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_notification_request.dart
@@ -1,0 +1,30 @@
+import 'package:at_auth/src/enroll/at_enrollment_request.dart';
+
+class AtEnrollmentNotificationRequest extends AtEnrollmentRequest {
+  String _encryptedApkamSymmetricKey;
+
+  String get encryptedApkamSymmetricKey => _encryptedApkamSymmetricKey;
+
+  AtEnrollmentNotificationRequest.builder(
+      AtEnrollmentNotificationRequestBuilder
+          atEnrollmentNotificationRequestBuilder)
+      : _encryptedApkamSymmetricKey =
+            atEnrollmentNotificationRequestBuilder._encryptedApkamSymmetricKey,
+        super.builder(atEnrollmentNotificationRequestBuilder);
+}
+
+class AtEnrollmentNotificationRequestBuilder
+    extends AtEnrollmentRequestBuilder {
+  late String _encryptedApkamSymmetricKey;
+
+  AtEnrollmentNotificationRequestBuilder setEncryptedApkamSymmetricKey(
+      String encryptedApkamSymmetricKey) {
+    _encryptedApkamSymmetricKey = encryptedApkamSymmetricKey;
+    return this;
+  }
+
+  /// Builds and returns an instance of [AtEnrollmentNotificationRequest].
+  AtEnrollmentNotificationRequest build() {
+    return AtEnrollmentNotificationRequest.builder(this);
+  }
+}

--- a/packages/at_auth/lib/src/enroll/at_enrollment_notification_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_notification_request.dart
@@ -1,5 +1,8 @@
 import 'package:at_auth/src/enroll/at_enrollment_request.dart';
 
+/// In APKAM approval flow, use this class from a privileged client to set attributes required for enrollment approval.
+/// Once a notification is received on the privileged client which can approve enrollment notifications from new devices,
+/// use [AtEnrollmentNotificationRequestBuilder] to create [AtEnrollmentNotificationRequest]
 class AtEnrollmentNotificationRequest extends AtEnrollmentRequest {
   String _encryptedApkamSymmetricKey;
 

--- a/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
@@ -1,7 +1,8 @@
 import 'package:at_auth/at_auth.dart';
 import 'package:at_commons/at_commons.dart';
 
-/// Represents an enrollment request for APKAM.
+/// Base class containing common attributes for enrollment requests either from first onboarding client with enrollment enabled
+/// or a new client requesting enrollment.
 class AtEnrollmentRequest {
   final String? _appName;
   final String? _deviceName;

--- a/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
@@ -6,7 +6,7 @@ class AtEnrollmentRequest {
   final String? _appName;
   final String? _deviceName;
   final Map<String, String>? _namespaces;
-  final EnrollOperationEnum _enrollOperationEnum;
+  EnrollOperationEnum _enrollOperationEnum = EnrollOperationEnum.request;
 
   final String? _enrollmentId;
 
@@ -97,7 +97,7 @@ class AtEnrollmentRequestBuilder {
   String? _appName;
   String? _deviceName;
   Map<String, String> _namespaces = {};
-  late EnrollOperationEnum _enrollmentOperationEnum;
+  EnrollOperationEnum _enrollmentOperationEnum = EnrollOperationEnum.request;
   String? _enrollmentId;
   String? _apkamPublicKey;
   AtAuthKeys? _atAuthKeys;
@@ -124,6 +124,12 @@ class AtEnrollmentRequestBuilder {
 
   AtEnrollmentRequestBuilder setApkamPublicKey(String? apkamPublicKey) {
     _apkamPublicKey = apkamPublicKey;
+    return this;
+  }
+
+  AtEnrollmentRequestBuilder setEnrollOperationEnum(
+      EnrollOperationEnum enrollOperationEnum) {
+    _enrollmentOperationEnum = enrollOperationEnum;
     return this;
   }
 

--- a/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_request.dart
@@ -1,24 +1,22 @@
+import 'package:at_auth/at_auth.dart';
 import 'package:at_commons/at_commons.dart';
 
 /// Represents an enrollment request for APKAM.
 class AtEnrollmentRequest {
   final String? _appName;
   final String? _deviceName;
-  final String? _otp;
   final Map<String, String>? _namespaces;
   final EnrollOperationEnum _enrollOperationEnum;
 
   final String? _enrollmentId;
-  final String? _apkamPublicKey;
-  final String? _encryptedAPKAMSymmetricKey;
 
-  final String? _encryptedDefaultEncryptionPrivateKey;
-  final String? _encryptedDefaultSelfEncryptionKey;
+  final String? _apkamPublicKey;
+
+  String? get apkamPublicKey => _apkamPublicKey;
+
   String? get appName => _appName;
 
   String? get deviceName => _deviceName;
-
-  String? get otp => _otp;
 
   Map<String, String>? get namespaces => _namespaces;
 
@@ -26,32 +24,20 @@ class AtEnrollmentRequest {
 
   String? get enrollmentId => _enrollmentId;
 
-  String? get encryptedAPKAMSymmetricKey => _encryptedAPKAMSymmetricKey;
+  final AtAuthKeys? _atAuthKeys;
 
-  String? get encryptedDefaultEncryptionPrivateKey =>
-      _encryptedDefaultEncryptionPrivateKey;
+  AtAuthKeys? get atAuthKeys => _atAuthKeys;
 
-  String? get encryptedDefaultSelfEncryptionKey =>
-      _encryptedDefaultSelfEncryptionKey;
-
-  String? get apkamPublicKey => _apkamPublicKey;
-
-  AtEnrollmentRequest._builder(
+  AtEnrollmentRequest.builder(
       AtEnrollmentRequestBuilder atEnrollmentRequestBuilder)
       : _appName = atEnrollmentRequestBuilder._appName,
         _deviceName = atEnrollmentRequestBuilder._deviceName,
         _namespaces = atEnrollmentRequestBuilder._namespaces,
-        _otp = atEnrollmentRequestBuilder._otp,
         _enrollOperationEnum =
             atEnrollmentRequestBuilder._enrollmentOperationEnum,
         _enrollmentId = atEnrollmentRequestBuilder._enrollmentId,
-        _encryptedAPKAMSymmetricKey =
-            atEnrollmentRequestBuilder._encryptedAPKAMSymmetricKey,
-        _encryptedDefaultEncryptionPrivateKey =
-            atEnrollmentRequestBuilder._encryptedDefaultEncryptionPrivateKey,
-        _encryptedDefaultSelfEncryptionKey =
-            atEnrollmentRequestBuilder._encryptedDefaultSelfEncryptionKey,
-        _apkamPublicKey = atEnrollmentRequestBuilder._apkamPublicKey;
+        _apkamPublicKey = atEnrollmentRequestBuilder._apkamPublicKey,
+        _atAuthKeys = atEnrollmentRequestBuilder._atAuthKeys;
 
   /// Creates an [AtEnrollmentRequestBuilder] for building enrollment requests.
   ///
@@ -111,13 +97,10 @@ class AtEnrollmentRequestBuilder {
   String? _appName;
   String? _deviceName;
   Map<String, String> _namespaces = {};
-  String? _otp;
   late EnrollOperationEnum _enrollmentOperationEnum;
   String? _enrollmentId;
-  String? _encryptedAPKAMSymmetricKey;
-  String? _encryptedDefaultEncryptionPrivateKey;
-  String? _encryptedDefaultSelfEncryptionKey;
   String? _apkamPublicKey;
+  AtAuthKeys? _atAuthKeys;
 
   AtEnrollmentRequestBuilder setAppName(String? appName) {
     _appName = appName;
@@ -134,32 +117,8 @@ class AtEnrollmentRequestBuilder {
     return this;
   }
 
-  AtEnrollmentRequestBuilder setOtp(String? otp) {
-    _otp = otp;
-    return this;
-  }
-
   AtEnrollmentRequestBuilder setEnrollmentId(String? enrollmentId) {
     _enrollmentId = enrollmentId;
-    return this;
-  }
-
-  AtEnrollmentRequestBuilder setEncryptedAPKAMSymmetricKey(
-      String? encryptedAPKAMSymmetricKey) {
-    _encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey;
-    return this;
-  }
-
-  AtEnrollmentRequestBuilder setEncryptedDefaultEncryptionPrivateKey(
-      String? encryptedDefaultEncryptionPrivateKey) {
-    _encryptedDefaultEncryptionPrivateKey =
-        encryptedDefaultEncryptionPrivateKey;
-    return this;
-  }
-
-  AtEnrollmentRequestBuilder setEncryptedDefaultSelfEncryptionKey(
-      String? encryptedDefaultSelfEncryptionKey) {
-    _encryptedDefaultSelfEncryptionKey = encryptedDefaultSelfEncryptionKey;
     return this;
   }
 
@@ -168,8 +127,13 @@ class AtEnrollmentRequestBuilder {
     return this;
   }
 
+  AtEnrollmentRequestBuilder setAtAuthKeys(AtAuthKeys? atAuthKeys) {
+    _atAuthKeys = atAuthKeys;
+    return this;
+  }
+
   /// Builds and returns an instance of [AtEnrollmentRequest].
   AtEnrollmentRequest build() {
-    return AtEnrollmentRequest._builder(this);
+    return AtEnrollmentRequest.builder(this);
   }
 }

--- a/packages/at_auth/lib/src/enroll/at_initial_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_initial_enrollment_request.dart
@@ -1,0 +1,43 @@
+import 'package:at_auth/src/enroll/at_enrollment_request.dart';
+
+class AtInitialEnrollmentRequest extends AtEnrollmentRequest {
+  final String _encryptedDefaultEncryptionPrivateKey;
+  final String _encryptedDefaultSelfEncryptionKey;
+
+  AtInitialEnrollmentRequest.builder(
+      AtInitialEnrollmentRequestBuilder atInitialEnrollmentRequestBuilder)
+      : _encryptedDefaultEncryptionPrivateKey =
+            atInitialEnrollmentRequestBuilder
+                ._encryptedDefaultEncryptionPrivateKey,
+        _encryptedDefaultSelfEncryptionKey = atInitialEnrollmentRequestBuilder
+            ._encryptedDefaultSelfEncryptionKey,
+        super.builder(atInitialEnrollmentRequestBuilder);
+
+  String get encryptedDefaultEncryptionPrivateKey =>
+      _encryptedDefaultEncryptionPrivateKey;
+
+  String get encryptedDefaultSelfEncryptionKey =>
+      _encryptedDefaultSelfEncryptionKey;
+}
+
+class AtInitialEnrollmentRequestBuilder extends AtEnrollmentRequestBuilder {
+  late String _encryptedDefaultEncryptionPrivateKey;
+  late String _encryptedDefaultSelfEncryptionKey;
+  AtEnrollmentRequestBuilder setEncryptedDefaultEncryptionPrivateKey(
+      String encryptedDefaultEncryptionPrivateKey) {
+    _encryptedDefaultEncryptionPrivateKey =
+        encryptedDefaultEncryptionPrivateKey;
+    return this;
+  }
+
+  AtEnrollmentRequestBuilder setEncryptedDefaultSelfEncryptionKey(
+      String encryptedDefaultSelfEncryptionKey) {
+    _encryptedDefaultSelfEncryptionKey = encryptedDefaultSelfEncryptionKey;
+    return this;
+  }
+
+  /// Builds and returns an instance of [AtInitialEnrollmentRequest].
+  AtInitialEnrollmentRequest build() {
+    return AtInitialEnrollmentRequest.builder(this);
+  }
+}

--- a/packages/at_auth/lib/src/enroll/at_initial_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_initial_enrollment_request.dart
@@ -1,5 +1,8 @@
 import 'package:at_auth/src/enroll/at_enrollment_request.dart';
 
+/// Class for attributes required specifically for enrollment from the first onboarding client that
+/// has enableEnrollment flag set to true from client side in preferences.
+/// Default encryption private key and default self encryption keys are encrypted using APKAM symmetric key generated for the onboarding client.
 class AtInitialEnrollmentRequest extends AtEnrollmentRequest {
   final String _encryptedDefaultEncryptionPrivateKey;
   final String _encryptedDefaultSelfEncryptionKey;

--- a/packages/at_auth/lib/src/enroll/at_new_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_new_enrollment_request.dart
@@ -1,0 +1,26 @@
+import 'package:at_auth/src/enroll/at_enrollment_request.dart';
+
+class AtNewEnrollmentRequest extends AtEnrollmentRequest {
+  String _otp;
+
+  AtNewEnrollmentRequest.builder(
+      AtNewEnrollmentRequestBuilder atNewEnrollmentRequestBuilder)
+      : _otp = atNewEnrollmentRequestBuilder._otp,
+        super.builder(atNewEnrollmentRequestBuilder);
+
+  String get otp => _otp;
+}
+
+class AtNewEnrollmentRequestBuilder extends AtEnrollmentRequestBuilder {
+  late String _otp;
+
+  AtNewEnrollmentRequestBuilder setOtp(String otp) {
+    _otp = otp;
+    return this;
+  }
+
+  /// Builds and returns an instance of [AtInitialEnrollmentRequest].
+  AtNewEnrollmentRequest build() {
+    return AtNewEnrollmentRequest.builder(this);
+  }
+}

--- a/packages/at_auth/lib/src/enroll/at_new_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/at_new_enrollment_request.dart
@@ -1,5 +1,6 @@
 import 'package:at_auth/src/enroll/at_enrollment_request.dart';
 
+/// Class for attributes required specifically for new enrollment requests from client.
 class AtNewEnrollmentRequest extends AtEnrollmentRequest {
   String _otp;
 
@@ -19,7 +20,7 @@ class AtNewEnrollmentRequestBuilder extends AtEnrollmentRequestBuilder {
     return this;
   }
 
-  /// Builds and returns an instance of [AtInitialEnrollmentRequest].
+  /// Builds and returns an instance of [AtNewEnrollmentRequest].
   AtNewEnrollmentRequest build() {
     return AtNewEnrollmentRequest.builder(this);
   }

--- a/packages/at_auth/test/enrollment_test.dart
+++ b/packages/at_auth/test/enrollment_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:at_auth/at_auth.dart';
+import 'package:at_auth/src/enroll/at_enrollment_notification_request.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
@@ -80,52 +81,136 @@ void main() {
     when(() => (mockAtLookUp as AtLookupImpl).close())
         .thenAnswer((_) async => ());
 
-    AtEnrollmentRequest atEnrollmentRequest = (AtEnrollmentRequest.request()
-          ..setAppName('wavi')
-          ..setDeviceName('pixel')
-          ..setOtp('12345')
-          ..setNamespaces({'wavi': 'rw'}))
-        .build();
+    // AtEnrollmentRequest atEnrollmentRequest = (AtEnrollmentRequest.request()
+    //       ..setAppName('wavi')
+    //       ..setDeviceName('pixel')
+    //       ..setOtp('12345')
+    //       ..setNamespaces({'wavi': 'rw'}))
+    //     .build();
 
     AtPkamKeyPair atPkamKeyPair =
         AtPkamKeyPair.create(apkamPublicKey, apkamPrivateKey);
     SymmetricKey symmetricKey = AESKey(apkamSymmetricKey);
 
-    AtEnrollmentResponse enrollmentSubmissionResponse =
-        await atEnrollmentServiceImpl.enrollInternal(
-            atEnrollmentRequest, mockAtLookUp, atPkamKeyPair, symmetricKey);
-    expect(enrollmentSubmissionResponse.enrollmentId, '123');
-    expect(enrollmentSubmissionResponse.enrollStatus, EnrollStatus.pending);
+    // AtEnrollmentResponse enrollmentSubmissionResponse =
+    //     await atEnrollmentServiceImpl.enrollInternal(
+    //         atEnrollmentRequest, mockAtLookUp, atPkamKeyPair, symmetricKey);
+    // expect(enrollmentSubmissionResponse.enrollmentId, '123');
+    // expect(enrollmentSubmissionResponse.enrollStatus, EnrollStatus.pending);
   });
 
   group('A group of test related to AtEnrollmentBuilder', () {
-    test('A test to verify generation of enrollment request', () {
-      AtEnrollmentRequestBuilder atEnrollmentRequestBuilder =
-          AtEnrollmentRequest.request()
+    test(
+        'A test to verify generation of initial onboarding enrollment request - default operation request',
+        () {
+      AtInitialEnrollmentRequestBuilder atInitialEnrollmentRequestBuilder =
+          AtInitialEnrollmentRequestBuilder()
             ..setAppName('wavi')
             ..setDeviceName('pixel')
-            ..setOtp('ABC123')
-            ..setNamespaces({'wavi': 'rw'});
-      AtEnrollmentRequest atEnrollmentRequest =
-          atEnrollmentRequestBuilder.build();
+            ..setNamespaces({'wavi': 'rw'})
+            ..setEncryptedDefaultEncryptionPrivateKey('testPrivateKey')
+            ..setEncryptedDefaultSelfEncryptionKey('testSelfKey')
+            ..setApkamPublicKey('testApkamPublicKey');
+      AtInitialEnrollmentRequest atInitialEnrollmentRequest =
+          atInitialEnrollmentRequestBuilder.build();
 
-      expect(atEnrollmentRequest.appName, 'wavi');
-      expect(atEnrollmentRequest.deviceName, 'pixel');
-      expect(atEnrollmentRequest.otp, 'ABC123');
-      expect(atEnrollmentRequest.namespaces, {'wavi': 'rw'});
+      expect(atInitialEnrollmentRequest.appName, 'wavi');
+      expect(atInitialEnrollmentRequest.deviceName, 'pixel');
+      expect(atInitialEnrollmentRequest.namespaces, {'wavi': 'rw'});
+      expect(atInitialEnrollmentRequest.encryptedDefaultEncryptionPrivateKey,
+          'testPrivateKey');
+      expect(atInitialEnrollmentRequest.encryptedDefaultSelfEncryptionKey,
+          'testSelfKey');
+      expect(atInitialEnrollmentRequest.apkamPublicKey, 'testApkamPublicKey');
+      expect(atInitialEnrollmentRequest.enrollOperationEnum,
+          EnrollOperationEnum.request);
+    });
+    test(
+        'A test to verify generation of initial onboarding enrollment request - set operation',
+        () {
+      AtInitialEnrollmentRequestBuilder atInitialEnrollmentRequestBuilder =
+          AtInitialEnrollmentRequestBuilder()
+            ..setAppName('wavi')
+            ..setDeviceName('pixel')
+            ..setNamespaces({'wavi': 'rw'})
+            ..setEncryptedDefaultEncryptionPrivateKey('testPrivateKey')
+            ..setEncryptedDefaultSelfEncryptionKey('testSelfKey')
+            ..setApkamPublicKey('testApkamPublicKey')
+            ..setEnrollOperationEnum(EnrollOperationEnum.approve);
+      AtInitialEnrollmentRequest atInitialEnrollmentRequest =
+          atInitialEnrollmentRequestBuilder.build();
+
+      expect(atInitialEnrollmentRequest.appName, 'wavi');
+      expect(atInitialEnrollmentRequest.deviceName, 'pixel');
+      expect(atInitialEnrollmentRequest.namespaces, {'wavi': 'rw'});
+      expect(atInitialEnrollmentRequest.encryptedDefaultEncryptionPrivateKey,
+          'testPrivateKey');
+      expect(atInitialEnrollmentRequest.encryptedDefaultSelfEncryptionKey,
+          'testSelfKey');
+      expect(atInitialEnrollmentRequest.apkamPublicKey, 'testApkamPublicKey');
+      expect(atInitialEnrollmentRequest.enrollOperationEnum,
+          EnrollOperationEnum.approve);
+    });
+
+    test(
+        'A test to verify generation of new enrollment request - default operation request',
+        () {
+      AtNewEnrollmentRequestBuilder atNewEnrollmentRequestBuilder =
+          AtNewEnrollmentRequestBuilder()
+            ..setAppName('wavi')
+            ..setDeviceName('pixel')
+            ..setNamespaces({'wavi': 'rw'})
+            ..setOtp('A123FE')
+            ..setApkamPublicKey('testApkamPublicKey');
+      AtNewEnrollmentRequest atNewEnrollmentRequest =
+          atNewEnrollmentRequestBuilder.build();
+
+      expect(atNewEnrollmentRequest.appName, 'wavi');
+      expect(atNewEnrollmentRequest.deviceName, 'pixel');
+      expect(atNewEnrollmentRequest.namespaces, {'wavi': 'rw'});
+      expect(atNewEnrollmentRequest.apkamPublicKey, 'testApkamPublicKey');
+      expect(atNewEnrollmentRequest.otp, 'A123FE');
+      expect(atNewEnrollmentRequest.enrollOperationEnum,
+          EnrollOperationEnum.request);
+    });
+
+    test(
+        'A test to verify generation of new enrollment request - set operation',
+        () {
+      AtNewEnrollmentRequestBuilder atNewEnrollmentRequestBuilder =
+          AtNewEnrollmentRequestBuilder()
+            ..setAppName('wavi')
+            ..setDeviceName('pixel')
+            ..setNamespaces({'wavi': 'rw'})
+            ..setOtp('A123FE')
+            ..setApkamPublicKey('testApkamPublicKey')
+            ..setEnrollOperationEnum(EnrollOperationEnum.request);
+      AtNewEnrollmentRequest atNewEnrollmentRequest =
+          atNewEnrollmentRequestBuilder.build();
+
+      expect(atNewEnrollmentRequest.appName, 'wavi');
+      expect(atNewEnrollmentRequest.deviceName, 'pixel');
+      expect(atNewEnrollmentRequest.namespaces, {'wavi': 'rw'});
+      expect(atNewEnrollmentRequest.apkamPublicKey, 'testApkamPublicKey');
+      expect(atNewEnrollmentRequest.otp, 'A123FE');
+      expect(atNewEnrollmentRequest.enrollOperationEnum,
+          EnrollOperationEnum.request);
     });
 
     test('A test to verify generation of enrollment approval request', () {
-      AtEnrollmentRequestBuilder atEnrollmentRequestBuilder =
-          AtEnrollmentRequest.approve()
+      AtEnrollmentNotificationRequestBuilder atEnrollmentNotificationBuilder =
+          AtEnrollmentNotificationRequestBuilder()
             ..setEnrollmentId('ABC-123-ID')
-            ..setEncryptedAPKAMSymmetricKey('dummy-apkam-symmetric-key');
-      AtEnrollmentRequest atEnrollmentRequest =
-          atEnrollmentRequestBuilder.build();
+            ..setEncryptedApkamSymmetricKey('dummy-apkam-symmetric-key')
+            ..setEnrollOperationEnum(EnrollOperationEnum.approve);
+      AtEnrollmentNotificationRequest atEnrollmentNotificationRequest =
+          atEnrollmentNotificationBuilder.build();
 
-      expect(atEnrollmentRequest.enrollmentId, 'ABC-123-ID');
-      expect(atEnrollmentRequest.encryptedAPKAMSymmetricKey,
+      expect(atEnrollmentNotificationRequest.enrollmentId, 'ABC-123-ID');
+      expect(atEnrollmentNotificationRequest.encryptedApkamSymmetricKey,
           'dummy-apkam-symmetric-key');
+      expect(atEnrollmentNotificationRequest.enrollOperationEnum,
+          EnrollOperationEnum.approve);
     });
 
     test('A test to verify generation of enrollment deny request', () {

--- a/packages/at_onboarding_cli/example/onboard.dart
+++ b/packages/at_onboarding_cli/example/onboard.dart
@@ -31,5 +31,6 @@ ArgParser getArgParser() {
     ..addOption('atsign',
         abbr: 'a', help: 'the atsign you would like to auth with')
     ..addOption('cram', abbr: 'c', help: 'CRAM secret for the atsign')
+    ..addOption('atKeysPath', abbr: 'k', help: 'path to save keys file')
     ..addFlag('help', abbr: 'h', help: 'Usage instructions', negatable: false);
 }

--- a/packages/at_onboarding_cli/example/util/atsign_preference.dart
+++ b/packages/at_onboarding_cli/example/util/atsign_preference.dart
@@ -14,9 +14,6 @@ class AtSignPreference {
         HomeDirectoryUtil.getCommitLogPath(atSign, enrollmentId: enrollmentId);
     preference.isLocalStoreRequired = true;
     preference.rootDomain = 'vip.ve.atsign.zone';
-    var hashFile = AtUtils.getShaForAtSign(atSign);
-    preference.keyStoreSecret =
-        _getKeyStoreSecret('${preference.hiveStoragePath}/$hashFile.hash');
     return preference;
   }
 

--- a/packages/at_onboarding_cli/example/util/atsign_preference.dart
+++ b/packages/at_onboarding_cli/example/util/atsign_preference.dart
@@ -1,8 +1,5 @@
-import 'dart:typed_data';
 import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_onboarding_cli/src/util/home_directory_util.dart';
-import 'package:at_utils/at_utils.dart';
-import 'dart:io';
 
 class AtSignPreference {
   static AtClientPreference getAlicePreference(
@@ -15,11 +12,5 @@ class AtSignPreference {
     preference.isLocalStoreRequired = true;
     preference.rootDomain = 'vip.ve.atsign.zone';
     return preference;
-  }
-
-  static List<int> _getKeyStoreSecret(String filePath) {
-    var hiveSecretString = File(filePath).readAsStringSync();
-    var secretAsUint8List = Uint8List.fromList(hiveSecretString.codeUnits);
-    return secretAsUint8List;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -21,7 +21,7 @@ abstract class AtOnboardingService {
   /// namespaces - key-value pair of namespace-access of the requesting client e.g {"wavi":"rw","contacts":"r"}
   /// pkamRetryIntervalMins - optional param which specifies interval in mins for pkam retry for this enrollment.
   /// The passed value will override the value in [AtOnboardingPreference]
-  Future<EnrollResponse> enroll(String appName, String deviceName, String otp,
+  Future<AtEnrollmentResponse> enroll(String appName, String deviceName, String otp,
       Map<String, String> namespaces,
       {int? pkamRetryIntervalMins});
 

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -28,6 +28,11 @@ dependencies:
    at_server_status: ^1.0.3
    at_utils: ^3.0.15
 
+dependency_overrides:
+  at_auth:
+    path: ../at_auth
+
+
 dev_dependencies:
   lints: ^2.1.0
   test: ^1.24.2

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -16,6 +16,10 @@ dependencies:
   at_utils: ^3.0.15
   at_lookup: ^3.0.40
 
+dependency_overrides:
+  at_auth:
+    path: ../../packages/at_auth
+
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.2


### PR DESCRIPTION
**- What I did**
- Move common logic in at_client_mobile and at_onboarding_cli to AtEnrollmentImpl
- EnrollVerb builder was called from multiple places. Remove enroll verb builder from callers and call EnrollVerb builder only from AtEnrollmentImpl --> submitEnrollment. For any future logic changes in enrollment submission, change has to be done only in  AtEnrollmentImpl
- .Added new request classes for initial  onboarding enrollment request and new enrollment request to clearly differentiate between what attributes are required for initial onboarding enrollment and new enrollment. This  matches the attributes specified in APKAM spec and easier to correlate between code and spec.
**- How I did it**
- Added new methods _initialClientEnrollment and _newClientEnrollment in AtEnrollmentImpl to differentiate enrollment done during onboarding and new enrollment.
- Removed method _sendEnrollmentRequest in AtEnrollmentImpl and introduced new method createEnrollVerbBuilder that returns EnrollVerbBuilder based on EnrollmentRequest type
- Added new class representations for different enrollment request types. AtEnrollmentNotificationRequest (approval notification), AtInitialEnrollmentRequest and AtNewEnrollmentRequest
-  Removed unnecessary code in AtOnboardingServiceImpl that has been moved to at_auth package.
- Added unit tests in at_enrollment_test.dart
**- How to verify it**
- Unit tests should pass
- at_onboarding_cli functional test should pass

