### PR TITLE
fix: Add unrevoke operation to enroll verb

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 4.0.12
-
 - feat: Add "unrevoke" operation to the enroll verb to restore revoked APKAM keys
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,7 +1,9 @@
+## 4.0.12
+
+- feat: Add "unrevoke" operation to the enroll verb to restore revoked APKAM keys
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text
 - fix: remove deprecated annotation from Metadata.pubKeyCS
-
 ## 4.0.10
 - fix: Add a "force" variable to enroll_verb_builder to propagate enroll:revoke:force value
 - fix: Deprecate apkam in PkamAuthMode enum

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.12
+## 4.1.0
 - feat: Add "unrevoke" operation to the enroll verb to restore revoked APKAM keys
 ## 4.0.11
 - chore: deprecate MessageTypeEnum.text

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -21,7 +21,16 @@ enum MessageTypeEnum {
 String getMessageType(MessageTypeEnum? messageTypeEnum) =>
     '$messageTypeEnum'.split('.').last;
 
-enum EnrollOperationEnum { request, approve, deny, revoke, list, update, fetch }
+enum EnrollOperationEnum {
+  request,
+  approve,
+  deny,
+  revoke,
+  list,
+  update,
+  fetch,
+  unrevoke
+}
 
 String getEnrollOperation(EnrollOperationEnum? enrollOperationEnum) =>
     '$enrollOperationEnum'.split('.').last;

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -128,7 +128,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|update|list|fetch)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|update|list|fetch|unrevoke)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.12
+version: 4.1.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.0.11
+version: 4.0.12
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 
@@ -16,5 +16,5 @@ dev_dependencies:
   build_runner: ^2.3.3
   json_serializable: ^6.6.0
   lints: ^2.0.0
-  test: ^1.21.4
+  test: ^1.25.8
   test_process: ^2.0.2

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -84,6 +84,16 @@ void main() {
       expect(enrollmentParams['operation'], 'fetch');
       expect(enrollmentParams['enrollParams'], '{"enrollmentId":"123"}');
     });
+
+    test('A test to verify enroll unrevoke params', () {
+      String command = 'enroll:unrevoke:{"enrollmentId":"123"}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
+
+      Map<dynamic, dynamic> enrollmentParams =
+          getVerbParams(VerbSyntax.enroll, command);
+      expect(enrollmentParams['operation'], 'unrevoke');
+      expect(enrollmentParams['enrollParams'], '{"enrollmentId":"123"}');
+    });
   });
 
   group('A group of tests to verify toJson and fromJson in EnrollParams', () {

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -90,5 +90,13 @@ void main() {
 
       expect(command, 'enroll:fetch:{"enrollmentId":"123"}\n');
     });
+
+    test('A test to validate the enroll unrevoke command', () {
+      EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.unrevoke
+        ..enrollmentId = '123';
+      expect(enrollVerbBuilder.buildCommand(),
+          'enroll:unrevoke:{"enrollmentId":"123"}\n');
+    });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add unrevoke operation to the "enroll" verb syntax and "EnrollOperationEnum" to bring back the the revoked apkam keys.

**- How I did it**
- Added unrevoke to the enroll verb regex.
- Added unrevoke to the EnrollOperationEnum

**- How to verify it**
- Added unit tests in at_commons tests to verify the changes

**- Description for the changelog**
- fix: Add unrevoke operation to enroll verb
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
