### PR TITLE
build: uptake at_chops major version

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.45
+- build[deps]: Upgraded at_chops to v2.0.0
 ## 3.0.44
 - build[deps]: Upgraded the following packages:
     - at_commons to v4.0.0

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.44
+version: 3.0.45
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -16,15 +16,8 @@ dependencies:
   at_commons: ^4.0.0
   mutex: ^3.0.0
   meta: ^1.8.0
-  at_chops: ^1.0.7
+  at_chops: ^2.0.0
 
-#TODO - replace with published version
-dependency_overrides:
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_chops
-      ref: pass_optional_key_params
 dev_dependencies:
   mocktail: ^1.0.1
   lints: ^1.0.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -18,6 +18,13 @@ dependencies:
   meta: ^1.8.0
   at_chops: ^1.0.7
 
+#TODO - replace with published version
+dependency_overrides:
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_chops
+      ref: pass_optional_key_params
 dev_dependencies:
   mocktail: ^1.0.1
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
 - uptake at_chops major version in at_lookup
**- How I did it**
- updated at_chops dependency in pubspec
- No impact in at_lookup since only at_chop.sign method (which has no changes in major version) is used.
**- How to verify it**
- tests should pass
