### PR TITLE
feat: add isEncrypted if set to false or true in notify command

### DIFF
--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,4 +1,6 @@
+import 'package:at_commons/src/keystore/at_key.dart';
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
+import 'package:at_commons/src/utils/string_utils.dart';
 import 'package:uuid/uuid.dart';
 
 import '../at_constants.dart';
@@ -60,7 +62,7 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
     }
 
     // Add in all of the metadata parameters in atProtocol command format
-    sb.write(atKey.metadata.toAtProtocolFragment());
+    sb.write(_toAtProtocolFragment(atKey.metadata));
 
     if (atKey.sharedWith != null) {
       sb.write(':${VerbUtil.formatAtSign(atKey.sharedWith)}');
@@ -80,6 +82,75 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
 
     sb.write('\n');
 
+    return sb.toString();
+  }
+
+  // temporary method till isEncrypted flag changes are done for update verb.
+  // TODO Remove this and use at_key.metadata.toProtocolFragment
+  String _toAtProtocolFragment(Metadata metadata) {
+    StringBuffer sb = StringBuffer();
+
+    // NB The order of the verb parameters is important - it MUST match the order
+    // in the regular expressions [VerbSyntax.update] and [VerbSyntax.update_meta]
+    if (metadata.ttl != null) {
+      sb.write(':ttl:${metadata.ttl}');
+    }
+    if (metadata.ttb != null) {
+      sb.write(':ttb:${metadata.ttb}');
+    }
+    if (metadata.ttr != null) {
+      sb.write(':ttr:${metadata.ttr}');
+    }
+    if (metadata.ccd != null) {
+      sb.write(':ccd:${metadata.ccd}');
+    }
+    if (metadata.dataSignature.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.publicDataSignature}:${metadata.dataSignature}');
+    }
+    if (metadata.sharedKeyStatus.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.sharedKeyStatus}:${metadata.sharedKeyStatus}');
+    }
+    if (metadata.isBinary) {
+      sb.write(':isBinary:${metadata.isBinary}');
+    }
+
+    sb.write(':isEncrypted:${metadata.isEncrypted}');
+
+    if (metadata.sharedKeyEnc.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.sharedKeyEncrypted}:${metadata.sharedKeyEnc}');
+    }
+    // ignore: deprecated_member_use_from_same_package
+    if (metadata.pubKeyCS.isNotNullOrEmpty) {
+      // ignore: deprecated_member_use_from_same_package
+      sb.write(
+          ':${AtConstants.sharedWithPublicKeyCheckSum}:${metadata.pubKeyCS}');
+    }
+    if (metadata.pubKeyHash != null) {
+      sb.write(
+          ':${AtConstants.sharedWithPublicKeyHashValue}:${metadata.pubKeyHash!.hash}');
+      sb.write(
+          ':${AtConstants.sharedWithPublicKeyHashAlgo}:${metadata.pubKeyHash!.publicKeyHashingAlgo.name}');
+    }
+    if (metadata.encoding.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.encoding}:${metadata.encoding}');
+    }
+    if (metadata.encKeyName.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.encryptingKeyName}:${metadata.encKeyName}');
+    }
+    if (metadata.encAlgo.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.encryptingAlgo}:${metadata.encAlgo}');
+    }
+    if (metadata.ivNonce.isNotNullOrEmpty) {
+      sb.write(':${AtConstants.ivOrNonce}:${metadata.ivNonce}');
+    }
+    if (metadata.skeEncKeyName.isNotNullOrEmpty) {
+      sb.write(
+          ':${AtConstants.sharedKeyEncryptedEncryptingKeyName}:${metadata.skeEncKeyName}');
+    }
+    if (metadata.skeEncAlgo.isNotNullOrEmpty) {
+      sb.write(
+          ':${AtConstants.sharedKeyEncryptedEncryptingAlgo}:${metadata.skeEncAlgo}');
+    }
     return sb.toString();
   }
 

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -16,9 +16,9 @@ void main() {
         ..ttln = 100;
       var command = notifyVerbBuilder.buildCommand();
       expect(command,
-          'notify:id:123:notifier:SYSTEM:ttln:100:public:email@alice:alice@gmail.com\n');
+          'notify:id:123:notifier:SYSTEM:ttln:100:isEncrypted:false:public:email@alice:alice@gmail.com\n');
       var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
