### PR TITLE
fix: set appName and deviceName in activate cli

### DIFF
--- a/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
@@ -15,6 +15,16 @@ Future<void> main(List<String> arguments) async {
   final parser = ArgParser()
     ..addOption('atsign', abbr: 'a', help: 'atSign to activate')
     ..addOption('cramkey', abbr: 'c', help: 'CRAM key', mandatory: false)
+    ..addOption('appName',
+        abbr: 'p',
+        help: 'application name that identifies the client',
+        mandatory: false,
+        defaultsTo: 'testapp')
+    ..addOption('deviceName',
+        abbr: 'd',
+        help: 'device name on which the application is running',
+        mandatory: false,
+        defaultsTo: 'testdevice')
     ..addOption('rootServer',
         abbr: 'r',
         help: 'root server\'s domain name',
@@ -42,7 +52,8 @@ Future<void> main(List<String> arguments) async {
   await activate(argResults);
 }
 
-Future<void> activate(ArgResults argResults, {AtOnboardingService? atOnboardingService}) async {
+Future<void> activate(ArgResults argResults,
+    {AtOnboardingService? atOnboardingService}) async {
   stdout.writeln('[Information] Root server is ${argResults['rootServer']}');
   stdout.writeln(
       '[Information] Registrar url provided is ${argResults['registrarUrl']}');
@@ -51,7 +62,9 @@ Future<void> activate(ArgResults argResults, {AtOnboardingService? atOnboardingS
     ..rootDomain = argResults['rootServer']
     ..registrarUrl = argResults['registrarUrl']
     ..cramSecret =
-        argResults.wasParsed('cramkey') ? argResults['cramkey'] : null;
+        argResults.wasParsed('cramkey') ? argResults['cramkey'] : null
+    ..appName = argResults['appName']
+    ..deviceName = argResults['deviceName'];
   //onboard the atSign
   atOnboardingService ??=
       AtOnboardingServiceImpl(argResults['atsign'], atOnboardingPreference);

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -20,17 +20,13 @@ dependencies:
    image: ^4.0.17
    path: ^1.8.1
    zxing2: ^0.2.0
-   at_auth: ^1.0.5
+   at_auth: ^2.0.1
    at_chops: ^2.0.0
    at_client: ^3.0.74
    at_commons: ^4.0.0
    at_lookup: ^3.0.45
    at_server_status: ^1.0.4
    at_utils: ^3.0.16
-
-dependency_overrides:
-  at_auth:
-    path: ../at_auth
 
 dev_dependencies:
   lints: ^2.1.0


### PR DESCRIPTION
**- What I did**
- set appName and deviceName in AtOnboardingCli 

**- How I did it**
- added flags for appName(-p) and deviceName(-d) in activate_cli.Default values are testapp and testdevice if no args 
are passed
- remove dependency overrides for at_auth
- modified code in activate method to set appName and deviceName in onboarding preference
**- How to verify it**
- tests should pass
- server github actions should pass after the merge to trunk

