### PR TITLE
fix: Add fetch operation to enroll verb

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.7
+- fix: Add fetch operation to enroll verb to get the enrollment details
 ## 4.0.6
 - fix: max key length validation changes
 - fix: PublicKey toString method should return 'cached:' when isCached is set in metadata

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -17,7 +17,7 @@ enum MessageTypeEnum { key, text }
 String getMessageType(MessageTypeEnum? messageTypeEnum) =>
     '$messageTypeEnum'.split('.').last;
 
-enum EnrollOperationEnum { request, approve, deny, revoke, list, update }
+enum EnrollOperationEnum { request, approve, deny, revoke, list, update, fetch }
 
 String getEnrollOperation(EnrollOperationEnum? enrollOperationEnum) =>
     '$enrollOperationEnum'.split('.').last;

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -128,7 +128,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|update|list)))(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|update|list|fetch)))(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.6
+version: 4.0.7
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
+
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
+
+import 'syntax_test.dart';
 
 void main() {
   group('A group of tests related to enroll verb', () {
@@ -70,6 +73,16 @@ void main() {
     test('A test to verify enroll list regex without params', () {
       String command = 'enroll:list';
       expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
+    });
+
+    test('A test to verify enroll fetch with enrollment id', () {
+      String command = 'enroll:fetch:{"enrollmentId":"123"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
+
+      Map<dynamic, dynamic> enrollmentParams =
+          getVerbParams(VerbSyntax.enroll, command);
+      expect(enrollmentParams['operation'], 'fetch');
+      expect(enrollmentParams['enrollParams'], '{"enrollmentId":"123"}');
     });
   });
 

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -71,5 +71,15 @@ void main() {
       var command = enrollVerbBuilder.buildCommand();
       expect(command, 'enroll:list\n');
     });
+
+    test('A test to validate the enroll fetch command', () {
+      EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.fetch
+        ..enrollmentId = '123';
+
+      var command = enrollVerbBuilder.buildCommand();
+
+      expect(command, 'enroll:fetch:{"enrollmentId":"123"}\n');
+    });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add enroll:fetch operation to fetch the enrollment details of the given enrollment id.
- Update the version of at_commons to v4.0.6 and update the CHANGELOG.md

**- How I did it**
- Add "fetch" operation to the enroll:fetch syntax.

**- How to verify it**
- Add unit tests to verify the enroll:fetch changes.

**- Description for the changelog**
- Add fetch operation to enroll verb to get the enrollment details

## 
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