-      expect(params.length, 7);
+      expect(params.length, 8);
       expect(params[AtConstants.id], '123');
       expect(params[AtConstants.value], 'alice@gmail.com');
       expect(params[AtConstants.publicScopeParam], 'public');
@@ -38,9 +38,9 @@ void main() {
         ..atKey.metadata.ttl = 1000;
       var command = notifyVerbBuilder.buildCommand();
       expect(command,
-          'notify:id:123:notifier:SYSTEM:ttl:1000:public:email@alice:alice@gmail.com\n');
+          'notify:id:123:notifier:SYSTEM:ttl:1000:isEncrypted:false:public:email@alice:alice@gmail.com\n');
       var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
-      expect(params.length, 7);
+      expect(params.length, 8);
       expect(params[AtConstants.id], '123');
       expect(params[AtConstants.value], 'alice@gmail.com');
       expect(params[AtConstants.publicScopeParam], 'public');
@@ -60,12 +60,13 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         ..atKey.metadata.pubKeyCS = '123'
         ..atKey.metadata.sharedKeyEnc = 'abc'
+        ..atKey.metadata.isEncrypted = true
         ..ttln = 100;
       var command = notifyVerbBuilder.buildCommand();
       expect(command,
-          'notify:id:123:notifier:SYSTEM:ttln:100:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
+          'notify:id:123:notifier:SYSTEM:ttln:100:isEncrypted:true:sharedKeyEnc:abc:pubKeyCS:123:@bob:email@alice:alice@atsign.com\n');
       var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
-      expect(params.length, 9);
+      expect(params.length, 10);
       expect(params[AtConstants.id], '123');
       expect(params[AtConstants.value], 'alice@atsign.com');
       expect(params[AtConstants.atKey], 'email');
@@ -118,17 +119,18 @@ void main() {
         ..atKey.metadata.encAlgo = 'ea'
         ..atKey.metadata.ivNonce = 'ivn'
         ..atKey.metadata.skeEncKeyName = 'ske_ekn'
-        ..atKey.metadata.skeEncAlgo = 'ske_ea';
+        ..atKey.metadata.skeEncAlgo = 'ske_ea'
+        ..atKey.metadata.isEncrypted = true;
       var command = notifyVerbBuilder.buildCommand();
       expect(
           command,
-          'notify:id:123:notifier:SYSTEM'
+          'notify:id:123:notifier:SYSTEM:isEncrypted:true'
           ':sharedKeyEnc:abc:pubKeyCS:123'
           ':encKeyName:ekn:encAlgo:ea:ivNonce:ivn'
           ':skeEncKeyName:ske_ekn:skeEncAlgo:ske_ea'
           ':@bob:email@alice:alice@atsign.com\n');
       var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
-      expect(params.length, 13);
+      expect(params.length, 14);
       expect(params[AtConstants.publicScopeParam], null);
       expect(params[AtConstants.id], '123');
       expect(params[AtConstants.value], 'alice@atsign.com');
@@ -178,7 +180,7 @@ void main() {
         var notifyCommand = verbHandler.buildCommand();
         var verbParams = getVerbParams(VerbSyntax.notify, notifyCommand.trim());
         expect(verbParams[AtConstants.id] != null, true);
-        expect(verbParams[AtConstants.isEncrypted], null);
+        expect(verbParams[AtConstants.isEncrypted], 'false');
       });
       test('Test to verify custom set notification id to verb builder', () {
         var verbHandler = NotifyVerbBuilder()

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -523,4 +523,79 @@ void main() {
       });
     });
   });
