### PR TITLE
fix: set default values for app name and device name in onboarding

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+- fix: set default value for app name and device name if they are not passed in the onboarding request.
 ## 2.0.1
 - fix: deprecate enableEnrollment flag in OnboardingRequest and removed the check in AtAuthImpl
 ## 2.0.0

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -16,6 +16,8 @@ import 'enroll/at_enrollment_impl.dart';
 
 class AtAuthImpl implements AtAuth {
   final AtSignLogger _logger = AtSignLogger('AtAuthServiceImpl');
+  final String _defaultAppNameForOnboarding = 'firstApp';
+  final String _defaultDeviceNameForOnboarding = 'firstDevice';
   @override
   AtChops? atChops;
 
@@ -201,11 +203,8 @@ class AtAuthImpl implements AtAuth {
       AtOnboardingRequest atOnboardingRequest,
       AtAuthKeys atAuthKeys,
       AtLookUp atLookup) async {
-    if (atOnboardingRequest.appName == null ||
-        atOnboardingRequest.deviceName == null) {
-      throw AtEnrollmentException(
-          'appName and deviceName are required for onboarding');
-    }
+    atOnboardingRequest.appName ??= _defaultAppNameForOnboarding;
+    atOnboardingRequest.deviceName ??= _defaultDeviceNameForOnboarding;
     AESEncryptionAlgo symmetricEncryptionAlgo =
         AESEncryptionAlgo(AESKey(atAuthKeys.apkamSymmetricKey!));
     // Encrypt the defaultEncryptionPrivateKey with APKAM Symmetric key

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.0.1
+version: 2.0.2
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 


### PR DESCRIPTION
**- What I did**
- set default values for app name and device name in onboarding, if they are not set
**- How I did it**
- Removed the exception block if appName and deviceName are not passed and replaced with default values.
- added unit test
**- How to verify it**
- tests should pass
