### PR TITLE
feat: at_chops - add optional public key/private key to asymmetric encryption, major version release

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+- [Breaking Change] fix: removed deprecated methods and members
+- [Breaking Change] feat: Introduced interface for ASymmetricEncryptionAlgorithm and modified DefaultEncryptionAlgorithm
+- build[deps]:
+    - changed minimum dart version in pubspec from 2.15.1 to 3.0.0
+    - upgraded pointycastle to 3.7.4
 ## 1.0.7
 - build[deps]: Upgraded the following packages:
     - at_commons to v4.0.0

--- a/packages/at_chops/example/zariot/at_chops_secure_element.dart
+++ b/packages/at_chops/example/zariot/at_chops_secure_element.dart
@@ -7,7 +7,7 @@ import 'external_signer.dart';
 
 class AtChopsSecureElement extends AtChopsImpl {
   late ExternalSigner externalSigner;
-  AtChopsSecureElement(AtChopsKeys atChopsKeys) : super(atChopsKeys);
+  AtChopsSecureElement(super.atChopsKeys);
 
   @override
   AtSigningResult sign(AtSigningInput signingInput) {

--- a/packages/at_chops/example/zariot/at_chops_secure_element.dart
+++ b/packages/at_chops/example/zariot/at_chops_secure_element.dart
@@ -28,6 +28,7 @@ class AtChopsSecureElement extends AtChopsImpl {
 
   Uint8List _getBytes(dynamic data) {
     if (data is String) {
+      // ignore: unnecessary_cast
       return utf8.encode(data) as Uint8List;
     } else if (data is Uint8List) {
       return data;

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -21,3 +21,5 @@ export 'src/algorithm/default_signing_algo.dart';
 export 'src/algorithm/pkam_signing_algo.dart';
 export 'src/algorithm/ecc_signing_algo.dart';
 export 'src/key/at_key_pair.dart';
+export 'src/key/at_public_key.dart';
+export 'src/key/at_private_key.dart';

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -16,7 +16,7 @@ export 'src/util/at_chops_util.dart';
 export 'src/algorithm/algo_type.dart';
 export 'src/algorithm/at_iv.dart';
 export 'src/algorithm/aes_encryption_algo.dart';
-export 'src/algorithm/default_encryption_algo.dart';
+export 'src/algorithm/rsa_encryption_algo.dart';
 export 'src/algorithm/default_signing_algo.dart';
 export 'src/algorithm/pkam_signing_algo.dart';
 export 'src/algorithm/ecc_signing_algo.dart';

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -28,11 +28,11 @@ abstract class ASymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
   AtPublicKey? atPublicKey;
   AtPrivateKey? atPrivateKey;
 
-  /// Encrypt [plainData] with [atPublicKey.publicKey] if set. Otherwise use default encryption public key set in at_chops instance
+  /// Encrypt [plainData] with [atPublicKey.publicKey]
   @override
   Uint8List encrypt(Uint8List plainData);
 
-  /// Decrypt [plainData] with [atPrivateKey.privateKey] if set. Otherwise use default encryption private key set in at_chops instance
+  /// Decrypt [encryptedData] with [atPrivateKey.privateKey]
   @override
   Uint8List decrypt(Uint8List encryptedData);
 }

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/at_private_key.dart';

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -25,13 +25,16 @@ abstract class SymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
 
 /// Interface for asymmetric encryption algorithms. Check [DefaultEncryptionAlgo] for sample implementation.
 abstract class ASymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
-  /// Encrypt [plainData] with [atPublicKey.publicKey] if passed. Otherwise use default encryption public key set in at_chops instance
-  @override
-  Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey});
+  AtPublicKey? atPublicKey;
+  AtPrivateKey? atPrivateKey;
 
-  /// Decrypt [plainData] with [atPublicKey.privateKey] if passed. Otherwise use default encryption private key set in at_chops instance
+  /// Encrypt [plainData] with [atPublicKey.publicKey] if set. Otherwise use default encryption public key set in at_chops instance
   @override
-  Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey});
+  Uint8List encrypt(Uint8List plainData);
+
+  /// Decrypt [plainData] with [atPrivateKey.privateKey] if set. Otherwise use default encryption private key set in at_chops instance
+  @override
+  Uint8List decrypt(Uint8List encryptedData);
 }
 
 /// Interface for data signing. Data is signed using private key from a key pair

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/at_private_key.dart';
@@ -21,6 +22,14 @@ abstract class SymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
   Uint8List encrypt(Uint8List plainData, {InitialisationVector iv});
   @override
   Uint8List decrypt(Uint8List encryptedData, {InitialisationVector iv});
+}
+
+/// Interface for asymmetric encryption algorithms. Check [DefaultEncryptionAlgo] for sample implementation.
+abstract class ASymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
+  @override
+  Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey});
+  @override
+  Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey});
 }
 
 /// Interface for data signing. Data is signed using private key from a key pair

