### PR TITLE
fix: Add revoke to at_enrollment_base.dart

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.4
+- fix: Add "revoke" to the "AtEnrollmentBase" to support enroll:revoke operation
 ## 2.0.3
 - fix: Add optional parameters to the "atAuth" method in "AtAuthInterface"
 ## 2.0.2

--- a/packages/at_auth/lib/src/enroll/at_enrollment_base.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_base.dart
@@ -102,7 +102,7 @@ abstract class AtEnrollmentBase {
   /// Returns a [Future] containing an [AtEnrollmentResponse] representing the result of the approval/denial of an enrollment.
   ///
   /// ```dart
-  ///  To approve an enrollment request
+  ///  To deny an enrollment request
   ///
   /// AtEnrollmentBase atEnrollmentBase = AtEnrollmentImpl('@alice');
   /// AtLookup atLookup = AtLookupImpl('@alice', 'dummy-root-domain', 64);
@@ -111,5 +111,24 @@ abstract class AtEnrollmentBase {
   /// AtEnrollmentResponse atEnrollmentResponse = await atEnrollmentBase.deny(enrollmentRequestDecision, atLookupImpl);
   /// ```
   Future<AtEnrollmentResponse> deny(
+      EnrollmentRequestDecision enrollmentRequestDecision, AtLookUp atLookUp);
+
+  /// Revokes an approved enrollment, closing any active connections and making it inactive for future use.
+  ///
+  /// Accepts [EnrollmentRequestDecision] which encapsulates the enrollment request details necessary to revoke an enrollment.
+  /// The [atLookUp] parameter is used to perform lookups during approval management.
+  ///
+  /// Returns a [Future] containing an [AtEnrollmentResponse] representing the result of the revoke of an enrollment.
+  ///
+  /// ```dart
+  ///  To revoke an enrollment request
+  ///
+  /// AtEnrollmentBase atEnrollmentBase = AtEnrollmentImpl('@alice');
+  /// AtLookup atLookup = AtLookupImpl('@alice', 'dummy-root-domain', 64);
+  ///
+  /// EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.revoked('dummy-enrollment-id');
+  /// AtEnrollmentResponse atEnrollmentResponse = await atEnrollmentBase.revoke(enrollmentRequestDecision, atLookupImpl);
+  /// ```
+  Future<AtEnrollmentResponse> revoke(
       EnrollmentRequestDecision enrollmentRequestDecision, AtLookUp atLookUp);
 }

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -167,6 +167,26 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
     return enrollmentResponse;
   }
 
+  @override
+  Future<AtEnrollmentResponse> revoke(
+      EnrollmentRequestDecision enrollmentRequestDecision,
+      AtLookUp atLookUp) async {
+    EnrollVerbBuilder revokeEnrollVerbBuilder = EnrollVerbBuilder()
+      ..enrollmentId = enrollmentRequestDecision.enrollmentId
+      ..operation = EnrollOperationEnum.revoke
+      ..force = enrollmentRequestDecision.force;
+
+    String? enrollmentResponseStr = await atLookUp
+        .executeCommand(revokeEnrollVerbBuilder.buildCommand(), auth: true);
+
+    enrollmentResponseStr = enrollmentResponseStr?.replaceAll('data:', '');
+    var enrollmentJsonMap = jsonDecode(enrollmentResponseStr!);
+    AtEnrollmentResponse enrollmentResponse = AtEnrollmentResponse(
+        enrollmentJsonMap['enrollmentId'],
+        _convertEnrollmentStatusToEnum(enrollmentJsonMap['status']));
+    return enrollmentResponse;
+  }
+
   Future<String> _getDefaultEncryptionPublicKey(AtLookUp atLookupImpl) async {
     var lookupVerbBuilder = LookupVerbBuilder()
       ..atKey = (AtKey()

--- a/packages/at_auth/lib/src/enroll/enrollment_request_decision.dart
+++ b/packages/at_auth/lib/src/enroll/enrollment_request_decision.dart
@@ -84,7 +84,7 @@ class EnrollmentRequestDecision {
     return enrollmentRequestDecision;
   }
 
-  /// If the request is denied, the requester application is prevented from logging into the application.
+  /// If the request is denied, the requester application is prevented from authenticating to the atServer.
   ///
   /// ```dart
   ///  EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.denied('dummy-enrollment-id');

--- a/packages/at_auth/lib/src/enroll/enrollment_request_decision.dart
+++ b/packages/at_auth/lib/src/enroll/enrollment_request_decision.dart
@@ -32,10 +32,19 @@ import 'package:at_commons/at_commons.dart';
 /// ```dart
 ///  EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.denied('dummy-enrollment-id');
 /// ```
+///
+/// To revoke an enrollment request. Optionally, set "force" parameter to true to revoke the enrollment permission of the current client
+/// which defaults to false.
+///
+/// Example:
+/// ```dart
+/// EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.revoked('enrollment123', force: false);
+/// ```
 class EnrollmentRequestDecision {
   late final String _enrollmentId;
   late final String _encryptedAPKAMSymmetricKey;
   late final EnrollOperationEnum _enrollOperationEnum;
+  bool force = false;
 
   String get enrollmentId => _enrollmentId;
 
@@ -75,7 +84,7 @@ class EnrollmentRequestDecision {
     return enrollmentRequestDecision;
   }
 
-  /// If the request is denied, the requester is prevented from logging into the application.
+  /// If the request is denied, the requester application is prevented from logging into the application.
   ///
   /// ```dart
   ///  EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.denied('dummy-enrollment-id');
@@ -84,6 +93,25 @@ class EnrollmentRequestDecision {
     return EnrollmentRequestDecision._()
       .._enrollmentId = enrollmentId
       .._enrollOperationEnum = EnrollOperationEnum.deny;
+  }
+
+  /// Revokes an approved enrollment, closing any active connections and making it inactive for future use.
+  ///
+  /// Creates an [EnrollmentRequestDecision] to revoke an enrollment. This method generates an [EnrollmentRequestDecision]
+  /// instance configured to revoke the enrollment specified by the provided [enrollmentId].
+  /// By default, the current client cannot revoke its own enrollment permission. To allow the current client to revoke
+  /// its own enrollment, set the force parameter to true.
+  ///
+  /// Example:
+  /// ```dart
+  /// EnrollmentRequestDecision enrollmentRequestDecision = EnrollmentRequestDecision.revoked('enrollment123', force: false);
+  /// ```
+  static EnrollmentRequestDecision revoked(String enrollmentId,
+      {bool force = false}) {
+    return EnrollmentRequestDecision._()
+      .._enrollmentId = enrollmentId
+      .._enrollOperationEnum = EnrollOperationEnum.revoke
+      ..force = force;
   }
 }
 

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.0.3
+version: 2.0.4
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^2.4.1
-  at_commons: ^4.0.5
+  at_commons: ^4.0.10
   at_lookup: ^3.0.46
   at_chops: ^2.0.0
   at_utils: ^3.0.16


### PR DESCRIPTION
 <!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add "revoke" method to "AtEnrollmentBase" to enable clients to revoke an approved enrollment. The revoke method accepts an instance of "EnrollmentRequestDescision" and instance of "AtLookup" as input parameters to perform revoke operation.
- Added a static method "revoked" to "EnrollmentRequestDecision" to get an instance of "EnrollmentRequestDecision".
- Update the version in pubspec.yaml and CHANGELOG.md

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
