### PR TITLE
build: at_commons version 4.0.11 for publishing

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 4.0.12
-- fix: remove deprecated annotation from Metadata.pubKeyCS
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text
+- fix: remove deprecated annotation from Metadata.pubKeyCS
+
 ## 4.0.10
 - fix: Add a "force" variable to enroll_verb_builder to propagate enroll:revoke:force value
 - fix: Deprecate apkam in PkamAuthMode enum

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.12
+version: 4.0.11
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
build: last published version of at_commons was 4.0.10, so keeping next published version as 4.0.11

**- How I did it**
bumped version back to 4.0.11