+  group('A group of tests to validate isEncrypted flag in update verb builder',
+      () {
+    test('for public key isEncrypted is false', () {
+      var updateBuilder = UpdateVerbBuilder()
+        ..value = 'alice@gmail.com'
+        ..atKey.metadata.isPublic = true
+        ..atKey.metadata.ttl = 5000
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice';
+      var updateCommand = updateBuilder.buildCommand();
+      expect(updateCommand,
+          'update:ttl:5000:public:email@alice alice@gmail.com\n');
+      var updateVerbParams =
+          getVerbParams(VerbSyntax.update, updateCommand.trim());
+      print(updateVerbParams);
+      // existing behaviour. TODO change to false after changes for update verb isEncrypted flag
+      expect(updateVerbParams['isEncrypted'], null);
+    });
+    test('for shared key - isEncrypted is true if set in metadata', () {
+      var updateBuilder = UpdateVerbBuilder()
+        ..value = 'sampleEncryptedValue'
+        ..atKey.metadata.ttl = 5000
+        ..atKey.metadata.isEncrypted = true
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob';
+      var updateCommand = updateBuilder.buildCommand();
+      print(updateCommand);
+      expect(updateCommand,
+          'update:ttl:5000:isEncrypted:true:@bob:email@alice sampleEncryptedValue\n');
+      var updateVerbParams =
+          getVerbParams(VerbSyntax.update, updateCommand.trim());
+      print(updateVerbParams);
+      expect(updateVerbParams['isEncrypted'], 'true');
+    });
+    test('for shared key - isEncrypted is false if NOT set in metadata', () {
+      var updateBuilder = UpdateVerbBuilder()
+        ..value = 'sampleEncryptedValue'
+        ..atKey.metadata.ttl = 5000
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob';
+      var updateCommand = updateBuilder.buildCommand();
+      print(updateCommand);
+      // existing behaviour. TODO Should contain isEncrypted:false after changes for update verb isEncrypted flag
+      expect(updateCommand,
+          'update:ttl:5000:@bob:email@alice sampleEncryptedValue\n');
+      var updateVerbParams =
+          getVerbParams(VerbSyntax.update, updateCommand.trim());
+      print(updateVerbParams);
+      // existing behaviour. TODO Should be false after changes for update verb isEncrypted flag
+      expect(updateVerbParams['isEncrypted'], null);
+    });
+
+    test('for shared key - isEncrypted is false if set to false in metadata',
+        () {
+      var updateBuilder = UpdateVerbBuilder()
+        ..value = 'sampleEncryptedValue'
+        ..atKey.metadata.ttl = 5000
+        ..atKey.metadata.isEncrypted = false
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob';
+      var updateCommand = updateBuilder.buildCommand();
+      print(updateCommand);
+      // existing behaviour. TODO Should contain isEncrypted:false after changes for update verb isEncrypted flag
+      expect(updateCommand,
+          'update:ttl:5000:@bob:email@alice sampleEncryptedValue\n');
+      var updateVerbParams =
+          getVerbParams(VerbSyntax.update, updateCommand.trim());
+      print(updateVerbParams);
+      // existing behaviour. TODO Should be false after changes for update verb isEncrypted flag
+      expect(updateVerbParams['isEncrypted'], null);
+    });
+  });
 }


### PR DESCRIPTION
Fixes  https://github.com/atsign-foundation/at_libraries/issues/650
**- What I did**
- Set isEncrypted flag in notify command whether it is true or false
**- How I did it**
- Temporarily introduce a private method _toAtProtocolFragment(duplicate of AtKey-->Metadata --> toAtProtocolFragment). Set isEncrypted whether it is true or false. Remove this private method and reuse AtKey method once update verb isEncrypted changes are done.
**- How to verify it**
- tests in dependent repos should pass

https://github.com/atsign-foundation/at_libraries/pull/646
https://github.com/atsign-foundation/at_server/pull/2087
https://github.com/atsign-foundation/at_client_sdk/pull/1393
https://github.com/atsign-foundation/at_libraries/pull/647
https://github.com/atsign-foundation/noports/pull/1344