### PR TITLE
test: add couple of functional tests related to APKAM

### DIFF
--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30 # v1.6.4
+      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
         with:
           sdk: stable
 
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30 # v1.6.4
+      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
         with:
           sdk: stable
 
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: dart-lang/setup-dart@f0ead981b4d9a35b37f30d36160575d60931ec30 # v1.6.4
+      - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1.6.5
         with:
           sdk: stable
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@23acc5c183826b7a8a97bce3cecc52db901f8251 # v3.25.10
+        uses: github/codeql-action/upload-sarif@b611370bb5703a7efb587f9d136a52ea24c5c38c # v3.25.11
         with:
           sarif_file: results.sarif

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -8,13 +8,16 @@ import 'package:at_auth/at_auth.dart';
 abstract class AtOnboardingService {
   static const Duration defaultApkamRetryInterval = Duration(seconds: 10);
 
-  ///perform initial one_time authentication to activate the atsign
-  ///returns true if onboarded
+  /// Perform initial one_time authentication to activate the atsign
+  /// returns true if successfully onboarded
   Future<bool> onboard();
 
-  ///Authenticate into secondary server using PKAM privateKey for legacy clients
-  ///For clients that are enrolled through APKAM, pass the enrollmentId and auth is done using APKAM private key
-  ///returns true if authenticated
+  /// Authenticate into secondary server using PKAM privateKey for legacy clients
+  ///
+  /// For clients that are enrolled through APKAM, pass the enrollmentId and
+  /// auth is done using APKAM private key
+  ///
+  /// Returns true if authentication is successful
   Future<bool> authenticate({String? enrollmentId});
 
   /// Sends an enroll request to the server, and waits for the request to be
@@ -67,19 +70,19 @@ abstract class AtOnboardingService {
     bool allowOverwrite = false,
   });
 
-  ///returns an authenticated instance of AtClient
+  /// Returns an authenticated instance of AtClient
   @Deprecated('use getter')
   Future<AtClient?> getAtClient();
 
   // return true if atsign is onboarded and keys are persisted in local storage. false otherwise
   Future<bool> isOnboarded();
 
-  ///returns authenticated instance of AtLookup
+  /// Returns authenticated instance of AtLookup
   @Deprecated('use getter')
   AtLookUp? getAtLookup();
 
-  ///Closes the current instance of onboarding_service
-  Future<void> close();
+  /// Closes the current instance of onboarding_service
+  Future<void> close({bool shouldExit = true, int exitCode = 0});
 
   set atClient(AtClient? atClient);
 

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -249,7 +249,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       retryInterval,
       logProgress: logProgress,
     );
