### PR TITLE
fix: backwards compatability issue with new enroll verb syntax

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.4
+## 4.0.5
 - feat: Enhance enroll:list to enable filtering based on enrollment status
 ## 4.0.3
 - fix: "toJson()" invoked on "pubKeyHash" leads to NullPointerException.

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -14,7 +14,7 @@ class EnrollParams {
   String? encryptedDefaultSelfEncryptionKey;
   String? encryptedAPKAMSymmetricKey;
   String? apkamPublicKey;
-  List<EnrollmentStatus>? enrollmentStatusFilter = EnrollmentStatus.values;
+  List<EnrollmentStatus>? enrollmentStatusFilter;
   EnrollParams();
   factory EnrollParams.fromJson(Map<String, dynamic> json) =>
       _$EnrollParamsFromJson(json);

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -39,7 +39,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// Filters enrollment requests based on provided [EnrollmentStatus] criteria.
   ///
   /// Accepts a list of enrollment statuses. Defaults to all EnrollmentStatuses
-  List<EnrollmentStatus> enrollmentStatusFilter = EnrollmentStatus.values;
+  List<EnrollmentStatus>? enrollmentStatusFilter;
 
   @override
   String buildCommand() {
@@ -61,7 +61,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       ..enrollmentStatusFilter = enrollmentStatusFilter;
 
     Map<String, dynamic> enrollParamsJson = enrollParams.toJson();
-    enrollParamsJson.removeWhere(_removeElements);
+    enrollParamsJson.removeWhere(_removeNonApplicableElements);
     if (enrollParamsJson.isNotEmpty) {
       sb.write(':${jsonEncode(enrollParamsJson)}');
     }
@@ -76,7 +76,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// Returning "false" will leave the key and its value in the map, which gets added to the
   /// enroll verb command. Returning true will remove the key and its value from the map to
   /// to refrain adding the key and its value to the enroll verb command.
-  bool _removeElements(String key, dynamic value) {
+  bool _removeNonApplicableElements(String key, dynamic value) {
     if (value == null || value.toString().isEmpty) {
       return true;
     }

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -61,7 +61,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       ..enrollmentStatusFilter = enrollmentStatusFilter;
 
     Map<String, dynamic> enrollParamsJson = enrollParams.toJson();
-    enrollParamsJson.removeWhere(_removeNonApplicableElements);
+    enrollParamsJson.removeWhere(_removeElements);
     if (enrollParamsJson.isNotEmpty) {
       sb.write(':${jsonEncode(enrollParamsJson)}');
     }
@@ -76,7 +76,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// Returning "false" will leave the key and its value in the map, which gets added to the
   /// enroll verb command. Returning true will remove the key and its value from the map to
   /// to refrain adding the key and its value to the enroll verb command.
-  bool _removeNonApplicableElements(String key, dynamic value) {
+  bool _removeElements(String key, dynamic value) {
     if (value == null || value.toString().isEmpty) {
       return true;
     }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.4
+version: 4.0.5
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -7,6 +7,7 @@ void main() {
     test('A test to verify enroll request params', () {
       String command =
           'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:request:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '1234');
@@ -25,6 +26,7 @@ void main() {
     test('A test to verify enroll approve params', () {
       String command =
           'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:approve:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '123');
@@ -41,6 +43,7 @@ void main() {
 
     test('A test to verify enroll deny params', () {
       String command = 'enroll:deny:{"enrollmentId":"123"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:deny:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '123');
@@ -48,6 +51,7 @@ void main() {
 
     test('A test to verify enroll revoke params', () {
       String command = 'enroll:revoke:{"enrollmentId":"123"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:revoke:', '');
       var enrollParams = jsonDecode(command);
       expect(enrollParams['enrollmentId'], '123');

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -69,8 +69,7 @@ void main() {
       var enrollVerbBuilder = EnrollVerbBuilder()
         ..operation = EnrollOperationEnum.list;
       var command = enrollVerbBuilder.buildCommand();
-      expect(command,
-          'enroll:list:{"enrollmentStatusFilter":["pending","approved","denied","revoked","expired"]}\n');
+      expect(command, 'enroll:list\n');
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Remove default values for enrollmentStatusFilter  from EnrollParams and EnrollVerbBuilder

**- More context**
- Following changes were made in 'https://github.com/atsign-foundation/at_libraries/pull/530':
> 1. Enroll verb syntax was updated to accept verbParams for enroll list (which previously was not the case)
> 2. Another change made in EnrollParams and EnrollVerbBuilder defaulted 'enrollmentStatusFilter' to EnrollmentStatus.values (all values) which when used by the EnrollVerbBuilder.buildCommand() would change the default enroll list command to '_enroll:list:{"enrollmentStatusFilter":["pending","approved","denied","revoked","expired"]}_'.

- Now this change in syntax and verb builder was being consumed by the client immediately, but not the server. This mismatch caused the server to throw and InvalidSyntax exception.

**- How this PR fixes things**
- Changes in this PR will change the default enroll list command to match the syntax that the AtServer accepts, hence the client although working with a NEW EnrollVerbSyntax will send out a command that matches the OLD EnrollVerbSyntax

**- How to verify it**
- The following is a draft PR in at_client_sdk that consumes the changes in this PR and runs the github test suite against it: https://github.com/atsign-foundation/at_client_sdk/pull/1271

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: Remove default values for enrollmentStatusFilter from EnrollParams and EnrollVerbBuilder