### PR TITLE
fix: update pkam verb syntax to include SHA512 as hashing algo

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,7 +1,8 @@
+## 4.0.12
+- fix: update pkam regex to accept sha512 as hashing algo
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text
 - fix: remove deprecated annotation from Metadata.pubKeyCS
-
 ## 4.0.10
 - fix: Add a "force" variable to enroll_verb_builder to propagate enroll:revoke:force value
 - fix: Deprecate apkam in PkamAuthMode enum

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -7,7 +7,7 @@ class VerbSyntax {
   static const pol = r'^pol$';
   static const cram = r'^cram:(?<digest>.+$)';
   static const pkam =
-      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)';
+      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)';
   static const llookup = r'^llookup'
       r'(:(?<operation>meta|all))?'
       r'(:cached)?'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.11
+version: 4.0.12
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -51,12 +51,14 @@ void main() {
               e.message == 'command does not match the regex')));
     });
   });
+
   group('A group of tests to verify pkam verb regex', () {
     test('pkam regex without signing algo', () {
       var command = 'pkam:abcd1234';
       var verbParams = getVerbParams(VerbSyntax.pkam, command);
       expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
     });
+
     test('pkam regex with rsa2048 signing algo and sha256 hashing algo', () {
       var command = 'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:abcd1234';
       var verbParams = getVerbParams(VerbSyntax.pkam, command);
@@ -64,6 +66,7 @@ void main() {
       expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha256');
       expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
     });
+
     test('pkam regex with ecc signing algo and sha256 hashing algo', () {
       var command =
           'pkam:signingAlgo:ecc_secp256r1:hashingAlgo:sha256:abcd1234';
@@ -72,17 +75,37 @@ void main() {
       expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha256');
       expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
     });
+
+    test('pkam regex with ecc signing algo and sha512 hashing algo', () {
+      var command =
+          'pkam:signingAlgo:ecc_secp256r1:hashingAlgo:sha512:abcd1234';
+      var verbParams = getVerbParams(VerbSyntax.pkam, command);
+      expect(verbParams[AtConstants.atPkamSigningAlgo], 'ecc_secp256r1');
+      expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha512');
+      expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
+    });
+
+    test('pkam regex with rsa signing algo and sha512 hashing algo', () {
+      var command = 'pkam:signingAlgo:rsa2048:hashingAlgo:sha512:abcd1234';
+      var verbParams = getVerbParams(VerbSyntax.pkam, command);
+      expect(verbParams[AtConstants.atPkamSigningAlgo], 'rsa2048');
+      expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha512');
+      expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
+    });
+
     test('pkam regex with invalid signing algo', () {
       var command = 'pkam:signingAlgo:ecc:abcd1234';
       var verbParams = getVerbParams(VerbSyntax.pkam, command);
       expect(verbParams[AtConstants.atPkamSigningAlgo], isNull);
     });
+
     test('pkam regex with invalid hashing algo', () {
       var command = 'pkam:hashingAlgo:md5:abcd1234';
       var verbParams = getVerbParams(VerbSyntax.pkam, command);
       expect(verbParams[AtConstants.atPkamHashingAlgo], isNull);
     });
   });
+
   group('A group of positive tests to verify keys verb regex', () {
     test('keys verb  - put public key', () {
       var command =


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- fix: update pkam verb syntax to include SHA512 as hashing algo

**- How to verify it**
- added unit tests to validate changes

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: update pkam verb syntax to include SHA512 as hashing algo