### PR TITLE
fix: upgrade at_lookup to 3.0.43

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.3
+- fix: upgrade at_lookup to 3.0.43 since 3.0.42 has breaking change for private key reference
 ## 1.0.2
 - feat: enrollment common code from at_client_mobile and at_onboarding_cli
 - chore: upgrade at_lookup to 3.0.42 and at_demo_data to 1.0.3

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 1.0.2
+version: 1.0.3
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   at_commons: ^3.0.58
-  at_lookup: ^3.0.42
+  at_lookup: ^3.0.43
   at_chops: ^1.0.6
   at_utils: ^3.0.15
   meta: ^1.8.0


### PR DESCRIPTION
**- What I did**
- upgrade at_lookup to 3.0.43 since 3.0.42 has breaking change
**- How I did it**
- made changes to changelog and pubspec
**- How to verify it**
- functional tests should pass