--- a/packages/at_chops/lib/src/algorithm/at_algorithm.dart
+++ b/packages/at_chops/lib/src/algorithm/at_algorithm.dart
@@ -26,8 +26,11 @@ abstract class SymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
 
 /// Interface for asymmetric encryption algorithms. Check [DefaultEncryptionAlgo] for sample implementation.
 abstract class ASymmetricEncryptionAlgorithm extends AtEncryptionAlgorithm {
+  /// Encrypt [plainData] with [atPublicKey.publicKey] if passed. Otherwise use default encryption public key set in at_chops instance
   @override
   Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey});
+
+  /// Decrypt [plainData] with [atPublicKey.privateKey] if passed. Otherwise use default encryption private key set in at_chops instance
   @override
   Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey});
 }

--- a/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
@@ -12,10 +12,10 @@ class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
   DefaultEncryptionAlgo.fromKeyPair(this._encryptionKeypair);
   DefaultEncryptionAlgo();
   @override
-  Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey}) {
+  Uint8List encrypt(Uint8List plainData) {
     if ((_encryptionKeypair == null ||
             _encryptionKeypair!.atPublicKey.publicKey.isEmpty) &&
-        (atPublicKey == null || atPublicKey.publicKey.isEmpty)) {
+        (atPublicKey == null || atPublicKey!.publicKey.isEmpty)) {
       throw AtEncryptionException('EncryptionKeypair/public key not set');
     }
     var publicKeyString = atPublicKey?.publicKey;
@@ -25,10 +25,10 @@ class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
   }
 
   @override
-  Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey}) {
+  Uint8List decrypt(Uint8List encryptedData) {
     if ((_encryptionKeypair == null ||
             _encryptionKeypair!.atPrivateKey.privateKey.isEmpty) &&
-        (atPrivateKey == null || atPrivateKey.privateKey.isEmpty)) {
+        (atPrivateKey == null || atPrivateKey!.privateKey.isEmpty)) {
       throw AtDecryptionException('EncryptionKeypair/public key not set');
     }
     var privateKeyString = atPrivateKey?.privateKey;
@@ -36,4 +36,10 @@ class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
     final rsaPrivateKey = RSAPrivateKey.fromString(privateKeyString);
     return rsaPrivateKey.decryptData(encryptedData);
   }
+
+  @override
+  AtPrivateKey? atPrivateKey;
+
+  @override
+  AtPublicKey? atPublicKey;
 }