-    logger.shout(enrollmentResponse.atAuthKeys!.apkamSymmetricKey);
 
     var decryptedEncryptionPrivateKey = EncryptionUtil.decryptValue(
         await _getEncryptionPrivateKeyFromServer(

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -16,6 +16,7 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
+import 'package:meta/meta.dart';
 import 'package:zxing2/qrcode.dart';
 import 'package:image/image.dart';
 import 'package:path/path.dart' as path;
@@ -234,11 +235,13 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       retryInterval,
       logProgress: logProgress,
     );
+    logger.shout(enrollmentResponse.atAuthKeys!.apkamSymmetricKey);
 
     var decryptedEncryptionPrivateKey = EncryptionUtil.decryptValue(
         await _getEncryptionPrivateKeyFromServer(
             enrollmentResponse.enrollmentId, atLookUpImpl),
         enrollmentResponse.atAuthKeys!.apkamSymmetricKey!);
+
     var decryptedSelfEncryptionKey = EncryptionUtil.decryptValue(
         await _getSelfEncryptionKeyFromServer(
             enrollmentResponse.enrollmentId, atLookUpImpl),

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -249,11 +249,13 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       retryInterval,
       logProgress: logProgress,
     );
+    logger.shout(enrollmentResponse.atAuthKeys!.apkamSymmetricKey);
 
     var decryptedEncryptionPrivateKey = EncryptionUtil.decryptValue(
         await _getEncryptionPrivateKeyFromServer(
             enrollmentResponse.enrollmentId, _atLookUp!),
         enrollmentResponse.atAuthKeys!.apkamSymmetricKey!);
+
     var decryptedSelfEncryptionKey = EncryptionUtil.decryptValue(
         await _getSelfEncryptionKeyFromServer(
             enrollmentResponse.enrollmentId, _atLookUp!),

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -427,7 +427,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<void> _persistKeysLocalSecondary() async {
     //when authenticating keys need to be fetched from atKeys file
     at_auth.AtAuthKeys atAuthKeys = _decryptAtKeysFile(
-        (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
+        (await readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
     //backup keys into local secondary
     bool? response = await atClient
         ?.getLocalSecondary()
@@ -479,7 +479,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to read and return data from .atKeysFile
   ///returns map containing encryption keys
-  Future<Map<String, String>> _readAtKeysFile(String? atKeysFilePath) async {
+  @visibleForTesting
+  Future<Map<String, String>> readAtKeysFile(String? atKeysFilePath) async {
     if (atKeysFilePath == null || atKeysFilePath.isEmpty) {
       throw AtClientException.message(
           'atKeys filePath is empty. atKeysFile is required to authenticate');
@@ -638,7 +639,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     _atLookUp = null;
     atClient = null;
     logger.info('Closing current instance of at_onboarding_cli');
-    if(shouldExit){
+    if (shouldExit) {
       exit(exitCode);
     }
   }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -59,7 +59,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   Future<void> _initAtClient(AtChops atChops, {String? enrollmentId}) async {
     AtClientManager atClientManager = AtClientManager.getInstance();
-    if (atOnboardingPreference.skipSync == true) {
+    if (atOnboardingPreference.skipSync) {
       atServiceFactory = ServiceFactoryWithNoOpSyncService();
     }
     await atClientManager.setCurrentAtSign(
@@ -477,7 +477,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       ..authMode = atOnboardingPreference.authMode
       ..rootDomain = atOnboardingPreference.rootDomain
       ..rootPort = atOnboardingPreference.rootPort
-    ..publicKeyId = atOnboardingPreference.publicKeyId;
+      ..publicKeyId = atOnboardingPreference.publicKeyId;
     var atAuthResponse = await atAuth!.authenticate(atAuthRequest);
     logger.finer('Auth response: $atAuthResponse');
     if (atAuthResponse.isSuccessful &&
@@ -673,9 +673,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     _atLookUp = null;
     atClient = null;
     logger.info('Closing current instance of at_onboarding_cli');
-    if (shouldExit) {
-      exit(exitCode);
-    }
+    if (shouldExit) exit(exitCode);
   }
 
   @override

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -440,7 +440,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<void> _persistKeysLocalSecondary() async {
     //when authenticating keys need to be fetched from atKeys file
     at_auth.AtAuthKeys atAuthKeys = _decryptAtKeysFile(
-        (await _readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
+        (await readAtKeysFile(atOnboardingPreference.atKeysFilePath)));
     //backup keys into local secondary
     bool? response = await atClient
         ?.getLocalSecondary()
@@ -493,7 +493,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   ///method to read and return data from .atKeysFile
   ///returns map containing encryption keys
-  Future<Map<String, String>> _readAtKeysFile(String? atKeysFilePath) async {
+  @visibleForTesting
+  Future<Map<String, String>> readAtKeysFile(String? atKeysFilePath) async {
     if (atKeysFilePath == null || atKeysFilePath.isEmpty) {
       throw AtClientException.message(
           'atKeys filePath is empty. atKeysFile is required to authenticate');
@@ -672,7 +673,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     _atLookUp = null;
     atClient = null;
     logger.info('Closing current instance of at_onboarding_cli');
-    if(shouldExit){
+    if (shouldExit) {
       exit(exitCode);
     }
   }

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -663,14 +663,16 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   @override
-  Future<void> close() async {
+  Future<void> close({bool shouldExit = true, int exitCode = 0}) async {
     if (_atLookUp != null) {
       await (_atLookUp as AtLookupImpl).close();
     }
     _atLookUp = null;
     atClient = null;
-    logger.info('Closing current instance of at_onboarding_cli (exit code: 0)');
-    exit(0);
+    logger.info('Closing current instance of at_onboarding_cli');
+    if(shouldExit){
+      exit(exitCode);
+    }
   }
 
   @override

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -18,7 +18,6 @@ dependency_overrides:
   at_onboarding_cli:
     path: ../../packages/at_onboarding_cli
 
-
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.2

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   at_lookup: ^3.0.47
+  at_client: ^3.0.76
   at_onboarding_cli: ^1.4.4
 
 dependency_overrides:
@@ -19,4 +20,4 @@ dependency_overrides:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.2
-  at_demo_data: ^1.0.0
+  at_demo_data: ^1.0.3

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.14.4 <4.0.0'
 
 dependencies:
+  at_client: ^3.0.76
   at_onboarding_cli: ^1.4.4
 
 dependency_overrides:
@@ -18,4 +19,4 @@ dependency_overrides:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.17.2
-  at_demo_data: ^1.0.0
+  at_demo_data: ^1.0.3

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -10,12 +10,14 @@ dependencies:
   at_lookup: ^3.0.47
   at_client: ^3.0.76
   at_onboarding_cli: ^1.4.4
+  at_commons: ^4.0.10
 
 dependency_overrides:
   at_auth:
     path: ../../packages/at_auth
   at_onboarding_cli:
     path: ../../packages/at_onboarding_cli
+
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
@@ -9,67 +9,52 @@ import 'package:at_client/src/service/enrollment_service_impl.dart';
 class EnrollmentOperations {
   late String atsign;
   EnrollmentService? enrollmentService;
-  String storageDir = 'test/testStorage/temp';
-  AtOnboardingService? onboardingService;
+  String storageDir = 'test/storage/temp';
   bool isAuthenticated = false;
 
   EnrollmentOperations(this.atsign);
 
-  void initOnboardingService({String? cramKey}) {
-    AtOnboardingPreference preference = AtOnboardingPreference()
-      ..commitLogPath = '$storageDir/commitLog/$atsign/1'
-      ..hiveStoragePath = '$storageDir/hive/$atsign/1'
-      ..atKeysFilePath = '$storageDir/keys/${atsign}_key.atKeys'
-      ..rootDomain = 'vip.ve.atsign.zone'
-      ..cramSecret = cramKey;
-
-    onboardingService = AtOnboardingServiceImpl(atsign, preference);
-  }
-
-  Future<bool> onboard({required String cramKey}) async {
-    initOnboardingService(cramKey: cramKey);
-    return await onboardingService!.onboard();
-  }
-
-  Future<String?> getOtp() async {
-    if (onboardingService == null) {
-      initOnboardingService();
-    }
-    if (!isAuthenticated) {
-      isAuthenticated = await onboardingService!.authenticate();
-    }
-
-    String? response = await onboardingService?.atClient
+  Future<String?> getOtp(String atKeysFilePath) async {
+    AtOnboardingService onboardingService = AtOnboardingServiceImpl(
+        atsign, getOnboardingPreference(atKeysFilePath: atKeysFilePath));
+    await onboardingService.authenticate();
+    String? response = await onboardingService.atClient
         ?.getRemoteSecondary()
         ?.executeCommand('otp:get\n', auth: true);
     stdout.writeln('[Test | EnrollmentOps] Fetch OTP response: $response');
     response = response?.replaceFirst('data:', '');
-
+    await onboardingService.close(shouldExit: false);
     return response;
   }
 
   Future<AtEnrollmentResponse> approve(
-      {String? enrollmentId,
-      String? encApkamSymmKey,
+      {required String atKeysFilePath,
+      String? enrollmentId,
+      String? encApkamSymmetricKey,
       String? appName,
       String? deviceName}) async {
-    if (onboardingService == null) {
-      initOnboardingService();
-    }
-    if (!isAuthenticated) {
-      isAuthenticated = await onboardingService!.authenticate();
-    }
+    AtOnboardingService onboardingService = AtOnboardingServiceImpl(
+        atsign, getOnboardingPreference(atKeysFilePath: atKeysFilePath));
+    await onboardingService.authenticate();
     enrollmentService = EnrollmentServiceImpl(
-        onboardingService!.atClient!, atAuthBase.atEnrollment(atsign));
-    // when enrollmentId is not provided. Fetches all enrollment requests based
-    // on appName and deviceName and uses the enrollmentId of the first request
-    enrollmentId ??= await fetchEnrollmentId(onboardingService!.atClient!,
-        appName: appName!, deviceName: deviceName!);
+        onboardingService.atClient!, atAuthBase.atEnrollment(atsign));
 
+    // when enrollmentId is not provided. Fetches all enrollment requests based
+    // on appName and deviceName and uses the data from the first request
+    //
+    // the assumption is that the first request with the given appName and deviceName
+    // is the one that needs to be approved
+    Enrollment? enrollment;
+    if (enrollmentId == null) {
+      enrollment = await fetchEnrollment(onboardingService.atClient!,
+          appName: appName!, deviceName: deviceName!);
+      enrollmentId = enrollment.enrollmentId;
+      encApkamSymmetricKey = enrollment.encryptedAPKAMSymmetricKey;
+    }
     EnrollmentRequestDecision decision = EnrollmentRequestDecision.approved(
         ApprovedRequestDecisionBuilder(
             enrollmentId: enrollmentId!,
-            encryptedAPKAMSymmetricKey: encApkamSymmKey!));
+            encryptedAPKAMSymmetricKey: encApkamSymmetricKey!));
     AtEnrollmentResponse? enrollmentResponse =
         await enrollmentService?.approve(decision);
     print('Enroll Approve Response: $enrollmentResponse');
@@ -80,14 +65,24 @@ class EnrollmentOperations {
   /// Fetches enrollment requests from server based on the [appName] and [deviceName] provided
   ///
   /// Always returns the first enrollmentId from the list fetched from server
-  Future<String?> fetchEnrollmentId(AtClient client,
+  Future<Enrollment> fetchEnrollment(AtClient client,
       {required String appName, required String deviceName}) async {
     EnrollmentListRequestParam requestParam = EnrollmentListRequestParam()
       ..appName = appName
-      ..deviceName = deviceName;
-      // ..enrollmentListFilter = [EnrollmentStatus.pending];
+      ..deviceName = deviceName
+      ..enrollmentListFilter = [EnrollmentStatus.pending];
     return (await enrollmentService!
-            .fetchEnrollmentRequests(enrollmentListParams: requestParam))[0]
-        .enrollmentId;
+        .fetchEnrollmentRequests(enrollmentListParams: requestParam))[0];
+  }
+
+  AtOnboardingPreference getOnboardingPreference(
+      {String? cramKey, String? atKeysFilePath}) {
+    return AtOnboardingPreference()
+      ..commitLogPath = '$storageDir/commitLog/$atsign/1'
+      ..hiveStoragePath = '$storageDir/hive/$atsign/1'
+      ..atKeysFilePath = '$storageDir/keys/${atsign}_key.atKeys'
+      ..rootDomain = 'vip.ve.atsign.zone'
+      ..cramSecret = cramKey
+      ..atKeysFilePath = atKeysFilePath;
   }
 }

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
@@ -4,70 +4,90 @@ import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_auth/at_auth.dart';
 import 'package:at_client/at_client.dart';
 
+import 'package:at_client/src/service/enrollment_service_impl.dart';
+
 class EnrollmentOperations {
-  String storageDir = '/home/srie/Desktop/temp';
-  Future<String?> getOtp(String atsign, {String? atKeysFilePath}) async {
+  late String atsign;
+  EnrollmentService? enrollmentService;
+  String storageDir = 'test/testStorage/temp';
+  AtOnboardingService? onboardingService;
+  bool isAuthenticated = false;
+
+  EnrollmentOperations(this.atsign);
+
+  void initOnboardingService({String? cramKey}) {
     AtOnboardingPreference preference = AtOnboardingPreference()
       ..commitLogPath = '$storageDir/commitLog/$atsign/1'
       ..hiveStoragePath = '$storageDir/hive/$atsign/1'
-      ..atKeysFilePath = atKeysFilePath
-      ..rootDomain = 'vip.ve.atsign.zone';
+      ..atKeysFilePath = '$storageDir/keys/${atsign}_key.atKeys'
+      ..rootDomain = 'vip.ve.atsign.zone'
+      ..cramSecret = cramKey;
 
-    AtOnboardingService onboardingService =
-        AtOnboardingServiceImpl(atsign, preference);
-    await onboardingService.authenticate();
+    onboardingService = AtOnboardingServiceImpl(atsign, preference);
+  }
 
-    String? response = await onboardingService.atClient
+  Future<bool> onboard({required String cramKey}) async {
+    initOnboardingService(cramKey: cramKey);
+    return await onboardingService!.onboard();
+  }
+
+  Future<String?> getOtp() async {
+    if (onboardingService == null) {
+      initOnboardingService();
+    }
+    if (!isAuthenticated) {
+      isAuthenticated = await onboardingService!.authenticate();
+    }
+
+    String? response = await onboardingService?.atClient
         ?.getRemoteSecondary()
         ?.executeCommand('otp:get\n', auth: true);
     stdout.writeln('[Test | EnrollmentOps] Fetch OTP response: $response');
     response = response?.replaceFirst('data:', '');
-    onboardingService.close(shouldExit: false);
 
     return response;
   }
 
-  Future<AtEnrollmentResponse> approve(String atsign,
-      {String? atKeysFilePath,
-      String? enrollmentId,
+  Future<AtEnrollmentResponse> approve(
+      {String? enrollmentId,
       String? encApkamSymmKey,
       String? appName,
       String? deviceName}) async {
-    AtOnboardingPreference preference = AtOnboardingPreference()
-      ..commitLogPath = '$storageDir/commitLog/$atsign/2'
-      ..hiveStoragePath = '$storageDir/hive/$atsign/2'
-      ..atKeysFilePath = atKeysFilePath
-      ..rootDomain = 'vip.ve.atsign.zone';
-
-    AtOnboardingService onboardingService =
-        AtOnboardingServiceImpl(atsign, preference);
-    await onboardingService.authenticate();
+    if (onboardingService == null) {
+      initOnboardingService();
+    }
+    if (!isAuthenticated) {
+      isAuthenticated = await onboardingService!.authenticate();
+    }
+    enrollmentService = EnrollmentServiceImpl(
+        onboardingService!.atClient!, atAuthBase.atEnrollment(atsign));
     // when enrollmentId is not provided. Fetches all enrollment requests based
     // on appName and deviceName and uses the enrollmentId of the first request
-    enrollmentId ??= await fetchEnrollmentId(onboardingService.atClient!,
+    enrollmentId ??= await fetchEnrollmentId(onboardingService!.atClient!,
         appName: appName!, deviceName: deviceName!);
 
     EnrollmentRequestDecision decision = EnrollmentRequestDecision.approved(
         ApprovedRequestDecisionBuilder(
-            enrollmentId: enrollmentId,
+            enrollmentId: enrollmentId!,
             encryptedAPKAMSymmetricKey: encApkamSymmKey!));
-    AtEnrollmentResponse enrollmentResponse = await atAuthBase
-        .atEnrollment(atsign)
-        .approve(decision, onboardingService.atLookUp!);
+    AtEnrollmentResponse? enrollmentResponse =
+        await enrollmentService?.approve(decision);
     print('Enroll Approve Response: $enrollmentResponse');
-    onboardingService.close(shouldExit: false);
 
-    return enrollmentResponse;
+    return enrollmentResponse!;
   }
 
   /// Fetches enrollment requests from server based on the [appName] and [deviceName] provided
   ///
   /// Always returns the first enrollmentId from the list fetched from server
-  Future<String> fetchEnrollmentId(AtClient client,
+  Future<String?> fetchEnrollmentId(AtClient client,
       {required String appName, required String deviceName}) async {
-    EnrollListRequestParam requestParam = EnrollListRequestParam()
+    EnrollmentListRequestParam requestParam = EnrollmentListRequestParam()
       ..appName = appName
       ..deviceName = deviceName;
-    return (await client.fetchEnrollmentRequests(requestParam))[0].enrollmentId;
+      // ..enrollmentListFilter = [EnrollmentStatus.pending];
+    return (await enrollmentService!
+            .fetchEnrollmentRequests(enrollmentListParams: requestParam))[0]
+        .enrollmentId;
   }
 }

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
@@ -67,7 +67,7 @@ class EnrollmentOperations {
 
   /// Fetches enrollment requests from server based on the [appName] and [deviceName] provided
   ///
-  /// Always returns the first enrollmentId from the list fetched from server
+  /// Always returns the first enrollment from the list fetched from server
   Future<Enrollment> fetchEnrollment(EnrollmentService enrollmentService,
       {required String appName, required String deviceName}) async {
     EnrollmentListRequestParam requestParam = EnrollmentListRequestParam()

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_operations.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_auth/at_auth.dart';
+import 'package:at_client/at_client.dart';
+
+class EnrollmentOperations {
+  String storageDir = '/home/srie/Desktop/temp';
+  Future<String?> getOtp(String atsign, {String? atKeysFilePath}) async {
+    AtOnboardingPreference preference = AtOnboardingPreference()
+      ..commitLogPath = '$storageDir/commitLog/$atsign/1'
+      ..hiveStoragePath = '$storageDir/hive/$atsign/1'
+      ..atKeysFilePath = atKeysFilePath
+      ..rootDomain = 'vip.ve.atsign.zone';
+
+    AtOnboardingService onboardingService =
+        AtOnboardingServiceImpl(atsign, preference);
+    await onboardingService.authenticate();
+
+    String? response = await onboardingService.atClient
+        ?.getRemoteSecondary()
+        ?.executeCommand('otp:get\n', auth: true);
+    stdout.writeln('[Test | EnrollmentOps] Fetch OTP response: $response');
+    response = response?.replaceFirst('data:', '');
+    onboardingService.close(shouldExit: false);
+
+    return response;
+  }
+
+  Future<AtEnrollmentResponse> approve(String atsign,
+      {String? atKeysFilePath,
+      String? enrollmentId,
+      String? encApkamSymmKey,
+      String? appName,
+      String? deviceName}) async {
+    AtOnboardingPreference preference = AtOnboardingPreference()
+      ..commitLogPath = '$storageDir/commitLog/$atsign/2'
+      ..hiveStoragePath = '$storageDir/hive/$atsign/2'
+      ..atKeysFilePath = atKeysFilePath
+      ..rootDomain = 'vip.ve.atsign.zone';
+
+    AtOnboardingService onboardingService =
+        AtOnboardingServiceImpl(atsign, preference);
+    await onboardingService.authenticate();
+    // when enrollmentId is not provided. Fetches all enrollment requests based
+    // on appName and deviceName and uses the enrollmentId of the first request
+    enrollmentId ??= await fetchEnrollmentId(onboardingService.atClient!,
+        appName: appName!, deviceName: deviceName!);
+
+    EnrollmentRequestDecision decision = EnrollmentRequestDecision.approved(
+        ApprovedRequestDecisionBuilder(
+            enrollmentId: enrollmentId,
+            encryptedAPKAMSymmetricKey: encApkamSymmKey!));
+    AtEnrollmentResponse enrollmentResponse = await atAuthBase
+        .atEnrollment(atsign)
+        .approve(decision, onboardingService.atLookUp!);
+    print('Enroll Approve Response: $enrollmentResponse');
+    onboardingService.close(shouldExit: false);
+
+    return enrollmentResponse;
+  }
+
+  /// Fetches enrollment requests from server based on the [appName] and [deviceName] provided
+  ///
+  /// Always returns the first enrollmentId from the list fetched from server
+  Future<String> fetchEnrollmentId(AtClient client,
+      {required String appName, required String deviceName}) async {
+    EnrollListRequestParam requestParam = EnrollListRequestParam()
+      ..appName = appName
+      ..deviceName = deviceName;
+    return (await client.fetchEnrollmentRequests(requestParam))[0].enrollmentId;
+  }
+}

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -1,11 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:at_auth/src/enroll/at_enrollment_response.dart';
 import 'package:at_client/at_client.dart';
-import 'package:at_commons/at_builders.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
@@ -23,7 +21,7 @@ var selfEncryptionKey;
 final logger = AtSignLogger('OnboardingEnrollmentTest');
 
 void main() {
-  AtSignLogger.root_level = 'FINER';
+  AtSignLogger.root_level = 'WARNING';
   String storageDir = 'test/storage';
 
   group('A group of tests to assert on authenticate functionality', () {
@@ -323,7 +321,7 @@ void main() {
         otp!,
         namespaces,
       );
-      logger.shout('Sleeping for 10s');
+      logger.info('Sleeping for 10s');
       await Future.delayed(Duration(seconds: 10));
 
       // Approve the new enrollment request
@@ -425,7 +423,7 @@ void main() {
         otp!,
         namespaces,
       );
-      logger.shout('Sleeping for 10s');
+      logger.info('Sleeping for 10s');
       await Future.delayed(Duration(seconds: 10));
 
       // Approve the new enrollment request


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Introduced EnrollmentOperations class, that currently has methods getOtp() and approve(). These methods accept a master atKeys file, create their own instance of OnboardingCli and perform elevated operations as required.
- Introduce 2 functional tests
- Introduce optional params in OnboardingService.close() named shouldExit and exitCode.

**- How to verify it**
- All tests should pass
