### PR TITLE
fix: Null pointer exception when pubKeyHash is null

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.3
+- fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.    
 ## 4.0.2
 - feat: changes to replace md5 checksum - deprecated pubKeyCS in AtKey and introduced new class PublicKeyHash
 ## 4.0.1

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -704,6 +704,12 @@ class Metadata {
     if (fullJson || skeEncAlgo != null) {
       map[AtConstants.sharedKeyEncryptedEncryptingAlgo] = skeEncAlgo;
     }
+    if (fullJson || namespaceAware) {
+      map['namespaceAware'] = namespaceAware;
+    }
+    if (fullJson || isCached) {
+      map['isCached'] = isCached;
+    }
     return map;
   }
 

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -683,7 +683,7 @@ class Metadata {
       // ignore: deprecated_member_use_from_same_package
       map[AtConstants.sharedWithPublicKeyCheckSum] = pubKeyCS;
     }
-    if (fullJson || pubKeyHash != null) {
+    if (fullJson && pubKeyHash != null) {
       map[AtConstants.sharedWithPublicKeyHash] = pubKeyHash!.toJson();
     }
     if (fullJson || encoding != null) {

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -683,8 +683,8 @@ class Metadata {
       // ignore: deprecated_member_use_from_same_package
       map[AtConstants.sharedWithPublicKeyCheckSum] = pubKeyCS;
     }
-    if (fullJson && pubKeyHash != null) {
-      map[AtConstants.sharedWithPublicKeyHash] = pubKeyHash!.toJson();
+    if (fullJson || pubKeyHash != null) {
+      map[AtConstants.sharedWithPublicKeyHash] = pubKeyHash?.toJson();
     }
     if (fullJson || encoding != null) {
       map[AtConstants.encoding] = encoding;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.2
+version: 4.0.3
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -987,4 +987,60 @@ void main() {
       expect(metadataObject.pubKeyHash, null);
     });
   });
+
+  group('A group of tests to verify at_key metadata',(){
+    test('A test to verify toJson invoked on empty metadata should not throw exception',(){
+      Metadata metadata = Metadata();
+      Map metadataMap = metadata.toJson();
+      expect(metadataMap['availableAt'], null);
+      expect(metadataMap['expiresAt'], null);
+      expect(metadataMap['refreshAt'], null);
+      expect(metadataMap['createdAt'], null);
+      expect(metadataMap['updatedAt'], null);
+      expect(metadataMap['isPublic'], false);
+      expect(metadataMap['ttl'], null);
+      expect(metadataMap['ttb'], null);
+      expect(metadataMap['ttr'], null);
+      expect(metadataMap['ccd'], null);
+      expect(metadataMap['isBinary'], false);
+      expect(metadataMap['isEncrypted'], false);
+      expect(metadataMap['dataSignature'], null);
+      expect(metadataMap['sharedKeyStatus'], null);
+      expect(metadataMap['pubKeyCS'], null);
+      expect(metadataMap['encoding'], null);
+      expect(metadataMap['encKeyName'], null);
+      expect(metadataMap['encAlgo'], null);
+      expect(metadataMap['ivNonce'], null);
+      expect(metadataMap['skeEncKeyName'], null);
+      expect(metadataMap['skeEncAlgo'], null);
+      expect(metadataMap['pubKeyHash'], null);
+    });
+
+    test('A test to verify toJson when metadata is populated',(){
+      Metadata metadata = Metadata()
+      ..ttl = 100
+      ..ttb = 100
+      ..ttr = 1
+      ..ccd = true
+      ..dataSignature = 'dummy_data_signature'
+      ..isPublic = true
+      ..isEncrypted = true
+      ..isCached = true
+      ..sharedKeyEnc = 'dummy_shared_key_enc'
+      ..pubKeyHash = PublicKeyHash('test_hash', PublicKeyHashingAlgo.sha256)
+      ..isBinary = true;
+      Map metadataMap = metadata.toJson();
+      expect(metadataMap['isPublic'], true);
+      expect(metadataMap['ttl'], 100);
+      expect(metadataMap['ttb'], 100);
+      expect(metadataMap['ttr'], 1);
+      expect(metadataMap['ccd'], true);
+      expect(metadataMap['isBinary'], true);
+      expect(metadataMap['isEncrypted'], true);
+      expect(metadataMap['dataSignature'], 'dummy_data_signature');
+      expect(metadataMap['sharedKeyEnc'], 'dummy_shared_key_enc');
+      expect(metadataMap['pubKeyHash']['hash'], 'test_hash');
+      expect(metadataMap['pubKeyHash']['algo'], 'sha256');
+    });
+  });
 }

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -988,8 +988,10 @@ void main() {
     });
   });
 
