### PR TITLE
fix: Add optional params to atAuth method to match with implementing …

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 2.0.3
-
 - fix: Add optional parameters to the "atAuth" method in "AtAuthInterface"
 ## 2.0.2
 - fix: set default value for app name and device name if they are not passed in the onboarding request.

--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.3
+
+- fix: Add optional parameters to the "atAuth" method in "AtAuthInterface"
 ## 2.0.2
 - fix: set default value for app name and device name if they are not passed in the onboarding request.
 ## 2.0.1

--- a/packages/at_auth/lib/src/auth_interface.dart
+++ b/packages/at_auth/lib/src/auth_interface.dart
@@ -1,4 +1,9 @@
 import 'package:at_auth/at_auth.dart';
+import 'package:at_auth/src/auth/pkam_authenticator.dart';
+import 'package:at_chops/at_chops.dart';
+import 'package:at_lookup/at_lookup.dart';
+
+import 'auth/cram_authenticator.dart';
 
 /// This abstract class defines the interface for authentication and enrollment
 /// with an @protocol server.
@@ -15,5 +20,10 @@ abstract class AtAuthInterface {
   /// This method facilitates the authentication process.
   ///
   /// Returns an instance of [AtAuth].
-  AtAuth atAuth();
+  AtAuth atAuth(
+      {AtLookUp? atLookUp,
+      AtChops? atChops,
+      CramAuthenticator? cramAuthenticator,
+      PkamAuthenticator? pkamAuthenticator,
+      AtEnrollmentBase? atEnrollmentBase});
 }

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.0.2
+version: 2.0.3
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 


### PR DESCRIPTION
…class

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The atAuth method in the AtAuthInterfaceImpl class accepts optional parameters to build and return an instance of "AtAuth".  But "atAuth" method in "AtAuthInterface" does not have optional parameters because of which users cannot set the optional parameters.

**- How I did it**
- Add optional parameters to the atAuth method in the AtAuthInterface class.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
