### PR TITLE
feat: add delete option to enroll verb

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.1.1
+- feat: Add "delete" operation to the enroll verb to allow deletion of denied enrollments
 ## 4.1.0
 - feat: Add "unrevoke" operation to the enroll verb to restore revoked APKAM keys
 ## 4.0.11

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -29,7 +29,8 @@ enum EnrollOperationEnum {
   list,
   update,
   fetch,
-  unrevoke
+  unrevoke,
+  delete
 }
 
 String getEnrollOperation(EnrollOperationEnum? enrollOperationEnum) =>

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -27,7 +27,6 @@ enum EnrollOperationEnum {
   deny,
   revoke,
   list,
-  update,
   fetch,
   unrevoke,
   delete

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -128,7 +128,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|update|list|fetch|unrevoke)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -128,7 +128,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.1.0
+version: 4.1.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -98,5 +98,13 @@ void main() {
       expect(enrollVerbBuilder.buildCommand(),
           'enroll:unrevoke:{"enrollmentId":"123"}\n');
     });
+
+    test('A test to validate enroll delete command', () {
+      EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.delete
+        ..enrollmentId = '4785';
+      expect(enrollVerbBuilder.buildCommand(),
+          'enroll:delete:{"enrollmentId":"4785"}\n');
+    });
   });
 }

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -312,6 +312,15 @@ void main() {
               e is InvalidSyntaxException &&
               e.message == 'command does not match the regex')));
     });
+
+    test('A test to validate enroll delete command', () {
+      String command = 'enroll:delete:{"enrollmentId":"4567"}\n';
+      var enrollVerbParams =
+          VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim());
+      expect(enrollVerbParams!['operation'], 'delete');
+      var enrollmentInfo = jsonDecode(enrollVerbParams['enrollParams']!);
+      expect(enrollmentInfo['enrollmentId'], '4567');
+    });
   });
 
   group('A group of tests related to otp verb', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- introduce option 'delete' in enrollVerbBuilder and enroll verb regex
- remove update operation from EnrollVerb regex and EnrollOperationEnum 

**- How to verify it**
- unit tests present to validate the changes

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: add delete option to enroll verb