### PR TITLE
fix: added more checks for apkam tests in at_onboarding_cli

### DIFF
--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_utils/at_utils.dart';
@@ -32,50 +33,78 @@ void main() {
       bool status = await onboardingService_1.onboard();
       expect(status, true);
       preference_1.privateKey = pkamPrivateKey;
+      var keysFilePath = preference_1.atKeysFilePath;
+      var keysFile = File(keysFilePath!);
+      expect(keysFile.existsSync(), true);
+      var keysFileContent = keysFile.readAsStringSync();
+      var keysFileJson = jsonDecode(keysFileContent);
+      expect(keysFileJson['enrollmentId'], isNotEmpty);
+      expect(keysFileJson['apkamSymmetricKey'], isNotEmpty);
 
       //2. authenticate first client
-      await onboardingService_1.authenticate();
+      var authResult = await onboardingService_1.authenticate();
+      expect(authResult, true);
       await _setLastReceivedNotificationDateTime(
           onboardingService_1.atClient!, atSign);
 
-      //3. run otp:get from first client
-      String? totp = await onboardingService_1.atClient!
+      Map<String, String> namespaces = {"buzz": "rw"};
+      //3.1 test invalid otp
+      String? totp = 'a6b4df';
+      AtOnboardingPreference enrollPreference_2 =
+          getPreferenceForEnroll(atSign);
+      final onboardingService_2 =
+          AtOnboardingServiceImpl(atSign, enrollPreference_2);
+      expect(
+          () async =>
+              onboardingService_2.enroll('buzz', 'iphone', totp!, namespaces),
+          throwsA(predicate((dynamic e) =>
+              e is AtLookUpException &&
+              e.errorCode == 'AT0011' &&
+              e.errorMessage!
+                  .contains('invalid otp. Cannot process enroll request'))));
+
+      //3.2 run otp:get from first client
+      totp = await onboardingService_1.atClient!
           .getRemoteSecondary()!
           .executeCommand('otp:get\n', auth: true);
       totp = totp!.replaceFirst('data:', '');
       totp = totp.trim();
       logger.finer('otp: $totp');
-      Map<String, String> namespaces = {"buzz": "rw"};
 
-      //4. enroll second client
-      AtOnboardingPreference enrollPreference_2 =
-          getPreferenceForEnroll(atSign);
-      final onboardingService_2 =
-          AtOnboardingServiceImpl(atSign, enrollPreference_2);
+      //3.3. enroll second client with valid otp
       var enrollResponse =
           await onboardingService_2.enroll('buzz', 'iphone', totp, namespaces);
       logger.finer('enroll response $enrollResponse');
       // enrollment id from the response
       var enrollmentId = enrollResponse.enrollmentId;
+      expect(enrollmentId, isNotEmpty);
+      expect(enrollResponse.enrollStatus, EnrollmentStatus.pending);
       var completer = Completer<void>(); // Create a Completer
 
-      //5. listen for notification from first client and invoke callback which approves the enrollment
+      //4. listen for notification from first client and invoke callback which approves the enrollment
       onboardingService_1.atClient!.notificationService
           .subscribe(regex: '.__manage')
           .listen(expectAsync1((notification) async {
-            logger.finer('got enroll notification');
+            logger.info('got enroll notification: $notification');
+
             await _notificationCallback(
                 notification, onboardingService_1.atClient!, 'approve');
             completer.complete();
           }, count: 1, max: -1));
       await completer.future;
 
-      //6. assert that the keys file is created for enrolled app
+      //5. assert that the keys file is created for enrolled app
       final enrolledClientKeysFile = File(enrollPreference_2.atKeysFilePath!);
       while (!await enrolledClientKeysFile.exists()) {
         await Future.delayed(Duration(seconds: 10));
       }
       expect(await enrolledClientKeysFile.exists(), true);
+      var enrolledClientKeysFileContent =
+          enrolledClientKeysFile.readAsStringSync();
+      var enrolledClientKeysFileJson =
+          jsonDecode(enrolledClientKeysFileContent);
+      expect(enrolledClientKeysFileJson['enrollmentId'], isNotEmpty);
+      expect(enrolledClientKeysFileJson['apkamSymmetricKey'], isNotEmpty);
       //  Authenticate now with the approved enrollmentID
       // assert that authentication is successful
       bool authResultWithEnrollment =
@@ -165,7 +194,11 @@ void main() {
     totp = totp.trim();
     logger.finer('otp: $totp');
     Map<String, String> namespaces = {"buzz": "rw"};
-
+    expect(totp.length, 6);
+    expect(
+        totp.contains('0') || totp.contains('o') || totp.contains('O'), false);
+    // check whether otp contains atleast one number and one alphabet
+    expect(RegExp(r'^(?=.*[a-zA-Z])(?=.*\d).+$').hasMatch(totp), true);
     //4. enroll second client
     AtOnboardingPreference enrollPreference_2 = getPreferenceForEnroll(atSign);
     final onboardingService_2 =
@@ -182,6 +215,13 @@ void main() {
         .subscribe(regex: '.__manage')
         .listen(expectAsync1((notification) async {
           logger.finer('got enroll notification');
+          expect(notification.value, isNotNull);
+          var notificationValueJson = jsonDecode(notification.value!);
+          expect(
+              notificationValueJson['encryptedApkamSymmetricKey'], isNotEmpty);
+          expect(notificationValueJson['appName'], 'buzz');
+          expect(notificationValueJson['deviceName'], 'iphone');
+          expect(notificationValueJson['namespace']['buzz'], 'rw');
           await _notificationCallback(
               notification, onboardingService_1.atClient!, 'deny');
           completer.complete();
@@ -226,6 +266,15 @@ Future<void> _notificationCallback(
       .getRemoteSecondary()!
       .executeCommand(enrollRequest, auth: true);
   print('enroll Response from server: $enrollResponse');
+  expect(enrollResponse, isNotEmpty);
+  enrollResponse = enrollResponse!.replaceFirst('data:', '');
+  var enrollResponseJson = jsonDecode(enrollResponse);
+  if (response == 'approve') {
+    expect(enrollResponseJson['status'], 'approved');
+  } else {
+    expect(enrollResponseJson['status'], 'denied');
+  }
+  expect(enrollResponseJson['enrollmentId'], enrollmentId);
 }
 
 Future<void> _setLastReceivedNotificationDateTime(

--- a/tests/at_onboarding_cli_functional_tests/test_scenarios/apkam/onboarding_cli.feature
+++ b/tests/at_onboarding_cli_functional_tests/test_scenarios/apkam/onboarding_cli.feature
@@ -8,13 +8,10 @@ Feature: onboarding enroll test
       | enableEnrollmentDuringOnboard | true |
     Then onboarding should be successful
     And onboard method should return true
-    ## TODO assert in enrollment_test.dart
     And .atKeys file should be generated in the specified location
-    ## TODO assert in enrollment_test.dart
     And .atKey file should store enrollmentId and apkamSymmetricKey
 
     When authenticate is done in onboarding service
-    ## TODO assert in enrollment_test.dart
     Then auth method should return true
 
   ## negative test
@@ -28,7 +25,6 @@ Feature: onboarding enroll test
   Scenario: Check Otp verb on onboarded and authenticated client
     Given A cli client is onboarded and authenticated
     When otp verb is executed using at client
-    ## TODO assert in enrollment_test.dart for expected otp result
     Then otp verb should return a string
     And otp should contain alpha numeric string
     And should have length of 6
@@ -43,22 +39,18 @@ Feature: onboarding enroll test
       | namespaces | {buzz,rw} |
       | otp        | <result of otp:get>|
     Then enroll method should return successful
-    ## TODO assert in enrollment_test.dart
     And AtEnrollmentResponse.enrollmentId should be non null
     And AtEnrollmentResponse.enrollStatus should be pending
 
     When A privileged client gets the notification
-    ## TODO assert in enrollment_test.dart
     Then notification should contain enrollmentId, encryptedApkamSymmetricKey
 
     When privileged client send enroll:approve request
-    ## TODO assert in enrollment_test.dart
-    Then enroll response from server should contain <TODO enter fields>
+    Then enroll response from server should contain enrollStatus='approved' and enrollmentId
 
     When A privileged client approves the enrollment notification
     Then Cli client requesting for enrollment will retry pkam auth in the background
     And atKeys file gets generated for the cli client requesting enrollment
-    ## TODO assert in enrollment_test.dart
     And atKeys file should store enrollmentId, apkamSymmetricKey, apkam public and private key
     And cli client should be able to authenticate with the keys file
 
@@ -66,12 +58,9 @@ Feature: onboarding enroll test
     Then notification should contain enrollmentId, encryptedApkamSymmetricKey
 
     When privileged client send enroll:deny request
-    ## TODO assert in enrollment_test.dart
-    Then enroll response from server should contain <TODO enter fields>
-    ## TODO assert in enrollment_test.dart
+    Then enroll response from server should contain enrollStatus='denied' and enrollmentId
     And auth attempt from the client should fail
 
-  #TODO write test
   Scenario: New onboarding cli client requests for enrollment with invalid otp
     Given A privileged client exists for an atsign to approve/deny enrollment
     When New cli client requests for an enrollment
@@ -82,13 +71,13 @@ Feature: onboarding enroll test
       | otp        | <invalid otp> |
     Then server should deny the request with invalid otp error response
 
-    #TODO write test
-  Scenario: New onboarding cli client requests for enrollment with valid but timedout otp
+    #To be tested manually since otp timeout on server is 1 min
+  Scenario: New onboarding cli client requests for enrollment with valid but timed out otp
     Given A privileged client exists for an atsign to approve/deny enrollment
     When New cli client requests for an enrollment
       | Field | Value |
       | appName | buzz |
       | deviceName | iphone |
       | namespaces | {buzz,rw} |
-      | otp        | <valid but timedout otp> |
+      | otp        | <valid but timed out otp> |
     Then server should deny the request with invalid otp error response

--- a/tests/at_onboarding_cli_functional_tests/test_scenarios/apkam/onboarding_cli.feature
+++ b/tests/at_onboarding_cli_functional_tests/test_scenarios/apkam/onboarding_cli.feature
@@ -1,0 +1,94 @@
+Feature: onboarding enroll test
+  Scenario: Initial onboarding with enableEnrollmentDuringOnboard flag set
+    Given New atsign is activated
+    And secondary server is running
+
+    When Onboarding is attempted with the below preference
+      | Field | Value |
+      | enableEnrollmentDuringOnboard | true |
+    Then onboarding should be successful
+    And onboard method should return true
+    ## TODO assert in enrollment_test.dart
+    And .atKeys file should be generated in the specified location
+    ## TODO assert in enrollment_test.dart
+    And .atKey file should store enrollmentId and apkamSymmetricKey
+
+    When authenticate is done in onboarding service
+    ## TODO assert in enrollment_test.dart
+    Then auth method should return true
+
+  ## negative test
+  Scenario: Initial onboarding with enableEnrollmentDuringOnboard flag set - params missing
+    Given New atsign is activated
+    And secondary server is running
+
+    When Onboarding is attempted without passing appName or deviceName
+    Then onboard method should throw AtOnboardingException
+
+  Scenario: Check Otp verb on onboarded and authenticated client
+    Given A cli client is onboarded and authenticated
+    When otp verb is executed using at client
+    ## TODO assert in enrollment_test.dart for expected otp result
+    Then otp verb should return a string
+    And otp should contain alpha numeric string
+    And should have length of 6
+    And should not have 0 or o
+
+  Scenario: New onboarding cli client requests for enrollment
+    Given A privileged client exists for an atsign to approve/deny enrollment
+    When New cli client requests for an enrollment
+      | Field | Value |
+      | appName | buzz |
+      | deviceName | iphone |
+      | namespaces | {buzz,rw} |
+      | otp        | <result of otp:get>|
+    Then enroll method should return successful
+    ## TODO assert in enrollment_test.dart
+    And AtEnrollmentResponse.enrollmentId should be non null
+    And AtEnrollmentResponse.enrollStatus should be pending
+
+    When A privileged client gets the notification
+    ## TODO assert in enrollment_test.dart
+    Then notification should contain enrollmentId, encryptedApkamSymmetricKey
+
+    When privileged client send enroll:approve request
+    ## TODO assert in enrollment_test.dart
+    Then enroll response from server should contain <TODO enter fields>
+
+    When A privileged client approves the enrollment notification
+    Then Cli client requesting for enrollment will retry pkam auth in the background
+    And atKeys file gets generated for the cli client requesting enrollment
+    ## TODO assert in enrollment_test.dart
+    And atKeys file should store enrollmentId, apkamSymmetricKey, apkam public and private key
+    And cli client should be able to authenticate with the keys file
+
+    When A privileged client gets the notification
+    Then notification should contain enrollmentId, encryptedApkamSymmetricKey
+
+    When privileged client send enroll:deny request
+    ## TODO assert in enrollment_test.dart
+    Then enroll response from server should contain <TODO enter fields>
+    ## TODO assert in enrollment_test.dart
+    And auth attempt from the client should fail
+
+  #TODO write test
+  Scenario: New onboarding cli client requests for enrollment with invalid otp
+    Given A privileged client exists for an atsign to approve/deny enrollment
+    When New cli client requests for an enrollment
+      | Field | Value |
+      | appName | buzz |
+      | deviceName | iphone |
+      | namespaces | {buzz,rw} |
+      | otp        | <invalid otp> |
+    Then server should deny the request with invalid otp error response
+
+    #TODO write test
+  Scenario: New onboarding cli client requests for enrollment with valid but timedout otp
+    Given A privileged client exists for an atsign to approve/deny enrollment
+    When New cli client requests for an enrollment
+      | Field | Value |
+      | appName | buzz |
+      | deviceName | iphone |
+      | namespaces | {buzz,rw} |
+      | otp        | <valid but timedout otp> |
+    Then server should deny the request with invalid otp error response


### PR DESCRIPTION
**- What I did**
- added checks for apkam test in at_onboarding_cli
**- How I did it**
- modified enrollment_test.dart to add additional checks for otp, verify response values, keyfile params etc.,
**- How to verify it**
- tests should pass
