### PR TITLE
chore: explicit Uint8List cast in at_lookup_impl.dart

### DIFF
--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -178,7 +178,7 @@ class AtLookupImpl implements AtLookUp {
       value = VerbUtil.getFormattedValue(value);
       logger.finer('value: $value dataSignature:$dataSignature');
       var isDataValid = publicKey.verifySHA256Signature(
-          utf8.encode(value), base64Decode(dataSignature));
+          utf8.encode(value) as Uint8List, base64Decode(dataSignature));
       logger.finer('data verify result: $isDataValid');
       return 'data:$value';
     } on Exception catch (e) {

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -178,6 +178,7 @@ class AtLookupImpl implements AtLookUp {
       value = VerbUtil.getFormattedValue(value);
       logger.finer('value: $value dataSignature:$dataSignature');
       var isDataValid = publicKey.verifySHA256Signature(
+          // ignore: unnecessary_cast
           utf8.encode(value) as Uint8List, base64Decode(dataSignature));
       logger.finer('data verify result: $isDataValid');
       return 'data:$value';


### PR DESCRIPTION
**- What I did**
- Add explicit `as Uint8List` cast

**- How I did it**

**- How to verify it**

**- Description for the changelog**
- discussed in architecture call that explicit cast wouldn't do any harm
- This is an issue that only I am running  into

**- Context**

```
../../.pub-cache/hosted/pub.dev/at_lookup-3.0.46/lib/src/at_lookup_impl.dart:181:16: Error: The argument type 'List<int>' can't be assigned to the parameter type 'Uint8List'.
 - 'List' is from 'dart:core'.
 - 'Uint8List' is from 'dart:typed_data'.
          utf8.encode(value), base64Decode(dataSignature));
```

I would get this error once I `dart pub cache clean && dart pub get`.

But by making the change in this PR, it would be fixed.

**- Additional context**

My pubspec.yaml:

```
name: dart_playground
description: A sample command-line application.
version: 1.0.0
# repository: https://github.com/my_org/my_repo

environment:
  sdk: ^3.1.3

# Add regular dependencies here.
dependencies:
  args: ^2.4.2
  at_client: ^3.0.75
  at_onboarding_cli: ^1.4.3
  at_utils: ^3.0.16
  version: ^3.0.2
  # path: ^1.8.0

dev_dependencies:
  lints: ^2.0.0
  test: ^1.21.0

```


