### PR TITLE
fix: Add ignore to fix dart analyze issue

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,6 +1,7 @@
+## 4.0.3
+- fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.
 ## 4.0.2
 - feat: changes to replace md5 checksum - deprecated pubKeyCS in AtKey and introduced new class PublicKeyHash
-- fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.
 ## 4.0.1
 - fix: Add "InvalidPinException" which is thrown when an invalid Semi Permanent Passcode is submitted.
 ## 4.0.0

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 4.0.3
-- fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.    
 ## 4.0.2
 - feat: changes to replace md5 checksum - deprecated pubKeyCS in AtKey and introduced new class PublicKeyHash
+- fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.
 ## 4.0.1
 - fix: Add "InvalidPinException" which is thrown when an invalid Semi Permanent Passcode is submitted.
 ## 4.0.0

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.2
+version: 4.0.3
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.3
+version: 4.0.2
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -57,6 +57,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
+      // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
         ..ttln = 100;
@@ -82,6 +83,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
+      // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
         ..atKey.metadata.isEncrypted = true;
@@ -109,6 +111,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
+        // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
         ..atKey.metadata.encKeyName = 'ekn'

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -39,6 +39,7 @@ void main() {
         ..atKey.key = 'email.wavi'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
+      // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = pubKeyCS
         ..atKey.metadata.sharedKeyEnc = ske
         ..atKey.metadata.skeEncKeyName = skeEncKeyName
@@ -130,6 +131,7 @@ void main() {
         ..atKey.key = 'cabbages_and_kings.wonderland'
         ..atKey.sharedBy = '@walrus'
         ..atKey.sharedWith = '@carpenter'
+      // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = pubKeyCS
         ..atKey.metadata.sharedKeyEnc = ske
         ..atKey.metadata.skeEncKeyName = skeEncKeyName
@@ -415,6 +417,7 @@ void main() {
         ..atKey.metadata.isBinary = isBinary
         ..atKey.metadata.isEncrypted = isEncrypted
         ..atKey.metadata.sharedKeyEnc = sharedKeyEncrypted
+      // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = pubKeyChecksum
         ..atKey.metadata.encoding = encoding
         ..atKey.metadata.encKeyName = encKeyName


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix dart analyze issues in at_commons
- When running `dart pub publish --dry-run` observed the below message, which says to use at_commons-4.0.2 (which is retracted version).  Hence setting back the at_commons version to 4.0.2

```
Total compressed archive size: 59 KB.
Validating package... (2.3s)
Package validation found the following hint:
* The previous version is 4.0.1.

  It seems you are not publishing an incremental update.

  Consider one of:
  * 5.0.0 for a breaking release.
  * 4.1.0 for a minor release.
  * 4.0.2 for a patch release.

Package has 0 warnings and 1 hint.
The server may enforce additional checks.
```


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
