### PR TITLE
fix: Add .atKeys extension to the custom file path

### DIFF
--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -386,8 +386,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }) async {
     if (atKeysFile == null) {
       if (!atOnboardingPreference.atKeysFilePath!.endsWith('.atKeys')) {
-        atOnboardingPreference.atKeysFilePath =
-            path.join(atOnboardingPreference.atKeysFilePath!, '.atKeys');
+        atOnboardingPreference.atKeysFilePath = path.setExtension(
+            atOnboardingPreference.atKeysFilePath!, '.atKeys');
       }
       atKeysFile = File(atOnboardingPreference.atKeysFilePath!);
     }

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -1,17 +1,18 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:at_auth/at_auth.dart';
 import 'package:at_chops/at_chops.dart';
+import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:crypton/crypton.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:at_lookup/at_lookup.dart';
-import 'package:at_client/at_client.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
-import 'package:at_auth/at_auth.dart';
 
 class MockAtLookupImpl extends Mock implements AtLookupImpl {}
 
@@ -161,6 +162,41 @@ void main() {
     tearDown(() async {
       await tearDownFunc();
     });
+  });
+
+  group('A group of tests related to generation of AtKeys', () {
+    test(
+        'A test to verify createAtKeys generates atKeys in the location specified in onboarding preference atKeysFilePath',
+        () async {
+      String atsign = '@alice_test';
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath = '${Directory.current.path}/test/$atsign';
+      AtOnboardingServiceImpl onboardingService =
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
+
+      AtEnrollmentResponse atEnrollmentResponse =
+          AtEnrollmentResponse('123', EnrollmentStatus.approved);
+
+      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      atEnrollmentResponse.atAuthKeys = AtAuthKeys()
+        ..enrollmentId = '123'
+        ..defaultSelfEncryptionKey = onboardingService.generateAESKey()
+        ..defaultEncryptionPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..defaultEncryptionPrivateKey =
+            encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPrivateKey = encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..apkamSymmetricKey = onboardingService.generateAESKey();
+
+      var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
+      expect(f.path.endsWith('$atsign.atKeys'), true);
+
+      File file = File(f.path);
+      expect(file.existsSync(), true);
+      // Delete the file at the end of the test.
+      file.deleteSync(recursive: true);
+    });
+    ;
   });
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes issue: https://github.com/atsign-foundation/at_libraries/issues/629

**- How I did it**
- In the atKeys file path, if the file name doesn’t end with the 'atKeys' extension, the problem occurs because "atKeys" is appended to the path rather than being set as the file extension.
- Replaced `path.join` method with `path.setExtension` to fix the issue.

**- How to verify it**
- Tested manually after the fix and below is log snippet:
```
sitaram@sitaram-ThinkPad-E14:~/IdeaProjects/atsign/core/at_libraries/packages/at_onboarding_cli$ dart bin/activate_cli.dart enroll -s ABC123 -p demo2 -d local -n "buzz:rw" -a @sitaram -r vip.ve.atsign.zone -k ~/keys/akam_keys/@sitaram_1_newkeys
Submitting enrollment request
Enrollment ID: 434a7047-18df-4ea2-9c24-bc0306adce2b
Waiting for approval; will check every 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  approved.
Creating atKeys file
[Success] Your .atKeys file saved at /home/sitaram/keys/akam_keys/@sitaram_1_newkeys.atKeys
```
- Added unit test to assert the change.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