--- a/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
@@ -1,17 +1,19 @@
 import 'dart:typed_data';
 
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/algorithm/at_iv.dart';
+import 'package:at_chops/src/key/at_private_key.dart';
+import 'package:at_chops/src/key/at_public_key.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
-class DefaultEncryptionAlgo implements AtEncryptionAlgorithm {
+class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
   final AtEncryptionKeyPair _encryptionKeypair;
   DefaultEncryptionAlgo(this._encryptionKeypair);
 
   @override
-  Uint8List encrypt(Uint8List plainData, {InitialisationVector? iv}) {
+  Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey}) {
+    //#TODO encrypt using atPublicKey if passed
     if (_encryptionKeypair.atPublicKey.publicKey.isEmpty) {
       throw AtEncryptionException('encryption public key is empty');
     }
@@ -21,7 +23,8 @@ class DefaultEncryptionAlgo implements AtEncryptionAlgorithm {
   }
 
   @override
-  Uint8List decrypt(Uint8List encryptedData, {InitialisationVector? iv}) {
+  Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey}) {
+    //#TODO decrypt using atPrivateKey if passed
     if (_encryptionKeypair.atPrivateKey.privateKey.isEmpty) {
       throw AtDecryptionException('decryption private key is empty');
     }

--- a/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_encryption_algo.dart
@@ -8,28 +8,32 @@ import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
 class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
-  final AtEncryptionKeyPair _encryptionKeypair;
-  DefaultEncryptionAlgo(this._encryptionKeypair);
-
+  AtEncryptionKeyPair? _encryptionKeypair;
+  DefaultEncryptionAlgo.fromKeyPair(this._encryptionKeypair);
+  DefaultEncryptionAlgo();
   @override
   Uint8List encrypt(Uint8List plainData, {AtPublicKey? atPublicKey}) {
-    //#TODO encrypt using atPublicKey if passed
-    if (_encryptionKeypair.atPublicKey.publicKey.isEmpty) {
-      throw AtEncryptionException('encryption public key is empty');
+    if ((_encryptionKeypair == null ||
+            _encryptionKeypair!.atPublicKey.publicKey.isEmpty) &&
+        (atPublicKey == null || atPublicKey.publicKey.isEmpty)) {
+      throw AtEncryptionException('EncryptionKeypair/public key not set');
     }
-    final rsaPublicKey =
-        RSAPublicKey.fromString(_encryptionKeypair.atPublicKey.publicKey);
+    var publicKeyString = atPublicKey?.publicKey;
+    publicKeyString ??= _encryptionKeypair!.atPublicKey.publicKey;
+    final rsaPublicKey = RSAPublicKey.fromString(publicKeyString);
     return rsaPublicKey.encryptData(plainData);
   }
 
   @override
   Uint8List decrypt(Uint8List encryptedData, {AtPrivateKey? atPrivateKey}) {
-    //#TODO decrypt using atPrivateKey if passed
-    if (_encryptionKeypair.atPrivateKey.privateKey.isEmpty) {
-      throw AtDecryptionException('decryption private key is empty');
+    if ((_encryptionKeypair == null ||
+            _encryptionKeypair!.atPrivateKey.privateKey.isEmpty) &&
+        (atPrivateKey == null || atPrivateKey.privateKey.isEmpty)) {
+      throw AtDecryptionException('EncryptionKeypair/public key not set');
     }
-    final rsaPrivateKey =
-        RSAPrivateKey.fromString(_encryptionKeypair.atPrivateKey.privateKey);
+    var privateKeyString = atPrivateKey?.privateKey;
+    privateKeyString ??= _encryptionKeypair!.atPrivateKey.privateKey;
+    final rsaPrivateKey = RSAPrivateKey.fromString(privateKeyString);
     return rsaPrivateKey.decryptData(encryptedData);
   }
 }

--- a/packages/at_chops/lib/src/algorithm/rsa_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/rsa_encryption_algo.dart
@@ -7,10 +7,10 @@ import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 
-class DefaultEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
+class RsaEncryptionAlgo implements ASymmetricEncryptionAlgorithm {
   AtEncryptionKeyPair? _encryptionKeypair;
-  DefaultEncryptionAlgo.fromKeyPair(this._encryptionKeypair);
-  DefaultEncryptionAlgo();
+  RsaEncryptionAlgo.fromKeyPair(this._encryptionKeypair);
+  RsaEncryptionAlgo();
   @override
   Uint8List encrypt(Uint8List plainData) {
     if ((_encryptionKeypair == null ||

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -4,8 +4,6 @@ import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
 import 'package:at_chops/src/algorithm/default_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/default_hashing_algo.dart';
-import 'package:at_chops/src/algorithm/default_signing_algo.dart';
-import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_chops/src/key/impl/at_chops_keys.dart';
 import 'package:at_chops/src/key/key_type.dart';
 import 'package:at_chops/src/metadata/at_signing_input.dart';
@@ -60,42 +58,6 @@ abstract class AtChops {
       {AtEncryptionAlgorithm? encryptionAlgorithm,
       String? keyName,
       InitialisationVector? iv});
-
-  /// Sign the input bytes [data] using a [signingAlgorithm].
-  // ignore: deprecated_member_use_from_same_package
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  // ignore: deprecated_member_use_from_same_package
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  // ignore: deprecated_member_use_from_same_package
-  AtSigningResult signBytes(Uint8List data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
-
-  /// Verify the [signature] of bytes [data] using a [signingAlgorithm]
-  // ignore: deprecated_member_use_from_same_package
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  // ignore: deprecated_member_use_from_same_package
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  AtSigningResult verifySignatureBytes(
-      Uint8List data,
-      Uint8List signature,
-      // ignore: deprecated_member_use_from_same_package
-      SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
-
-  /// Sign the input string [data] using a [signingAlgorithm].
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  @Deprecated('Use sign() instead')
-  AtSigningResult signString(String data, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
-
-  /// Verify the [signature] of string [data] using a [signingAlgorithm]
-  /// If [signingKeyType] is [SigningKeyType.pkamSha256] then [signingAlgorithm] will be set to [PkamSigningAlgo]
-  /// If [signingKeyType] is [SigningKeyType.signingSha256] then [signingAlgorithm] will be set to [DefaultSigningAlgo]
-  @Deprecated('Use verify() instead')
-  AtSigningResult verifySignatureString(
-      String data, String signature, SigningKeyType signingKeyType,
-      {AtSigningAlgorithm? signingAlgorithm});
 
   /// Compute data signature using the private key from a key pair
   /// Input has to be set using [AtSigningInput] object

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
-import 'package:at_chops/src/algorithm/default_encryption_algo.dart';
+import 'package:at_chops/src/algorithm/rsa_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/default_hashing_algo.dart';
 import 'package:at_chops/src/key/impl/at_chops_keys.dart';
 import 'package:at_chops/src/key/key_type.dart';
@@ -20,7 +20,7 @@ abstract class AtChops {
   AtChops(this._atChopsKeys);
 
   /// Encrypts the input bytes [data] using an [encryptionAlgorithm] and returns [AtEncryptionResult].
-  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [DefaultEncryptionAlgo]
+  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [RsaEncryptionAlgo]
   /// [keyName] specifies which key pair to use if user has multiple key pairs configured.
   /// If [keyName] is not passed default encryption/decryption keypair from .atKeys file will be used.
   AtEncryptionResult encryptBytes(
@@ -30,7 +30,7 @@ abstract class AtChops {
       InitialisationVector? iv});
 
   /// Encrypts the input string [data] using an [encryptionAlgorithm] and returns [AtEncryptionResult].
-  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [DefaultEncryptionAlgo]
+  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [RsaEncryptionAlgo]
   /// [keyName] specifies which key pair to use if user has multiple key pairs configured.
   /// If [keyName] is not passed default encryption/decryption keypair from .atKeys file will be used.
   AtEncryptionResult encryptString(
@@ -40,7 +40,7 @@ abstract class AtChops {
       InitialisationVector? iv});
 
   /// Decrypts the input bytes [data] using an [encryptionAlgorithm] and returns [AtEncryptionResult].
-  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [DefaultEncryptionAlgo]
+  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [RsaEncryptionAlgo]
   /// [keyName] specifies which key pair to use if user has multiple key pairs configured.
   /// If [keyName] is not passed default encryption/decryption keypair from .atKeys file will be used.
   AtEncryptionResult decryptBytes(
@@ -50,7 +50,7 @@ abstract class AtChops {
       InitialisationVector? iv});
 
   /// Decrypts the input string [data] using an [encryptionAlgorithm] and returns [AtEncryptionResult].
-  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [DefaultEncryptionAlgo]
+  /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [RsaEncryptionAlgo]
   /// [keyName] specifies which key pair to use if user has multiple key pairs configured.
   /// If [keyName] is not passed default encryption/decryption keypair from .atKeys file will be used.
   AtEncryptionResult decryptString(

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -14,7 +14,6 @@ import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
 import 'package:at_chops/src/at_chops_base.dart';
 import 'package:at_chops/src/key/at_key_pair.dart';
 import 'package:at_chops/src/key/impl/aes_key.dart';
-import 'package:at_chops/src/key/impl/at_chops_keys.dart';
 import 'package:at_chops/src/key/impl/at_encryption_key_pair.dart';
 import 'package:at_chops/src/key/key_names.dart';
 import 'package:at_chops/src/key/key_type.dart';
@@ -27,7 +26,7 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_logger.dart';
 
 class AtChopsImpl extends AtChops {
-  AtChopsImpl(AtChopsKeys atChopsKeys) : super(atChopsKeys);
+  AtChopsImpl(super.atChopsKeys);
 
   final AtSignLogger _logger = AtSignLogger('AtChopsImpl');
 

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -214,7 +214,6 @@ class AtChopsImpl extends AtChops {
         throw AtEncryptionException(
             'Cannot find encryption algorithm for encryption key type $encryptionKeyType');
     }
-    return null;
   }
 
   AtEncryptionKeyPair? _getEncryptionKeyPair(String? keyName) {

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -7,7 +7,7 @@ import 'package:at_chops/src/algorithm/aes_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/algo_type.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/algorithm/at_iv.dart';
-import 'package:at_chops/src/algorithm/default_encryption_algo.dart';
+import 'package:at_chops/src/algorithm/rsa_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/default_signing_algo.dart';
 import 'package:at_chops/src/algorithm/ecc_signing_algo.dart';
 import 'package:at_chops/src/algorithm/pkam_signing_algo.dart';
@@ -201,14 +201,11 @@ class AtChopsImpl extends AtChops {
       EncryptionKeyType encryptionKeyType, String? keyName) {
     switch (encryptionKeyType) {
       case EncryptionKeyType.rsa2048:
-        return DefaultEncryptionAlgo.fromKeyPair(
-            _getEncryptionKeyPair(keyName)!);
+        return RsaEncryptionAlgo.fromKeyPair(_getEncryptionKeyPair(keyName)!);
       case EncryptionKeyType.rsa4096:
-        // TODO: Handle this case.
-        break;
+        throw AtEncryptionException('EncryptionKeyType.rsa4096 not supported');
       case EncryptionKeyType.ecc:
-        // TODO: Handle this case.
-        break;
+        throw AtEncryptionException('EncryptionKeyType.ecc not supported');
       case EncryptionKeyType.aes128:
         return AESEncryptionAlgo(_getSymmetricKey(keyName)! as AESKey);
       case EncryptionKeyType.aes256:

--- a/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
+++ b/packages/at_chops/lib/src/key/impl/at_chops_keys.dart
@@ -13,12 +13,6 @@ class AtChopsKeys {
   /// Key pair for data signing and verification
   AtSigningKeyPair? atSigningKeyPair;
 
-  @Deprecated('Use selfEncryptionKey')
-  SymmetricKey? get symmetricKey => selfEncryptionKey;
-
-  @Deprecated('Use selfEncryptionKey')
-  set symmetricKey(SymmetricKey? sk) => selfEncryptionKey = sk;
-
   /// Default self encryption key
   SymmetricKey? selfEncryptionKey;
 
@@ -28,11 +22,6 @@ class AtChopsKeys {
   AtChopsKeys.create(this.atEncryptionKeyPair, this._atPkamKeyPair);
 
   AtChopsKeys();
-
-  @Deprecated('Use selfEncryptionKey')
-  AtChopsKeys.createSymmetric(SymmetricKey sk) {
-    selfEncryptionKey = sk;
-  }
 
   AtPkamKeyPair? get atPkamKeyPair => _atPkamKeyPair;
 }

--- a/packages/at_chops/lib/src/key/impl/at_encryption_key_pair.dart
+++ b/packages/at_chops/lib/src/key/impl/at_encryption_key_pair.dart
@@ -1,6 +1,6 @@
 import 'package:at_chops/src/key/at_key_pair.dart';
 
 class AtEncryptionKeyPair extends AsymmetricKeyPair {
-  AtEncryptionKeyPair.create(String publicKey, String privateKey)
-      : super.create(publicKey, privateKey);
+  AtEncryptionKeyPair.create(super.publicKey, super.privateKey)
+      : super.create();
 }

--- a/packages/at_chops/lib/src/key/impl/at_pkam_key_pair.dart
+++ b/packages/at_chops/lib/src/key/impl/at_pkam_key_pair.dart
@@ -1,6 +1,5 @@
 import 'package:at_chops/src/key/at_key_pair.dart';
 
 class AtPkamKeyPair extends AsymmetricKeyPair {
-  AtPkamKeyPair.create(String publicKey, String privateKey)
-      : super.create(publicKey, privateKey);
+  AtPkamKeyPair.create(super.publicKey, super.privateKey) : super.create();
 }

--- a/packages/at_chops/lib/src/key/impl/at_signing_key_pair.dart
+++ b/packages/at_chops/lib/src/key/impl/at_signing_key_pair.dart
@@ -1,6 +1,5 @@
 import 'package:at_chops/src/key/at_key_pair.dart';
 
 class AtSigningKeyPair extends AsymmetricKeyPair {
-  AtSigningKeyPair.create(String publicKey, String privateKey)
-      : super.create(publicKey, privateKey);
+  AtSigningKeyPair.create(super.publicKey, super.privateKey) : super.create();
 }

--- a/packages/at_chops/lib/src/key/key_type.dart
+++ b/packages/at_chops/lib/src/key/key_type.dart
@@ -1,4 +1,1 @@
 enum EncryptionKeyType { rsa2048, rsa4096, ecc, aes128, aes192, aes256 }
-
-@Deprecated('use signing/hashing algo type from algo_type.dart')
-enum SigningKeyType { pkamSha256, signingSha256 }

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,10 +1,10 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 1.0.7
+version: 2.0.0
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:
-  sdk: '>=2.15.1 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   args: ^2.4.2
@@ -14,7 +14,7 @@ dependencies:
   ecdsa: ^0.1.0
   dart_periphery: ^0.9.5
   elliptic: ^0.3.10
-  pointycastle: ^3.7.3
+  pointycastle: ^3.7.4
   at_commons: ^4.0.0
   at_utils: ^3.0.16
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -45,7 +45,9 @@ void main() {
       final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
-          utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
+          // ignore: unnecessary_cast
+          utf8.encode(data) as Uint8List,
+          EncryptionKeyType.aes256,
           iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
       expect(encryptionResult.result, isNotEmpty);
@@ -75,7 +77,9 @@ void main() {
       final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
-          utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
+          // ignore: unnecessary_cast
+          utf8.encode(data) as Uint8List,
+          EncryptionKeyType.aes256,
           iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
       expect(encryptionResult.result, isNotEmpty);
@@ -105,7 +109,9 @@ void main() {
       final iv = AtChopsUtil.generateRandomIV(16);
 
       final encryptionResult = atChops.encryptBytes(
-          utf8.encode(data) as Uint8List, EncryptionKeyType.aes256,
+          // ignore: unnecessary_cast
+          utf8.encode(data) as Uint8List,
+          EncryptionKeyType.aes256,
           iv: iv);
       expect(encryptionResult.atEncryptionMetaData, isNotNull);
       expect(encryptionResult.result, isNotEmpty);
@@ -217,133 +223,6 @@ void main() {
   });
 
   group('A group of tests for data signing and verification', () {
-    test('Test pkam signing and verification', () {
-      String data = 'Hello World';
-      final atPkamKeyPair = AtChopsUtil.generateAtPkamKeyPair();
-      final atChopsKeys = AtChopsKeys.create(null, atPkamKeyPair);
-      final atChops = AtChopsImpl(atChopsKeys);
-
-      final signingResult = atChops.signBytes(
-          Uint8List.fromList(data.codeUnits),
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.pkamSha256);
-      expect(signingResult.atSigningMetaData, isNotNull);
-      expect(signingResult.result, isNotEmpty);
-      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(signingResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-
-      final verificationResult = atChops.verifySignatureBytes(
-          Uint8List.fromList(data.codeUnits),
-          signingResult.result,
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.pkamSha256);
-      expect(verificationResult.atSigningMetaData, isNotNull);
-      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(verificationResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(verificationResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-      expect(verificationResult.result, true);
-    });
-
-    test('Test data signing and verification - emoji char', () {
-      String data = 'Hello World🛠';
-      final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
-      final atChops = AtChopsImpl(atChopsKeys);
-
-      final signingResult = atChops.signBytes(
-          Uint8List.fromList(data.codeUnits),
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData, isNotNull);
-      expect(signingResult.result, isNotEmpty);
-      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(signingResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-
-      final verificationResult = atChops.verifySignatureBytes(
-          Uint8List.fromList(data.codeUnits),
-          signingResult.result,
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.signingSha256);
-      expect(verificationResult.atSigningMetaData, isNotNull);
-      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(verificationResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(verificationResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-      expect(verificationResult.result, true);
-    });
-
-    test('Test data signing and verification - special char', () {
-      String data = 'Hello\' World!*``';
-      final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
-      final atChops = AtChopsImpl(atChopsKeys);
-
-      final signingResult = atChops.signBytes(
-          Uint8List.fromList(data.codeUnits),
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData, isNotNull);
-      expect(signingResult.result, isNotEmpty);
-      expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
-      expect(signingResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(signingResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-
-      final verificationResult = atChops.verifySignatureBytes(
-          Uint8List.fromList(data.codeUnits),
-          signingResult.result,
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.signingSha256);
-      expect(verificationResult.atSigningMetaData, isNotNull);
-      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(verificationResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(verificationResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-      expect(verificationResult.result, true);
-    });
-
-    test('Test data signing and verification - string data type', () {
-      String data = 'Hello World🛠';
-      final atEncryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
-      final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
-      final atChops = AtChopsImpl(atChopsKeys);
-
-      final signingResult =
-          // ignore: deprecated_member_use_from_same_package
-          atChops.signString(data, SigningKeyType.signingSha256);
-      expect(signingResult.atSigningMetaData, isNotNull);
-      expect(signingResult.result, isNotEmpty);
-      expect(signingResult.atSigningResultType, AtSigningResultType.string);
-      expect(signingResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(signingResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-
-      final verificationResult = atChops.verifySignatureString(
-          data,
-          signingResult.result,
-          // ignore: deprecated_member_use_from_same_package
-          SigningKeyType.signingSha256);
-      expect(verificationResult.atSigningMetaData, isNotNull);
-      expect(verificationResult.atSigningResultType, AtSigningResultType.bool);
-      expect(verificationResult.atSigningMetaData.signingAlgoType,
-          SigningAlgoType.rsa2048);
-      expect(verificationResult.atSigningMetaData.hashingAlgoType,
-          HashingAlgoType.sha256);
-      expect(verificationResult.result, true);
-    });
-
     test('Test sign() and verify() with default algorithms', () {
       final data = 'testData';
       final encryptionKeypair = AtChopsUtil.generateAtEncryptionKeyPair();
@@ -360,6 +239,7 @@ void main() {
       expect(
           signingResult.result,
           base64Encode(rsaPrivateKey
+              // ignore: unnecessary_cast
               .createSHA256Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,
@@ -403,6 +283,7 @@ void main() {
       expect(
           signingResult.result,
           base64Encode(rsaPrivateKey
+              // ignore: unnecessary_cast
               .createSHA256Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,
@@ -449,6 +330,7 @@ void main() {
       expect(
           signingResult.result,
           base64Encode(rsaPrivateKey
+              // ignore: unnecessary_cast
               .createSHA512Signature(utf8.encode(data) as Uint8List)));
       expect(signingResult.atSigningResultType, AtSigningResultType.bytes);
       expect(signingResult.atSigningMetaData.signingAlgoType,

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(encryptionResult.atEncryptionMetaData.encryptionKeyType,
           EncryptionKeyType.rsa2048);
       expect(encryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
-          'DefaultEncryptionAlgo');
+          'RsaEncryptionAlgo');
 
       final decryptionResult = atChops.decryptString(
           encryptionResult.result, EncryptionKeyType.rsa2048);
@@ -33,7 +33,7 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.encryptionKeyType,
           EncryptionKeyType.rsa2048);
       expect(decryptionResult.atEncryptionMetaData.atEncryptionAlgorithm,
-          'DefaultEncryptionAlgo');
+          'RsaEncryptionAlgo');
       expect(decryptionResult.result, data);
     });
 

--- a/packages/at_chops/test/default_encryption_algo_test.dart
+++ b/packages/at_chops/test/default_encryption_algo_test.dart
@@ -1,8 +1,6 @@
 import 'dart:convert';
 
 import 'package:at_chops/at_chops.dart';
-import 'package:at_chops/src/key/at_private_key.dart';
-import 'package:at_chops/src/key/at_public_key.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
@@ -15,20 +13,21 @@ void main() {
       var rsa2048KeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       var rsaPublicKey = rsa2048KeyPair.atPublicKey;
       var dataToEncrypt = 'Hello World12!@';
-      var encryptedData = defaultEncryptionAlgo
-          .encrypt(utf8.encode(dataToEncrypt), atPublicKey: rsaPublicKey);
+      defaultEncryptionAlgo.atPublicKey = rsaPublicKey;
+      var encryptedData =
+          defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt));
       var rsaPrivateKey = rsa2048KeyPair.atPrivateKey;
-      var decryptedData = defaultEncryptionAlgo.decrypt(encryptedData,
-          atPrivateKey: rsaPrivateKey);
+      defaultEncryptionAlgo.atPrivateKey = rsaPrivateKey;
+      var decryptedData = defaultEncryptionAlgo.decrypt(encryptedData);
       expect(utf8.decode(decryptedData), dataToEncrypt);
     });
     test('Test encrypt throws exception when passed public key is null', () {
       var defaultEncryptionAlgo = DefaultEncryptionAlgo();
       var dataToEncrypt = 'Hello World12!@';
       AtPublicKey? publicKey;
+      defaultEncryptionAlgo.atPublicKey = publicKey;
       expect(
-          () => defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt),
-              atPublicKey: publicKey),
+          () => defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt)),
           throwsA(predicate((e) =>
               e is AtEncryptionException &&
               e.toString().contains('EncryptionKeypair/public key not set'))));
@@ -37,9 +36,9 @@ void main() {
       var defaultEncryptionAlgo = DefaultEncryptionAlgo();
       var encryptedData = 'random data';
       AtPrivateKey? privateKey;
+      defaultEncryptionAlgo.atPrivateKey = privateKey;
       expect(
-          () => defaultEncryptionAlgo.decrypt(utf8.encode(encryptedData),
-              atPrivateKey: privateKey),
+          () => defaultEncryptionAlgo.decrypt(utf8.encode(encryptedData)),
           throwsA(predicate((e) =>
               e is AtDecryptionException &&
               e.toString().contains('EncryptionKeypair/public key not set'))));

--- a/packages/at_chops/test/default_encryption_algo_test.dart
+++ b/packages/at_chops/test/default_encryption_algo_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/key/at_private_key.dart';
+import 'package:at_chops/src/key/at_public_key.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+      'A group of tests for encryption/decryption by passing public/private key',
+      () {
+    test('Test asymmetric encryption/decryption using rsa 2048', () {
+      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var rsa2048KeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      var rsaPublicKey = rsa2048KeyPair.atPublicKey;
+      var dataToEncrypt = 'Hello World12!@';
+      var encryptedData = defaultEncryptionAlgo
+          .encrypt(utf8.encode(dataToEncrypt), atPublicKey: rsaPublicKey);
+      var rsaPrivateKey = rsa2048KeyPair.atPrivateKey;
+      var decryptedData = defaultEncryptionAlgo.decrypt(encryptedData,
+          atPrivateKey: rsaPrivateKey);
+      expect(utf8.decode(decryptedData), dataToEncrypt);
+    });
+    test('Test encrypt throws exception when passed public key is null', () {
+      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var dataToEncrypt = 'Hello World12!@';
+      AtPublicKey? publicKey;
+      expect(
+          () => defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt),
+              atPublicKey: publicKey),
+          throwsA(predicate((e) =>
+              e is AtEncryptionException &&
+              e.toString().contains('EncryptionKeypair/public key not set'))));
+    });
+    test('Test decrypt throws exception when passed private key is null', () {
+      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var encryptedData = 'random data';
+      AtPrivateKey? privateKey;
+      expect(
+          () => defaultEncryptionAlgo.decrypt(utf8.encode(encryptedData),
+              atPrivateKey: privateKey),
+          throwsA(predicate((e) =>
+              e is AtDecryptionException &&
+              e.toString().contains('EncryptionKeypair/public key not set'))));
+    });
+  });
+
+  group(
+      'A group of tests for encryption/decryption by setting encryption key pair',
+      () {
+    test('Test asymmetric encryption/decryption using rsa 2048 key pair', () {
+      var rsa2048KeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      var defaultEncryptionAlgo =
+          DefaultEncryptionAlgo.fromKeyPair(rsa2048KeyPair);
+      var dataToEncrypt = 'Hello World12!@';
+      var encryptedData =
+          defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt));
+      var decryptedData = defaultEncryptionAlgo.decrypt(encryptedData);
+      expect(utf8.decode(decryptedData), dataToEncrypt);
+    });
+    test('Test encrypt throws exception when encryption keypair is null', () {
+      var defaultEncryptionAlgo = DefaultEncryptionAlgo.fromKeyPair(null);
+      var dataToEncrypt = 'Hello World12!@';
+      expect(
+          () => defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt)),
+          throwsA(predicate((e) =>
+              e is AtEncryptionException &&
+              e.toString().contains('EncryptionKeypair/public key not set'))));
+    });
+    test('Test decrypt throws exception when encryption keypair is null', () {
+      var defaultEncryptionAlgo = DefaultEncryptionAlgo.fromKeyPair(null);
+      var encryptedData = 'random data';
+      expect(
+          () => defaultEncryptionAlgo.decrypt(utf8.encode(encryptedData)),
+          throwsA(predicate((e) =>
+              e is AtDecryptionException &&
+              e.toString().contains('EncryptionKeypair/public key not set'))));
+    });
+  });
+}

--- a/packages/at_chops/test/rsa_encryption_algo_test.dart
+++ b/packages/at_chops/test/rsa_encryption_algo_test.dart
@@ -9,7 +9,7 @@ void main() {
       'A group of tests for encryption/decryption by passing public/private key',
       () {
     test('Test asymmetric encryption/decryption using rsa 2048', () {
-      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var defaultEncryptionAlgo = RsaEncryptionAlgo();
       var rsa2048KeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       var rsaPublicKey = rsa2048KeyPair.atPublicKey;
       var dataToEncrypt = 'Hello World12!@';
@@ -22,7 +22,7 @@ void main() {
       expect(utf8.decode(decryptedData), dataToEncrypt);
     });
     test('Test encrypt throws exception when passed public key is null', () {
-      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var defaultEncryptionAlgo = RsaEncryptionAlgo();
       var dataToEncrypt = 'Hello World12!@';
       AtPublicKey? publicKey;
       defaultEncryptionAlgo.atPublicKey = publicKey;
@@ -33,7 +33,7 @@ void main() {
               e.toString().contains('EncryptionKeypair/public key not set'))));
     });
     test('Test decrypt throws exception when passed private key is null', () {
-      var defaultEncryptionAlgo = DefaultEncryptionAlgo();
+      var defaultEncryptionAlgo = RsaEncryptionAlgo();
       var encryptedData = 'random data';
       AtPrivateKey? privateKey;
       defaultEncryptionAlgo.atPrivateKey = privateKey;
@@ -51,7 +51,7 @@ void main() {
     test('Test asymmetric encryption/decryption using rsa 2048 key pair', () {
       var rsa2048KeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
       var defaultEncryptionAlgo =
-          DefaultEncryptionAlgo.fromKeyPair(rsa2048KeyPair);
+          RsaEncryptionAlgo.fromKeyPair(rsa2048KeyPair);
       var dataToEncrypt = 'Hello World12!@';
       var encryptedData =
           defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt));
@@ -59,7 +59,7 @@ void main() {
       expect(utf8.decode(decryptedData), dataToEncrypt);
     });
     test('Test encrypt throws exception when encryption keypair is null', () {
-      var defaultEncryptionAlgo = DefaultEncryptionAlgo.fromKeyPair(null);
+      var defaultEncryptionAlgo = RsaEncryptionAlgo.fromKeyPair(null);
       var dataToEncrypt = 'Hello World12!@';
       expect(
           () => defaultEncryptionAlgo.encrypt(utf8.encode(dataToEncrypt)),
@@ -68,7 +68,7 @@ void main() {
               e.toString().contains('EncryptionKeypair/public key not set'))));
     });
     test('Test decrypt throws exception when encryption keypair is null', () {
-      var defaultEncryptionAlgo = DefaultEncryptionAlgo.fromKeyPair(null);
+      var defaultEncryptionAlgo = RsaEncryptionAlgo.fromKeyPair(null);
       var encryptedData = 'random data';
       expect(
           () => defaultEncryptionAlgo.decrypt(utf8.encode(encryptedData)),


### PR DESCRIPTION
**- What I did**
- Currently at_chops uses encryptionKeyPair from AtChopsKeys for Asymmetric encryption/decryption. It is not possible to use another atsign's public key for encryption.  Made changes to enable asymmetric algorithm to set new public key for encryption
- Removed deprecated methods/classes for major version release
**- How I did it**
- Introduced a new interface in at_algorithm.dart ASymmetricEncryptionAlgorithm which has AtPublicKey and AtPrivateKey attributes
- Extended DefaultEncryptionAlgo from ASymmetricEncryptionAlgorithm. Removed iv from optional param since it is not needed for asymmetric encryption/decryption. Modified encrypt/decrypt implementation to try reading from set AtPublicKey/AtPrivateKey. Otherwise fallback to default behavior of using encryption keys from EncryptionKeyPair
- Removed methods signBytes, verifySignatureBytes, signString, verifySignatureString which are deprecated/not required
- Removed deprecated symmetricKey from AtChopsKeys
- Removed deprecated SigningKeyType from key_type.dart
- analyzer fixes

**- How to verify it**
- unit tests should pass
- at_client tests pointing to this branch should pass
https://github.com/atsign-foundation/at_client_sdk/pull/1213
