### PR TITLE
fix: key length validation changes

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.6
+- fix: max key length validation changes
+- fix: PublicKey toString method should return 'cached:' when isCached is set in metadata
 ## 4.0.5
 - feat: Enhance enroll:list to enable filtering based on enrollment status
 ## 4.0.3

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -347,11 +347,6 @@ class PublicKey extends AtKey {
     super.metadata = Metadata();
     super.metadata.isPublic = true;
   }
-
-  @override
-  String toString() {
-    return 'public:$key${_dotNamespaceIfPresent()}$_sharedBy'.toLowerCase();
-  }
 }
 
 ///Represents a Self key.

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -228,16 +228,8 @@ class AtKey {
       ..sharedBy(sharedBy);
   }
 
-  /// Private key's that are created by the owner of the atSign and these keys
-  /// are not shown in the scan.
-  ///
-  /// Builds a private key and returns a [PrivateKeyBuilder]. Private key's are not
-  /// returned when fetched for key's of atSign.
-  ///
-  /// Example: privatekey:phone.wavi@alice
-  /// ```dart
-  /// AtKey privateKey = AtKey.private('phone', namespace: 'wavi').build();
-  /// ```
+  /// Obsolete, was never used
+  @Deprecated("Obsolete, from the ancient times")
   static PrivateKeyBuilder private(String key, {String? namespace}) {
     return PrivateKeyBuilder()
       ..key(key)
@@ -382,7 +374,8 @@ class SharedKey extends AtKey {
   }
 }
 
-/// Represents a Private key.
+/// Obsolete, was never used
+@Deprecated("Obsolete, from the ancient times")
 class PrivateKey extends AtKey {
   PrivateKey() {
     super.metadata = Metadata()..isHidden = true;

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -347,30 +347,12 @@ class SelfKey extends AtKey {
     super.metadata = Metadata();
     super.metadata.isPublic = false;
   }
-
-  @override
-  String toString() {
-    // If sharedWith is populated and sharedWith is equal to sharedBy, then
-    // keys is a self key.
-    // @alice:phone@alice or phone@alice
-    if (_sharedWith != null && _sharedWith!.isNotEmpty) {
-      return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy'
-          .toLowerCase();
-    }
-    return '$key${_dotNamespaceIfPresent()}$_sharedBy'.toLowerCase();
-  }
 }
 
 /// Represents a key shared to another atSign.
 class SharedKey extends AtKey {
   SharedKey() {
     super.metadata = Metadata();
-  }
-
-  @override
-  String toString() {
-    return '$_sharedWith:$key${_dotNamespaceIfPresent()}$_sharedBy'
-        .toLowerCase();
   }
 }
 
@@ -394,11 +376,6 @@ class LocalKey extends AtKey {
   LocalKey() {
     isLocal = true;
     super.metadata = Metadata();
-  }
-
-  @override
-  String toString() {
-    return 'local:$key${_dotNamespaceIfPresent()}$sharedBy'.toLowerCase();
   }
 }
 

--- a/packages/at_commons/lib/src/keystore/at_key_builder_impl.dart
+++ b/packages/at_commons/lib/src/keystore/at_key_builder_impl.dart
@@ -123,7 +123,8 @@ class SelfKeyBuilder extends AbstractKeyBuilder {
   }
 }
 
-/// Builder to build the hidden keys
+/// Obsolete, was never used
+@Deprecated("Obsolete, from the ancient times")
 class PrivateKeyBuilder extends AbstractKeyBuilder {
   PrivateKeyBuilder() : super() {
     _atKey = PrivateKey();

--- a/packages/at_commons/lib/src/validators/at_key_validation_impl.dart
+++ b/packages/at_commons/lib/src/validators/at_key_validation_impl.dart
@@ -140,18 +140,21 @@ class ReservedEntityValidation extends Validation {
   }
 }
 
-/// Validates key length of a @sign
+/// Validates key length of a key
 class KeyLengthValidation extends Validation {
-  static const int _maxKeyLength = 240;
+  static const int maxKeyLength = 255;
+  static const int maxKeyLengthWithoutCached = 248;
   String key;
 
   KeyLengthValidation(this.key);
 
   @override
   ValidationResult doValidate() {
-    if (key.length > _maxKeyLength) {
+    int maxLength =
+        key.startsWith('cached:') ? maxKeyLength : maxKeyLengthWithoutCached;
+    if (key.length > maxLength) {
       return ValidationResult(
-          'Key length exceeds maximum permissible length of $_maxKeyLength characters');
+          'Key length exceeds maximum permissible length of $maxLength characters');
     }
     return ValidationResult.noFailure();
   }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.5
+version: 4.0.6
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -1135,4 +1135,104 @@ void main() {
       expect(publicKey.toString(), 'cached:public:phone.buzz@bob');
     });
   });
