### PR TITLE
build: Uptake at chops major version atauth

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+- build[deps]: Upgraded the following packages:
+  - at_chops to v2.0.0
+  - at_lookup to v3.0.45
 ## 1.0.4
 - build[deps]: Upgraded the following packages:
     - at_commons to v4.0.0

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -16,17 +16,12 @@ dependencies:
   at_demo_data: ^1.0.3
   crypton: ^2.1.0
 
-# dependency_overrides:
-#   at_lookup:
-#     git:
-#       url: https://github.com/atsign-foundation/at_libraries.git
-#       path: packages/at_lookup
-#       ref: uptake_commons_changes_into_lookup
-#   at_chops:
-#     git:
-#       url: https://github.com/atsign-foundation/at_libraries.git
-#       path: packages/at_chops
-#       ref: uptake_commons_into_atchops
+dependency_overrides:
+  at_chops:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_chops
+      ref: pass_optional_key_params
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   at_utils: ^3.0.16
   meta: ^1.8.0
   at_demo_data: ^1.0.3
-  crypton: ^2.1.0
+  crypton: ^2.2.1
 
 dependency_overrides:
   at_chops:

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 1.0.4
+version: 1.0.5
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 
@@ -9,19 +9,12 @@ environment:
 
 dependencies:
   at_commons: ^4.0.0
-  at_lookup: ^3.0.44
-  at_chops: ^1.0.7
+  at_lookup: ^3.0.45
+  at_chops: ^2.0.0
   at_utils: ^3.0.16
   meta: ^1.8.0
   at_demo_data: ^1.0.3
   crypton: ^2.2.1
-
-dependency_overrides:
-  at_chops:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_chops
-      ref: pass_optional_key_params
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
**- What I did**
- uptake at_chop major version in at_auth
**- How I did it**
- changed at_chops version from 1.0.7 to 2.0.0
- changed at_lookup version from 3.0.44 to 3.0.45
**- How to verify it**
- unit tests should pass