-  group('A group of tests to verify at_key metadata',(){
-    test('A test to verify toJson invoked on empty metadata should not throw exception',(){
+  group('A group of tests to verify at_key metadata', () {
+    test(
+        'A test to verify toJson invoked on empty metadata should not throw exception',
+        () {
       Metadata metadata = Metadata();
       Map metadataMap = metadata.toJson();
       expect(metadataMap['availableAt'], null);
@@ -1002,8 +1004,10 @@ void main() {
       expect(metadataMap['ttb'], null);
       expect(metadataMap['ttr'], null);
       expect(metadataMap['ccd'], null);
+      expect(metadataMap['namespaceAware'], true);
       expect(metadataMap['isBinary'], false);
       expect(metadataMap['isEncrypted'], false);
+      expect(metadataMap['isCached'], false);
       expect(metadataMap['dataSignature'], null);
       expect(metadataMap['sharedKeyStatus'], null);
       expect(metadataMap['pubKeyCS'], null);
@@ -1016,31 +1020,58 @@ void main() {
       expect(metadataMap['pubKeyHash'], null);
     });
 
-    test('A test to verify toJson when metadata is populated',(){
+    test('A test to verify toJson when metadata is populated', () {
       Metadata metadata = Metadata()
-      ..ttl = 100
-      ..ttb = 100
-      ..ttr = 1
-      ..ccd = true
-      ..dataSignature = 'dummy_data_signature'
-      ..isPublic = true
-      ..isEncrypted = true
-      ..isCached = true
-      ..sharedKeyEnc = 'dummy_shared_key_enc'
-      ..pubKeyHash = PublicKeyHash('test_hash', PublicKeyHashingAlgo.sha256)
-      ..isBinary = true;
+        ..ttl = 100
+        ..ttb = 100
+        ..ttr = 1
+        ..ccd = true
+        ..availableAt = DateTime.parse('2024-02-24T13:27:00z')
+        ..expiresAt = DateTime.parse('2024-02-24T14:27:00z')
+        ..refreshAt = DateTime.parse('2024-02-24T15:27:00z')
+        ..createdAt = DateTime.parse('2024-02-24T16:27:00z')
+        ..updatedAt = DateTime.parse('2024-02-24T17:27:00z')
+        ..dataSignature = 'dummy_data_signature'
+        ..sharedKeyStatus = 'delivered'
+        ..isPublic = true
+        ..namespaceAware = false
+        ..isBinary = true
+        ..isEncrypted = true
+        ..isCached = false
+        ..sharedKeyEnc = 'dummy_shared_key_enc'
+        ..pubKeyHash = PublicKeyHash('test_hash', PublicKeyHashingAlgo.sha256)
+        ..encoding = 'base64'
+        ..encKeyName = 'key_12345.__shared_keys.wavi'
+        ..encAlgo = 'RSA'
+        ..ivNonce = '16'
+        ..skeEncKeyName = 'dummy_enc_key_name'
+        ..skeEncAlgo = 'RSA';
       Map metadataMap = metadata.toJson();
-      expect(metadataMap['isPublic'], true);
       expect(metadataMap['ttl'], 100);
       expect(metadataMap['ttb'], 100);
       expect(metadataMap['ttr'], 1);
       expect(metadataMap['ccd'], true);
+      expect(metadataMap['availableAt'], '2024-02-24 13:27:00.000Z');
+      expect(metadataMap['expiresAt'], '2024-02-24 14:27:00.000Z');
+      expect(metadataMap['refreshAt'], '2024-02-24 15:27:00.000Z');
+      expect(metadataMap['createdAt'], '2024-02-24 16:27:00.000Z');
+      expect(metadataMap['updatedAt'], '2024-02-24 17:27:00.000Z');
+      expect(metadataMap['dataSignature'], 'dummy_data_signature');
+      expect(metadataMap['sharedKeyStatus'], 'delivered');
+      expect(metadataMap['isPublic'], true);
+      expect(metadataMap['namespaceAware'], false);
       expect(metadataMap['isBinary'], true);
       expect(metadataMap['isEncrypted'], true);
-      expect(metadataMap['dataSignature'], 'dummy_data_signature');
+      expect(metadataMap['isCached'], false);
       expect(metadataMap['sharedKeyEnc'], 'dummy_shared_key_enc');
       expect(metadataMap['pubKeyHash']['hash'], 'test_hash');
       expect(metadataMap['pubKeyHash']['algo'], 'sha256');
+      expect(metadataMap['encoding'], 'base64');
+      expect(metadataMap['encKeyName'], 'key_12345.__shared_keys.wavi');
+      expect(metadataMap['encAlgo'], 'RSA');
+      expect(metadataMap['ivNonce'], '16');
+      expect(metadataMap['skeEncKeyName'], 'dummy_enc_key_name');
+      expect(metadataMap['skeEncAlgo'], 'RSA');
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes https://github.com/atsign-foundation/at_libraries/issues/521

**- How I did it**
- when `fullJson` is set to true (the default value), the resultant map contains all the fields. If the value is not set, null is populated. To be consistent with the other fields, changed the implementation as `pubKeyHash!.toJson()` to `pubKeyHash?.toJson()`

**- How to verify it**
- Raised a draft PR in at_client_sdk to verify the changes: https://github.com/atsign-foundation/at_client_sdk/pull/1245
- Added unit tests to assert the changes.

**- Description for the changelog**
- fix: Null pointer exception when pubKeyHash is null
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