+  group('A group of tests to verify self key toString', () {
+    test('test to verify self key toString without namespace and no sharedWith',
+        () {
+      var selfKey = (SelfKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob'))
+          .build();
+      expect(selfKey.toString(), 'phone@bob');
+    });
+    test(
+        'test to verify self key toString without namespace and sharedWith set',
+        () {
+      var selfKey = (SelfKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob'))
+          .build()
+        ..sharedWith = '@bob';
+      expect(selfKey.toString(), '@bob:phone@bob');
+    });
+    test('test to verify self key toString with namespace and no sharedWith',
+        () {
+      var selfKey = (SelfKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob')
+            ..namespace('buzz'))
+          .build();
+      expect(selfKey.toString(), 'phone.buzz@bob');
+    });
+    test('test to verify self key toString with namespace and sharedWith set',
+        () {
+      var selfKey = (SelfKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob')
+            ..namespace('buzz'))
+          .build()
+        ..sharedWith = '@bob';
+      expect(selfKey.toString(), '@bob:phone.buzz@bob');
+    });
+    test('test to verify self key mixed case', () {
+      var selfKey = (SelfKeyBuilder()
+            ..key('pHoNE')
+            ..sharedBy('@boB')
+            ..namespace('Buzz'))
+          .build()
+        ..sharedWith = '@bob';
+      expect(selfKey.toString(), '@bob:phone.buzz@bob');
+    });
+    group('A group of tests to verify shared key toString', () {
+      test('test to verify shared key toString without namespace ', () {
+        var sharedKey = (SharedKeyBuilder()
+              ..key('phone')
+              ..sharedBy('@bob')
+              ..sharedWith('@alice'))
+            .build();
+        expect(sharedKey.toString(), '@alice:phone@bob');
+      });
+      test('test to verify shared key toString with namespace', () {
+        var sharedKey = (SharedKeyBuilder()
+              ..key('phone')
+              ..sharedBy('@bob')
+              ..sharedWith('@alice')
+              ..namespace('buzz'))
+            .build();
+        expect(sharedKey.toString(), '@alice:phone.buzz@bob');
+      });
+      test('test to verify shared key toString mixed case', () {
+        var sharedKey = (SharedKeyBuilder()
+              ..key('phone')
+              ..sharedBy('@bob')
+              ..sharedWith('@alice')
+              ..namespace('buzz'))
+            .build();
+        expect(sharedKey.toString(), '@alice:phone.buzz@bob');
+      });
+    });
+    group('A group of tests to verify local key toString', () {
+      test('test to verify localkey toString without namespace', () {
+        var localKey = (LocalKeyBuilder()
+              ..key('secret')
+              ..sharedBy('@bob'))
+            .build();
+        expect(localKey.toString(), 'local:secret@bob');
+      });
+      test('test to verify localkey toString with namespace', () {
+        var localKey = (LocalKeyBuilder()
+              ..key('secret')
+              ..sharedBy('@bob')
+              ..namespace('buzz'))
+            .build();
+        expect(localKey.toString(), 'local:secret.buzz@bob');
+      });
+      test('test to verify localkey toString mixed case', () {
+        var localKey = (LocalKeyBuilder()
+              ..key('seCreT')
+              ..sharedBy('@boB'))
+            .build();
+        expect(localKey.toString(), 'local:secret@bob');
+      });
+    });
+  });
 }

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -1125,4 +1125,38 @@ void main() {
           'Key length exceeds maximum permissible length of ${KeyLengthValidation.maxKeyLength} characters');
     });
   });
