### PR TITLE
fix: `.atKeys` filename was trimmed when filename has period('.') in it

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.6.3
+- fix: `.atKeys` filename was trimmed when filename has period('.') in it
 ## 1.6.2
 - fix: `.atKeys` file was being generated in the wrong location in some cases
 ## 1.6.1

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -4,23 +4,22 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:at_auth/at_auth.dart' as at_auth;
 import 'package:at_auth/at_auth.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
-import 'package:at_auth/at_auth.dart' as at_auth;
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
-import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
-import 'package:at_server_status/at_server_status.dart';
-import 'package:at_utils/at_utils.dart';
-import 'package:at_onboarding_cli/src/factory/service_factories.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_onboarding_cli/src/factory/service_factories.dart';
+import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_server_status/at_server_status.dart';
+import 'package:at_utils/at_utils.dart';
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart';
+import 'package:image/image.dart';
 import 'package:meta/meta.dart';
 import 'package:zxing2/qrcode.dart';
-import 'package:image/image.dart';
-import 'package:path/path.dart' as path;
 
 import '../util/home_directory_util.dart';
 import '../util/onboarding_util.dart';
@@ -386,8 +385,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }) async {
     if (atKeysFile == null) {
       if (!atOnboardingPreference.atKeysFilePath!.endsWith('.atKeys')) {
-        atOnboardingPreference.atKeysFilePath = path.setExtension(
-            atOnboardingPreference.atKeysFilePath!, '.atKeys');
+        atOnboardingPreference.atKeysFilePath =
+            '${atOnboardingPreference.atKeysFilePath}.atKeys';
       }
       atKeysFile = File(atOnboardingPreference.atKeysFilePath!);
     }
@@ -654,7 +653,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   @override
   Future<void> close() async {
     logger.info('Closing');
-    if (_atLookUp != null && (_atLookUp as AtLookupImpl).isConnectionAvailable()) {
+    if (_atLookUp != null &&
+        (_atLookUp as AtLookupImpl).isConnectionAvailable()) {
       await _atLookUp!.close();
     }
     atClient?.notificationService.stopAllSubscriptions();

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.6.2
+version: 1.6.3
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -196,7 +196,102 @@ void main() {
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
-    ;
+
+    test(
+        'A test to verify createAtKeys when keys location as . in the filename',
+        () async {
+      String atsign = '@alice_test';
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath = '${Directory.current.path}/test/$atsign.me';
+      AtOnboardingServiceImpl onboardingService =
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
+
+      AtEnrollmentResponse atEnrollmentResponse =
+          AtEnrollmentResponse('123', EnrollmentStatus.approved);
+
+      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      atEnrollmentResponse.atAuthKeys = AtAuthKeys()
+        ..enrollmentId = '123'
+        ..defaultSelfEncryptionKey = onboardingService.generateAESKey()
+        ..defaultEncryptionPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..defaultEncryptionPrivateKey =
+            encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPrivateKey = encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..apkamSymmetricKey = onboardingService.generateAESKey();
+
+      var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
+      expect(f.path.endsWith('$atsign.me.atKeys'), true);
+
+      File file = File(f.path);
+      expect(file.existsSync(), true);
+      // Delete the file at the end of the test.
+      file.deleteSync(recursive: true);
+    });
+
+    test(
+        'A test to verify createAtKeys when keys location as - in the filename',
+        () async {
+      String atsign = '@alice_test';
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath = '${Directory.current.path}/test/$atsign-me';
+      AtOnboardingServiceImpl onboardingService =
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
+
+      AtEnrollmentResponse atEnrollmentResponse =
+          AtEnrollmentResponse('123', EnrollmentStatus.approved);
+
+      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      atEnrollmentResponse.atAuthKeys = AtAuthKeys()
+        ..enrollmentId = '123'
+        ..defaultSelfEncryptionKey = onboardingService.generateAESKey()
+        ..defaultEncryptionPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..defaultEncryptionPrivateKey =
+            encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPrivateKey = encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..apkamSymmetricKey = onboardingService.generateAESKey();
+
+      var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
+      expect(f.path.endsWith('$atsign-me.atKeys'), true);
+
+      File file = File(f.path);
+      expect(file.existsSync(), true);
+      // Delete the file at the end of the test.
+      file.deleteSync(recursive: true);
+    });
+
+    test(
+        'A test to verify createAtKeys does not append .atKeys when filename has .atKeys extension',
+        () async {
+      String atsign = '@alice_test';
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath = '${Directory.current.path}/test/$atsign-me.atKeys';
+      AtOnboardingServiceImpl onboardingService =
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
+
+      AtEnrollmentResponse atEnrollmentResponse =
+          AtEnrollmentResponse('123', EnrollmentStatus.approved);
+
+      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      atEnrollmentResponse.atAuthKeys = AtAuthKeys()
+        ..enrollmentId = '123'
+        ..defaultSelfEncryptionKey = onboardingService.generateAESKey()
+        ..defaultEncryptionPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..defaultEncryptionPrivateKey =
+            encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPrivateKey = encryptionRsaKeyPair.privateKey.toString()
+        ..apkamPublicKey = encryptionRsaKeyPair.publicKey.toString()
+        ..apkamSymmetricKey = onboardingService.generateAESKey();
+
+      var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
+      expect(f.path.endsWith('$atsign-me.atKeys'), true);
+
+      File file = File(f.path);
+      expect(file.existsSync(), true);
+      // Delete the file at the end of the test.
+      file.deleteSync(recursive: true);
+    });
   });
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- When creating an atKeys file, if the filename contains a period ('.'), the last part of the filename is replaced with the '.atKeys' extension due to the path.setExtension() method. Attaching the API docs for reference: https://pub.dev/documentation/path/latest/path/Context/setExtension.html

- To resolve this issue, the path.setExtension() method was removed. Now, if the filename does not already end with '.atKeys', the extension is concatenated to the filename string.

**- How to verify it**
- Added unit test to assert the changes.
- Tested with no-ports and with the changes works as expected. Attaching the test logs:
```
sitaram@sitaram-ThinkPad-E14:~/IdeaProjects/atsign/noports/packages/dart/sshnoports$ ./bin/at_activate enroll -s ABC123  -p sshnp   -d orac_subkey-1  -n "orac.sshnp:rw,orac.sshrvd:rw" -a @sitaram -r vip.ve.atsign.zone --keys ~/.atsign/keys/orac.sshnp
Submitting enrollment request
Enrollment ID: a5651010-fc9e-4643-9bb5-01540c074a39
Waiting for approval; will check every 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  approved.
Creating atKeys file
[Success] Your .atKeys file saved at /home/sitaram/.atsign/keys/orac.sshnp.atKeys
```

**- Description for the changelog**
- `.atKeys` filename was trimmed when filename has period('.') in it
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
