### PR TITLE
fix: at_commons: Add "shared_key.bob@alice" to reserved key regex

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 4.0.8
 - fix: Add shared_key.atsign@atsign to reservedKey regex
-- fix: change inconsistent field name encryptedApkamSymmetricKey to encryptedAPKAMSymmetricKey
 ## 4.0.7
 - fix: Add fetch operation to enroll verb to get the enrollment details
 ## 4.0.6

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.8
+- fix: Add shared_key.atsign@atsign to reservedKey regex
+- fix: change inconsistent field name encryptedApkamSymmetricKey to encryptedAPKAMSymmetricKey
 ## 4.0.7
 - fix: Add fetch operation to enroll verb to get the enrollment details
 ## 4.0.6

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -106,7 +106,7 @@ class AtConstants {
       'encryptedDefaultEncPrivateKey';
   static const String apkamEncryptedDefaultSelfEncryptionKey =
       'encryptedDefaultSelfEncryptionKey';
-  static const String apkamEncryptedSymmetricKey = 'encryptedAPKAMSymmetricKey';
+  static const String apkamEncryptedSymmetricKey = 'encryptedApkamSymmetricKey';
   static const String apkamPublicKey = 'apkamPublicKey';
   static const String apkamNamespaces = 'namespaces';
   static const String defaultEncryptionPrivateKey = 'default_enc_private_key';

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -106,7 +106,7 @@ class AtConstants {
       'encryptedDefaultEncPrivateKey';
   static const String apkamEncryptedDefaultSelfEncryptionKey =
       'encryptedDefaultSelfEncryptionKey';
-  static const String apkamEncryptedSymmetricKey = 'encryptedApkamSymmetricKey';
+  static const String apkamEncryptedSymmetricKey = 'encryptedAPKAMSymmetricKey';
   static const String apkamPublicKey = 'apkamPublicKey';
   static const String apkamNamespaces = 'namespaces';
   static const String defaultEncryptionPrivateKey = 'default_enc_private_key';

--- a/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -21,16 +21,23 @@ abstract class Regexes {
 
   /// The following reserved keys are suffixed by the atsign. [ownershipFragment]
   /// at the end represents the atsign
-  static const _reservedKeysWithAtsignSuffix = r'(((?<=private:)blocklist'
+  static const _reservedKeysWithAtsignSuffix = r'('
+      '('
+      '(?<=private:)'
+      'blocklist'
       '|(?<=public:)signing_publickey'
       '|(?<=$ownershipFragmentWithoutNamedGroup:)signing_privatekey'
       '|(?<=^@($sharedWithFragment))shared_key'
-      '|(?<=public:)publickey)(?=$ownershipFragment))';
+      '|(?<=public:)publickey'
+      ')(?=$ownershipFragment)'
+      '|(shared_key\\.$ownershipFragmentWithoutAtPrefix)'
+      ')';
 
-  static const String namespaceFragment =
-      '''\\.(?<namespace>$charsInNamespace)''';
+  static const String namespaceFragment = '\\.(?<namespace>$charsInNamespace)';
+  static const String ownershipFragmentWithoutAtPrefix =
+      '(($charsInAtSign|$allowedEmoji){1,55})';
   static const String ownershipFragment =
-      '''@(?<owner>($charsInAtSign|$allowedEmoji){1,55})''';
+      '@(?<owner>$ownershipFragmentWithoutAtPrefix)';
   static const String ownershipFragmentWithoutNamedGroup =
       '''@($charsInAtSign|$allowedEmoji){1,55}''';
   static const String sharedWithFragment =
@@ -56,12 +63,19 @@ abstract class Regexes {
       '''(?<visibility>(local:){1})$entityFragment''';
 
   String get publicKey;
+
   String get privateKey;
+
   String get selfKey;
+
   String get sharedKey;
+
   String get cachedSharedKey;
+
   String get cachedPublicKey;
+
   String get reservedKey;
+
   String get localKey;
 
   static final Regexes _regexesWithMandatoryNamespace =

--- a/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
+++ b/packages/at_commons/lib/src/utils/at_key_regex_utils.dart
@@ -29,8 +29,8 @@ abstract class Regexes {
       '|(?<=$ownershipFragmentWithoutNamedGroup:)signing_privatekey'
       '|(?<=^@($sharedWithFragment))shared_key'
       '|(?<=public:)publickey'
-      ')(?=$ownershipFragment)'
       '|(shared_key\\.$ownershipFragmentWithoutAtPrefix)'
+      ')(?=$ownershipFragment)'
       ')';
 
   static const String namespaceFragment = '\\.(?<namespace>$charsInNamespace)';

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.7
+version: 4.0.8
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_regex_test.dart
+++ b/packages/at_commons/test/at_key_regex_test.dart
@@ -270,6 +270,7 @@ void main() {
         () {
       String key = '_latestNotificationId';
       var type = RegexUtil.keyType(key, false);
+      print('Expected reservedKey, got $type for $key');
       expect(type, KeyType.reservedKey);
 
       var matches = RegexUtil.matchesByGroup(Regexes(false).reservedKey, key);

--- a/packages/at_commons/test/at_key_type_test.dart
+++ b/packages/at_commons/test/at_key_type_test.dart
@@ -123,7 +123,7 @@ void main() {
         var type = RegexUtil.keyType(key, false);
         print(key);
         if (type != KeyType.reservedKey) {
-          fails.add('$key classified as $type - should be ${KeyType.reservedKey}');
+          fails.add('$key classified as $type - should be reservedKey');
         }
       }
       expect(fails, []);

--- a/packages/at_commons/test/at_key_type_test.dart
+++ b/packages/at_commons/test/at_key_type_test.dart
@@ -98,8 +98,9 @@ void main() {
       var keyTypeList = [];
       var fails = [];
       // keys with atsign
+      keyTypeList.add('shared_key.bob@alice');
+      keyTypeList.add('@bob:shared_key@alice');
       keyTypeList.add('${AtConstants.atBlocklist}@☎️_0002');
-      keyTypeList.add('@bob:${AtConstants.atEncryptionSharedKey}@alice');
       keyTypeList.add('@allen:${AtConstants.atSigningPrivateKey}@allen');
       keyTypeList.add('${AtConstants.atEncryptionPublicKey}@owner');
       keyTypeList.add('public:signing_publickey@alice');

--- a/packages/at_commons/test/at_key_type_test.dart
+++ b/packages/at_commons/test/at_key_type_test.dart
@@ -123,7 +123,7 @@ void main() {
         var type = RegexUtil.keyType(key, false);
         print(key);
         if (type != KeyType.reservedKey) {
-          fails.add('$key classified as $type - actually a reserved key');
+          fails.add('$key classified as $type - should be ${KeyType.reservedKey}');
         }
       }
       expect(fails, []);
@@ -137,7 +137,8 @@ void main() {
       keyTypeList.add('public:publickey');
       keyTypeList.add('public:signing_publickey');
       keyTypeList.add(AtConstants.atBlocklist);
-      keyTypeList.add('@bob:${AtConstants.atEncryptionSharedKey}');
+      keyTypeList.add('@bob:shared_key');
+      keyTypeList.add('shared_key.bob');
       keyTypeList.add(AtConstants.atEncryptionSharedKey);
       keyTypeList.add('@allen:${AtConstants.atSigningPrivateKey}');
       keyTypeList.add(AtConstants.atSigningPrivateKey);

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -57,7 +57,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
-      // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
         ..ttln = 100;
@@ -83,7 +83,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob'
-      // ignore: deprecated_member_use_from_same_package
+        // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
         ..atKey.metadata.isEncrypted = true;


### PR DESCRIPTION
Problem which required this fix was that atClients with namespace access limitations were unable to store "shared_key.bob@alice" to the atServer because the server wasn't identifying that as a reserved key type

**- What I did**
- fix: Add shared_key.atsign@atsign to reservedKey regex

**- How I did it**
- Modified reservedKey regex, added positive and negative test cases for shared_key.foo@bar
- updated CHANGELOG and pubspec for at_commons 4.0.8

**- How to verify it**
- [x] Tests pass
- [x] at_client tests pass against this branch [at_client_sdk test PR](https://github.com/atsign-foundation/at_client_sdk/pull/1307)
- [x] at_server tests pass against this branch [at_server test PR](https://github.com/atsign-foundation/at_server/pull/1924)