### PR TITLE
ci: use `docker compose [...]` instead of `docker-compose [...]`

### DIFF
--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Start docker instance
         working-directory: tests/${{ matrix.package }}
-        run: sudo docker-compose up -d
+        run: sudo docker compose up -d
 
       - name: Check for docker container readiness
         working-directory: tests/${{ matrix.package }}
@@ -143,4 +143,4 @@ jobs:
 
       - name: kill docker image
         working-directory: tests/${{ matrix.package }}
-        run: sudo docker-compose down
+        run: sudo docker compose down


### PR DESCRIPTION
**- What I did**
- ci: use `docker compose [...]` instead of `docker-compose [...]`
- see also https://github.com/atsign-foundation/operations/issues/134

**- How I did it**
See commits

**- How to verify it**
Tests pass (functional_tests_at_onboarding_cli specifically)

