### PR TITLE
feat: Modify "executeCommand" to throw exception on error response from atServer (as "executeVerb" does)

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.46
+- fix: Modify "executeCommand" to parse the error response from server and return appropriate exception
 ## 3.0.45
 - build[deps]: Upgraded at_chops to v2.0.0
 ## 3.0.44

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -326,10 +326,22 @@ class AtLookupImpl implements AtLookUp {
     // Setting the errorCode and errorDescription to default values.
     var errorCode = 'AT0014';
     var errorDescription = 'Unknown server error';
-
-    var errorMap = jsonDecode(verbResult);
-    errorCode = errorMap['errorCode'];
-    errorDescription = errorMap['errorDescription'];
+    try {
+      var errorMap = jsonDecode(verbResult);
+      errorCode = errorMap['errorCode'];
+      errorDescription = errorMap['errorDescription'];
+    } on FormatException {
+      // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
+      // TODO: Can we remove the below catch block in next release once all the servers are migrated to new version.
+      if (verbResult.contains('-')) {
+        if (verbResult.split('-')[0].isNotEmpty) {
+          errorCode = verbResult.split('-')[0];
+        }
+        if (verbResult.split('-')[1].isNotEmpty) {
+          errorDescription = verbResult.split('-')[1];
+        }
+      }
+    }
 
     throw AtLookUpException(errorCode, errorDescription);
   }

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -301,41 +301,37 @@ class AtLookupImpl implements AtLookUp {
       var errorCode = AtLookUpExceptionUtil.getErrorCode(e);
       throw AtLookUpException(errorCode, e.toString());
     }
+    return _verbResponseHandler(verbResult);
+  }
+
+  String _verbResponseHandler(String verbResult) {
     // If connection time-out, do not return empty verbResult;
     // throw AtLookupException.
     if (verbResult.isEmpty) {
       throw AtLookUpException('AT0014', 'Request timed out');
     }
-    // If response starts with error:, throw AtLookupException.
-    if (_isError(verbResult)) {
-      verbResult = verbResult.replaceAll('error:', '');
-      // Setting the errorCode and errorDescription to default values.
-      var errorCode = 'AT0014';
-      var errorDescription = 'Unknown server error';
-      try {
-        var errorMap = jsonDecode(verbResult);
-        errorCode = errorMap['errorCode'];
-        errorDescription = errorMap['errorDescription'];
-      } on FormatException {
-        // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
-        // TODO: Can we remove the below catch block in next release once all the servers are migrated to new version.
-        if (verbResult.contains('-')) {
-          if (verbResult.split('-')[0].isNotEmpty) {
-            errorCode = verbResult.split('-')[0];
-          }
-          if (verbResult.split('-')[1].isNotEmpty) {
-            errorDescription = verbResult.split('-')[1];
-          }
-        }
-      }
-      throw AtLookUpException(errorCode, errorDescription);
+    // Response starting with "data:", represents successfully processing of verb
+    // return the response.
+    if (verbResult.startsWith('data:')) {
+      return verbResult;
     }
-    // Return the verb result.
+    if (verbResult.startsWith('error:')) {
+      _errorResponseHandler(verbResult);
+    }
     return verbResult;
   }
 
-  bool _isError(String verbResult) {
-    return verbResult.startsWith('error:');
+  void _errorResponseHandler(String verbResult) {
+    verbResult = verbResult.replaceAll('error:', '');
+    // Setting the errorCode and errorDescription to default values.
+    var errorCode = 'AT0014';
+    var errorDescription = 'Unknown server error';
+
+    var errorMap = jsonDecode(verbResult);
+    errorCode = errorMap['errorCode'];
+    errorDescription = errorMap['errorDescription'];
+
+    throw AtLookUpException(errorCode, errorDescription);
   }
 
   Future<String> _update(UpdateVerbBuilder builder) async {
@@ -402,7 +398,8 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   Future<String?> executeCommand(String atCommand, {bool auth = false}) async {
-    return await _process(atCommand, auth: auth);
+    String verbResponse = await _process(atCommand, auth: auth);
+    return _verbResponseHandler(verbResponse);
   }
 
   final Mutex _pkamAuthenticationMutex = Mutex();
@@ -537,7 +534,7 @@ class AtLookupImpl implements AtLookUp {
   }
 
   @Deprecated('use AtLookup().cramAuthenticate()')
-  // ignore: non_constant_identifier_names
+// ignore: non_constant_identifier_names
   Future<bool> authenticate_cram(var secret) async {
     secret ??= cramSecret;
     if (secret == null) {

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.45
+version: 3.0.46
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Currently, the server response are only parsed in the "executeVerb" method. But the requests that sent via the "executeCommand" are not parsed. The responses are returned as is to the client.
- Modify the "executeCommand" method to parse the server response and then return the response or the exception.

**- How I did**
- Move the logic that parses the server response in the "executeVerb" method to a private method "_verbResponseHandler". 
- Move the logic that parses the error response to a private method "_errorResponseHandler". The "_verbResponseHandler" invokes the "_errorResponseHandler" if the server response starts with "error:".
- Pass the response received via the execute command to _verbResponseHandler to parse the server response.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
