### PR TITLE
fix: throw Exception when input IV is null for decryption(with Symmetric Encryption)

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.1
+- fix: throw Exception when input IV is null for decryption(with Symmetric Encryption)
 ## 2.0.0
 - [Breaking Change] fix: removed deprecated methods and members
 - [Breaking Change] feat: Introduced interface for ASymmetricEncryptionAlgorithm and modified DefaultEncryptionAlgorithm

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -39,6 +39,10 @@ class AtChopsImpl extends AtChops {
     try {
       encryptionAlgorithm ??=
           _getEncryptionAlgorithm(encryptionKeyType, keyName)!;
+      if (encryptionAlgorithm is SymmetricEncryptionAlgorithm && iv == null) {
+        throw InvalidDataException(
+            'Initialization vector required for SymmetricKeyEncryption');
+      }
       final atEncryptionMetaData = AtEncryptionMetaData(
           encryptionAlgorithm.runtimeType.toString(), encryptionKeyType);
       atEncryptionMetaData.keyName = keyName;

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -40,7 +40,7 @@ class AtChopsImpl extends AtChops {
       encryptionAlgorithm ??=
           _getEncryptionAlgorithm(encryptionKeyType, keyName)!;
       if (encryptionAlgorithm is SymmetricEncryptionAlgorithm && iv == null) {
-        throw InvalidDataException(
+        throw AtDecryptionException(
             'Initialization vector required for SymmetricKeyEncryption');
       }
       final atEncryptionMetaData = AtEncryptionMetaData(

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -41,7 +41,7 @@ class AtChopsImpl extends AtChops {
           _getEncryptionAlgorithm(encryptionKeyType, keyName)!;
       if (encryptionAlgorithm is SymmetricEncryptionAlgorithm && iv == null) {
         throw AtDecryptionException(
-            'Initialization vector required for SymmetricKeyEncryption');
+            'Initialization vector required for decryption using SymmetricKeyEncryption');
       }
       final atEncryptionMetaData = AtEncryptionMetaData(
           encryptionAlgorithm.runtimeType.toString(), encryptionKeyType);

--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -41,7 +41,7 @@ class AtChopsImpl extends AtChops {
           _getEncryptionAlgorithm(encryptionKeyType, keyName)!;
       if (encryptionAlgorithm is SymmetricEncryptionAlgorithm && iv == null) {
         throw AtDecryptionException(
-            'Initialization vector required for decryption using SymmetricKeyEncryption');
+            'Initialization vector required for decryption using SymmetricKey');
       }
       final atEncryptionMetaData = AtEncryptionMetaData(
           encryptionAlgorithm.runtimeType.toString(), encryptionKeyType);

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/atsign-foundation/at_libraries
 
 environment:

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -237,7 +237,7 @@ void main() {
           throwsA(predicate((e) =>
               e is AtDecryptionException &&
               e.toString().contains(
-                  'Initialization vector required for SymmetricKeyEncryption'))));
+                  'Initialization vector required for decryption using SymmetricKeyEncryption'))));
     });
   });
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -237,7 +237,7 @@ void main() {
           throwsA(predicate((e) =>
               e is AtDecryptionException &&
               e.toString().contains(
-                  'Initialization vector required for decryption using SymmetricKeyEncryption'))));
+                  'Initialization vector required for decryption using SymmetricKey'))));
     });
   });
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -237,7 +237,7 @@ void main() {
           throwsA(predicate((e) =>
               e is AtDecryptionException &&
               e.toString().contains(
-                  'Exception: Exception: Initialization vector required for SymmetricKeyEncryption'))));
+                  'Initialization vector required for SymmetricKeyEncryption'))));
     });
   });
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -231,16 +231,13 @@ void main() {
       var encryptionResult =
           atChops.encryptBytes(utf8EncData, EncryptionKeyType.aes256, iv: iv);
 
-      bool exceptionCatchFlag = false;
-      try {
-        atChops.decryptBytes(encryptionResult.result, EncryptionKeyType.aes256,
-            iv: null);
-      } on Exception catch (e) {
-        expect(e.runtimeType, AtDecryptionException);
-        expect(e.toString(), 'Exception: Exception: Initialization vector required for SymmetricKeyEncryption');
-        exceptionCatchFlag = true;
-      }
-      expect(exceptionCatchFlag, true);
+      expect(
+          () => atChops.decryptBytes(
+              encryptionResult.result, EncryptionKeyType.aes256, iv: null),
+          throwsA(predicate((e) =>
+              e is AtDecryptionException &&
+              e.toString().contains(
+                  'Exception: Exception: Initialization vector required for SymmetricKeyEncryption'))));
     });
   });
 

--- a/packages/at_chops/test/at_chops_test.dart
+++ b/packages/at_chops/test/at_chops_test.dart
@@ -220,6 +220,28 @@ void main() {
       expect(decryptionResult.atEncryptionMetaData.iv, iv);
       expect(decryptionResult.result, data);
     });
+
+    test('validate decryption behaviour with null iv', () {
+      final aesKey = AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
+      final atChopsKeys = AtChopsKeys()..selfEncryptionKey = aesKey;
+      final atChops = AtChopsImpl(atChopsKeys);
+
+      var iv = AtChopsUtil.generateRandomIV(15);
+      var utf8EncData = utf8.encode('abcd');
+      var encryptionResult =
+          atChops.encryptBytes(utf8EncData, EncryptionKeyType.aes256, iv: iv);
+
+      bool exceptionCatchFlag = false;
+      try {
+        atChops.decryptBytes(encryptionResult.result, EncryptionKeyType.aes256,
+            iv: null);
+      } on Exception catch (e) {
+        expect(e.runtimeType, AtDecryptionException);
+        expect(e.toString(), 'Exception: Exception: Initialization vector required for SymmetricKeyEncryption');
+        exceptionCatchFlag = true;
+      }
+      expect(exceptionCatchFlag, true);
+    });
   });
 
   group('A group of tests for data signing and verification', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_libraries/issues/481
**- What I did**
- Throw exception when input IV is null for decryption(with Symmetric Encryption)

**- How to verify it**
- added unit test
- at_client_sdk github test suite ran against this branch in https://github.com/atsign-foundation/at_client_sdk/pull/1292
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: throw Exception when input IV is null for decryption(with Symmetric Encryption)