### PR TITLE
fix: onboarding_cli example workaround for apkam notification  bug

### DIFF
--- a/packages/at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart
+++ b/packages/at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart
@@ -56,8 +56,14 @@ Future<void> _notificationCallback(AtNotification notification,
   var enrollParamsJson = {};
   enrollParamsJson['enrollmentId'] = enrollmentId;
   if (approveResponse == 'yes') {
-    final encryptedAPKAMSymmetricKey =
+    var encryptedAPKAMSymmetricKey =
         jsonDecode(notification.value!)['encryptedAPKAMSymmetricKey'];
+    // workaround for a server issue where it may send encryptedAPKAMSymmetricKey or encryptedApkamSymmetricKey
+    if (encryptedAPKAMSymmetricKey == null ||
+        encryptedAPKAMSymmetricKey.isEmpty) {
+      encryptedAPKAMSymmetricKey =
+          jsonDecode(notification.value!)['encryptedApkamSymmetricKey'];
+    }
     final apkamSymmetricKey = EncryptionUtil.decryptKey(
         encryptedAPKAMSymmetricKey, atAuthKeys.defaultEncryptionPrivateKey!);
     print('decrypted apkam symmetric key: $apkamSymmetricKey');


### PR DESCRIPTION
**- What I did**
- workaround for an issue in apkam notification where server can send either encryptedAPKAMSymmetricKey or encryptedApkamSymmetricKey in enroll request notification.
**- How I did it**
- added logic to handle both encryptedAPKAMSymmetricKey,encryptedApkamSymmetricKey in apkam example
**- How to verify it**
- run the examples following the README.md in apkam_examples