### PR TITLE
fix: at_lookup: Fix handling of non-json-formatted error responses 

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.47
+- fix: Fixed legacy error handling so error message isn't truncated if it 
+  contains a hyphen
 ## 3.0.46
 - fix: Modify "executeCommand" to parse the error response from server and return appropriate exception
 ## 3.0.45

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -335,12 +335,9 @@ class AtLookupImpl implements AtLookUp {
       // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
       // TODO: Can we remove the below catch block in next release once all the servers are migrated to new version.
       if (verbResult.contains('-')) {
-        if (verbResult.split('-')[0].isNotEmpty) {
-          errorCode = verbResult.split('-')[0];
-        }
-        if (verbResult.split('-')[1].isNotEmpty) {
-          errorDescription = verbResult.split('-')[1];
-        }
+        final resultParts = verbResult.split('-');
+        errorCode = verbResult.substring(0, verbResult.indexOf('-'));
+        errorDescription = verbResult.substring(verbResult.indexOf('-')+1);
       }
     }
 

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -335,9 +335,10 @@ class AtLookupImpl implements AtLookUp {
       // Catching the FormatException to preserve backward compatibility - responses without jsonEncoding.
       // TODO: Can we remove the below catch block in next release once all the servers are migrated to new version.
       if (verbResult.contains('-')) {
-        final resultParts = verbResult.split('-');
         errorCode = verbResult.substring(0, verbResult.indexOf('-'));
         errorDescription = verbResult.substring(verbResult.indexOf('-')+1);
+      } else {
+        errorDescription += ": $verbResult";
       }
     }
 

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.46
+version: 3.0.47
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
Problem which required this fix is that enrollment exception error messages from the server contain enrollment ids which contain hyphens, and the messages were therefore being truncated

**- What I did**
- fix: Fix handling of non-json-formatted error responses in AtLookupImpl so error message isn't truncated if it contains a hyphen
- test: Add two test cases (json format and legacy format) testing error handling
- fix: if we ever (which we should not) get an `error:` response which isn't json and doesn't look like `$errorCode-$errorDescription` then take the full response and add it to the error description rather than only saying "Unknown server error"

**- How I did it**
See commits

**- How to verify it**
- [x] Tests pass
- [x] at_client tests pass against this branch [at_client_sdk test PR](https://github.com/atsign-foundation/at_client_sdk/pull/1307)
- [x] at_server tests pass against this branch [at_server test PR](https://github.com/atsign-foundation/at_server/pull/1924)