+  group('A group of tests to verify public key toString', () {
+    test('test to verify public key toString without namespace ', () {
+      var publicKey = (PublicKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob'))
+          .build();
+      expect(publicKey.toString(), 'public:phone@bob');
+    });
+    test('test to verify public key toString with namespace ', () {
+      var publicKey = (PublicKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob')
+            ..namespace('wavi'))
+          .build();
+      expect(publicKey.toString(), 'public:phone.wavi@bob');
+    });
+    test('test to verify cached public key toString without namespace  ', () {
+      var publicKey = (PublicKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob')
+            ..cache(10, true))
+          .build();
+      expect(publicKey.toString(), 'cached:public:phone@bob');
+    });
+    test('test to verify cached public key toString with namespace  ', () {
+      var publicKey = (PublicKeyBuilder()
+            ..key('phone')
+            ..sharedBy('@bob')
+            ..cache(10, true)
+            ..namespace('buzz'))
+          .build();
+      expect(publicKey.toString(), 'cached:public:phone.buzz@bob');
+    });
+  });
 }

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -363,13 +363,6 @@ void main() {
       expect(selfKeyBuilder, isA<SelfKeyBuilder>());
       expect(selfKeyBuilder.build().toString(), 'phone.wavi@bob');
     });
-
-    test('Validate the hidden key builder', () {
-      PrivateKeyBuilder hiddenKeyBuilder =
-          AtKey.private('phone', namespace: 'wavi');
-      expect(hiddenKeyBuilder, isA<PrivateKeyBuilder>());
-      expect(hiddenKeyBuilder.build().toString(), 'privatekey:phone.wavi');
-    });
   });
 
   group('A group of tests to validate the AtKey instances', () {
@@ -394,12 +387,6 @@ void main() {
           AtKey.self('phone', namespace: 'wavi', sharedBy: '@alice').build();
       expect(selfKey, isA<SelfKey>());
       expect(selfKey.toString(), 'phone.wavi@alice');
-    });
-
-    test('Test to verify the hidden key', () {
-      AtKey selfKey = AtKey.private('phone', namespace: 'wavi').build();
-      expect(selfKey, isA<PrivateKey>());
-      expect(selfKey.toString(), 'privatekey:phone.wavi');
     });
   });
 
@@ -818,17 +805,6 @@ void main() {
           ..isPublic = true)
         ..namespace = 'wavi';
       expect('cached:public:phone.wavi@alice', atKey.toString());
-    });
-
-    //Private keys
-    test('Verify a privatekey creation using static factory method', () {
-      var atKey = PrivateKey()..key = 'at_secret';
-      expect('privatekey:at_secret', atKey.toString());
-    });
-
-    test('Verify a privatekey creation', () {
-      var atKey = AtKey()..key = 'privatekey:at_secret';
-      expect('privatekey:at_secret', atKey.toString());
     });
   });
 

--- a/packages/at_commons/test/test_utils.dart
+++ b/packages/at_commons/test/test_utils.dart
@@ -1,0 +1,10 @@
+import 'dart:math';
+
+class TestUtils {
+  static String createRandomString(int length) {
+    final String characters =
+        '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_';
+    return String.fromCharCodes(Iterable.generate(length,
+        (index) => characters.codeUnitAt(Random().nextInt(characters.length))));
+  }
+}


### PR DESCRIPTION
**- What I did**
- changes for key length validation
**- How I did it**
- modified key lengths in KeyValidation class. 248 chars for normal keys and 255 chars for cached keys
- PublicKey toString was not returning 'cached:' when isCached=true. Removed the toString method and use toString from AtKey super class. Added tests.
**- How to verify it**
- unit tests should pass
- at_client tests pointing to this branch of at_commons
https://github.com/atsign-foundation/at_client_sdk/pull/1286
- at_server tests pointing to this branch
https://github.com/atsign-foundation/at_server/pull/1884
- tested at_notifications and at_talk demo 
 - @purnimavenkatasubbu tested the changes using wavi and buzz app
