### PR TITLE
fix: Corresponding to the changes in server rename encryptedDefaultEn…

### DIFF
--- a/packages/at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart
+++ b/packages/at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart
@@ -65,7 +65,7 @@ Future<void> _notificationCallback(AtNotification notification,
         atAuthKeys.defaultEncryptionPrivateKey!, apkamSymmetricKey);
     var encryptedDefaultSelfEncKey = EncryptionUtil.encryptValue(
         atAuthKeys.defaultSelfEncryptionKey!, apkamSymmetricKey);
-    enrollParamsJson['encryptedDefaultEncryptedPrivateKey'] =
+    enrollParamsJson['encryptedDefaultEncryptionPrivateKey'] =
         encryptedDefaultPrivateEncKey;
     enrollParamsJson['encryptedDefaultSelfEncryptionKey'] =
         encryptedDefaultSelfEncKey;

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -211,7 +211,7 @@ Future<void> _notificationCallback(
       EncryptionUtil.encryptValue(encryptionPrivateKey, apkamSymmetricKey);
   var encryptedDefaultSelfEncKey =
       EncryptionUtil.encryptValue(selfEncryptionKey!, apkamSymmetricKey);
-  enrollParamsJson['encryptedDefaultEncryptedPrivateKey'] =
+  enrollParamsJson['encryptedDefaultEncryptionPrivateKey'] =
       encryptedDefaultPrivateEncKey;
   enrollParamsJson['encryptedDefaultSelfEncryptionKey'] =
       encryptedDefaultSelfEncKey;


### PR DESCRIPTION
…cryptedPrivateKey to encryptedDefaultEncryptionPrivateKey

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the failing functional test. The test failed because, the when sending encryption private key to the server in json, the key was earlier named as "encryptedDefaultEncryptedPrivateKey" which is later changed to "encryptedDefaultEncryptionPrivateKey" in the server. Updated the value in the test and in the example.

**- How to verify it**
- The functional test should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
