### PR TITLE
fix: remove deprecated annotation from Metadata.pubKeyCS

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.0.12
+- fix: remove deprecated annotation from Metadata.pubKeyCS
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text
 ## 4.0.10

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -39,7 +39,7 @@
 - feat: Introduce "AtThrottleLimitExceeded" exception which is thrown when enrollment request exceeds the limit
 - feat: Introduce new error codes for apkam enrollments
 ## 3.0.54
-- fix: Modify "totp" verb regex to include alpha-numeric characters
+- fix: Modify "totp" verb regex to include alphanumeric characters
 - feat: Introduce "EnrollResponse" class which represents the enrollment response.
 ## 3.0.53
 - feat: Modify "enroll" verb regex.
@@ -130,7 +130,7 @@
 - Add constant for stats notification id
 ## 3.0.20
 - Enhance notify verb to include the isEncrypted field
-- Add intent and exception scenario to AtException sub-classes
+- Add intent and exception scenario to AtException subclasses
 - Introducing class SecureSocketConfig to store config params to create security context for secure sockets.
 ## 3.0.19
 - Rename byPassCache to bypassCache in lookup, plookup verb builders and at_constants

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -453,9 +453,11 @@ class Metadata {
   /// See also [skeEncKeyName]
   String? sharedKeyEnc;
 
-  /// Stores the checksum of the encryption public key used to encrypt the [sharedKeyEnc]. We use this
-  /// to verify that the encryption key-pair used to encrypt and decrypt the value are same
-  @Deprecated('Use pubKeyHash')
+  /// Stores the checksum of the encryption public key used to encrypt the
+  /// [sharedKeyEnc]. We use this to verify that the encryption key-pairs used
+  /// to encrypt and decrypt the value are the same
+  /// Will be marked as `@Deprecated('Use pubKeyHash')` once at_server and
+  /// at_client_sdk fully support pubKeyHash
   String? pubKeyCS;
 
   /// Stores the hash of the encryption public key used to encrypt the [sharedKeyEnc]

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -12,7 +12,11 @@ enum StrategyEnum { all, latest }
 String getStrategy(StrategyEnum? strategyEnum) =>
     '$strategyEnum'.split('.').last;
 
-enum MessageTypeEnum { key, @Deprecated('text based notifications are deprecated') text }
+enum MessageTypeEnum {
+  key,
+  @Deprecated('text based notifications are deprecated')
+  text,
+}
 
 String getMessageType(MessageTypeEnum? messageTypeEnum) =>
     '$messageTypeEnum'.split('.').last;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.11
+version: 4.0.12
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
Resolves #614 

**- What I did**
- fix: remove deprecated annotation from `Metadata.pubKeyCS`
- docs: add 4.0.12 to at_commons CHANGELOG
- update at_commons version to 4.0.12
- chore: run dart format, and clean up two minor typos in changelog