### PR TITLE
feat: Add InvalidPinException thrown when an invalid Semi Permanent P…

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.1
+- fix: Add "InvalidPinException" which is thrown when an invalid Semi Permanent Passcode is submitted.
 ## 4.0.0
 - [Breaking Change] fix: Updated regex for Reserved keys (Internal keys used by the server)
 - fix: Add "put" operation to OTP verb to store semi-permanent pass codes

--- a/packages/at_commons/lib/src/exception/at_client_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_client_exceptions.dart
@@ -74,3 +74,9 @@ class AtKeyNotFoundException extends AtClientException {
       : super.message(message,
             intent: intent, exceptionScenario: exceptionScenario);
 }
+
+class InvalidPinException extends AtClientException {
+  InvalidPinException(errorCode, message) : super(errorCode, message);
+
+  InvalidPinException.message(String message) : super.message(message);
+}

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.0
+version: 4.0.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add InvalidPinException which is thrown when an invalid semi permanent pass-code is supplied by the mobile apps via the at_client SDK.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
