### PR TITLE
feat: at_cli_commons 1.1.0 : CLIBase: add maxConnectAttempts parameter

### DIFF
--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 1.1.0
 
-- feat: Add `maxConnectAttempts` parameter to CLIBase. The default is 100,
-  which means 20 attempts to connect, with a 3-second delay between attempts.
-  In scripted situations, this is important as the previous behaviour (retry
+- feat: Add `maxConnectAttempts` parameter to CLIBase. The default is 20,
+  i.e. 20 attempts to connect, with a 3-second delay between attempts. When 
+  used in scripts this is important, as the previous behaviour (retry 
   forever) is usually not what is required.
 
 ## 1.0.5

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,16 +1,34 @@
+## 1.1.0
+
+- feat: Add `maxConnectAttempts` parameter to CLIBase. The default is 100,
+  which means 20 attempts to connect, with a 3-second delay between attempts.
+  In scripted situations, this is important as the previous behaviour (retry
+  forever) is usually not what is required.
+
 ## 1.0.5
+
 - fix: Make CLIBase write progress messages to stderr, not stdout
+
 ## 1.0.4
+
 - fix: handle malformed atsigns (no leading `@`) in CLIBase constructor
 - build: updated dependencies
+
 ## 1.0.3
+
 - Added `example/` package, moved code samples from `bin/` to `example/`
+
 ## 1.0.2
+
 - docs: Added some code samples in bin/ directory
 - docs: Added some class and method documentation to CLIBase
 - docs: Updated README
 - feat: Added static `fromCommandLineArgs` factory method to CLIBase
+
 ## 1.0.1
+
 - Small edits to README
+
 ## 1.0.0
+
 - Initial version.

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -11,6 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:version/version.dart';
 
 class CLIBase {
+  static const defaultMaxConnectAttempts = 20;
   /// An ArgParser which has all of the options and flags required by [CLIBase]
   /// Used by [fromCommandLineArgs] if the `parser` parameter isn't supplied.
   static final ArgParser argsParser = ArgParser()
@@ -39,7 +40,7 @@ class CLIBase {
     ..addOption('max-connect-attempts',
         help: 'Number of times to attempt to initially connect to atServer.'
             ' Note: there is a 3-second delay between connection attempts.',
-        defaultsTo: "100");
+        defaultsTo: defaultMaxConnectAttempts.toString());
 
   /// Constructs a CLIBase from a list of command-line arguments
   /// and calls [init] on it.
@@ -129,7 +130,7 @@ class CLIBase {
     this.downloadDir,
     this.cramSecret,
     this.syncDisabled = false,
-    this.maxConnectAttempts = 5,
+    this.maxConnectAttempts = defaultMaxConnectAttempts,
   }) {
     this.atSign = AtUtils.fixAtSign(atSign);
     if (homeDir == null) {

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -214,6 +214,12 @@ class CLIBase {
         await Future.delayed(retryDuration);
       }
     }
+    if (!authenticated) {
+      stderr.writeln();
+      var msg = 'Failed to connect after $attempts attempts';
+      stderr.writeln(chalk.brightRed(msg));
+      throw SecondaryServerConnectivityException(msg);
+    }
     stderr.writeln(chalk.brightGreen('Connected'));
 
     // Get the AtClient which the onboardingService just authenticated

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 1.0.5
+version: 1.1.0
 
 repository: https://github.com/atsign-foundation/at_libraries/tree/trunk/packages/at_cli_commons
 homepage: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
- feat: Add `maxConnectAttempts` parameter to CLIBase. The default is 20,
  i.e. 20 attempts to connect, with a 3-second delay between attempts. When 
  used in scripts this is important, as the previous behaviour (retry 
  forever) is usually not what is required.

**- How I did it**
- See commits

**- How to verify it**
- Tests pass

