### PR TITLE
feat: at_commons changes for setting isEncrypted for both true and false

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 5.0.0
-- [Breaking Change]feat: Add isEncrypted flag to update verb metadata for both true and false
+- [Breaking Change]feat: Emit the isEncrypted value in the metadata if it is false
 - fix: update pkam regex to accept sha512 as hashing algo
 ## 4.1.2
 - feat: Add "expiry" enroll params to support apkam keys to auto expiry after specified time duration

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 4.1.3
-- feat: Add isEncrypted flag to update verb metadata for both true and false
+## 5.0.0
+- [Breaking Change]feat: Add isEncrypted flag to update verb metadata for both true and false
 - fix: update pkam regex to accept sha512 as hashing algo
 ## 4.1.2
 - feat: Add "expiry" enroll params to support apkam keys to auto expiry after specified time duration

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 4.1.3
+- feat: Add isEncrypted flag to update verb metadata for both true and false
 ## 4.1.2
 - feat: Add "expiry" enroll params to support apkam keys to auto expiry after specified time duration
 ## 4.1.1

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -559,9 +559,9 @@ class Metadata {
     if (isBinary) {
       sb.write(':isBinary:$isBinary');
     }
-    if (isEncrypted) {
-      sb.write(':isEncrypted:$isEncrypted');
-    }
+
+    sb.write(':isEncrypted:$isEncrypted');
+
     if (sharedKeyEnc.isNotNullOrEmpty) {
       sb.write(':${AtConstants.sharedKeyEncrypted}:$sharedKeyEnc');
     }

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,5 +1,3 @@
-import 'package:at_commons/src/keystore/at_key.dart';
-import 'package:at_commons/src/utils/string_utils.dart';
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
 import 'package:uuid/uuid.dart';
 

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -61,7 +61,7 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
     }
 
     // Add in all of the metadata parameters in atProtocol command format
-    sb.write(_toAtProtocolFragment(atKey.metadata));
+    sb.write(atKey.metadata.toAtProtocolFragment());
 
     if (atKey.sharedWith != null) {
       sb.write(':${VerbUtil.formatAtSign(atKey.sharedWith)}');
@@ -81,75 +81,6 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
 
     sb.write('\n');
 
-    return sb.toString();
-  }
-
-  // temporary method till isEncrypted flag changes are done for update verb.
-  // TODO Remove this and use at_key.metadata.toProtocolFragment
-  String _toAtProtocolFragment(Metadata metadata) {
-    StringBuffer sb = StringBuffer();
-
-    // NB The order of the verb parameters is important - it MUST match the order
-    // in the regular expressions [VerbSyntax.update] and [VerbSyntax.update_meta]
-    if (metadata.ttl != null) {
-      sb.write(':ttl:${metadata.ttl}');
-    }
-    if (metadata.ttb != null) {
-      sb.write(':ttb:${metadata.ttb}');
-    }
-    if (metadata.ttr != null) {
-      sb.write(':ttr:${metadata.ttr}');
-    }
-    if (metadata.ccd != null) {
-      sb.write(':ccd:${metadata.ccd}');
-    }
-    if (metadata.dataSignature.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.publicDataSignature}:${metadata.dataSignature}');
-    }
-    if (metadata.sharedKeyStatus.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.sharedKeyStatus}:${metadata.sharedKeyStatus}');
-    }
-    if (metadata.isBinary) {
-      sb.write(':isBinary:${metadata.isBinary}');
-    }
-
-    sb.write(':isEncrypted:${metadata.isEncrypted}');
-
-    if (metadata.sharedKeyEnc.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.sharedKeyEncrypted}:${metadata.sharedKeyEnc}');
-    }
-    // ignore: deprecated_member_use_from_same_package
-    if (metadata.pubKeyCS.isNotNullOrEmpty) {
-      // ignore: deprecated_member_use_from_same_package
-      sb.write(
-          ':${AtConstants.sharedWithPublicKeyCheckSum}:${metadata.pubKeyCS}');
-    }
-    if (metadata.pubKeyHash != null) {
-      sb.write(
-          ':${AtConstants.sharedWithPublicKeyHashValue}:${metadata.pubKeyHash!.hash}');
-      sb.write(
-          ':${AtConstants.sharedWithPublicKeyHashAlgo}:${metadata.pubKeyHash!.publicKeyHashingAlgo.name}');
-    }
-    if (metadata.encoding.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.encoding}:${metadata.encoding}');
-    }
-    if (metadata.encKeyName.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.encryptingKeyName}:${metadata.encKeyName}');
-    }
-    if (metadata.encAlgo.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.encryptingAlgo}:${metadata.encAlgo}');
-    }
-    if (metadata.ivNonce.isNotNullOrEmpty) {
-      sb.write(':${AtConstants.ivOrNonce}:${metadata.ivNonce}');
-    }
-    if (metadata.skeEncKeyName.isNotNullOrEmpty) {
-      sb.write(
-          ':${AtConstants.sharedKeyEncryptedEncryptingKeyName}:${metadata.skeEncKeyName}');
-    }
-    if (metadata.skeEncAlgo.isNotNullOrEmpty) {
-      sb.write(
-          ':${AtConstants.sharedKeyEncryptedEncryptingAlgo}:${metadata.skeEncAlgo}');
-    }
     return sb.toString();
   }
 

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.1.3
+version: 5.0.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 4.1.2
+version: 4.1.3
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -13,7 +13,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommand(),
-          'update:public:email@alice alice@gmail.com\n');
+          'update:isEncrypted:false:public:email@alice alice@gmail.com\n');
     });
 
     test('verify private at key command', () {
@@ -22,7 +22,7 @@ void main() {
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommand(),
-          'update:email@alice alice@atsign.com\n');
+          'update:isEncrypted:false:email@alice alice@atsign.com\n');
     });
 
     test(
@@ -47,7 +47,7 @@ void main() {
       var updateCommand = updateBuilder.buildCommand();
       expect(
           updateCommand,
-          'update'
+          'update:isEncrypted:false'
           ':sharedKeyEnc:$ske'
           ':pubKeyCS:$pubKeyCS'
           ':skeEncKeyName:$skeEncKeyName'
@@ -75,7 +75,7 @@ void main() {
         ..atKey.sharedBy = '@alice'
         ..atKey.isLocal = true;
       expect(updateBuilder.buildCommand(),
-          'update:local:email@alice alice@atsign.com\n');
+          'update:isEncrypted:false:local:email@alice alice@atsign.com\n');
     });
   });
 
@@ -87,7 +87,7 @@ void main() {
         ..atKey.key = 'phone'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommandForMeta(),
-          'update:meta:phone@alice:isBinary:true\n');
+          'update:meta:phone@alice:isBinary:true:isEncrypted:false\n');
     });
 
     test('verify ttl metadata', () {
@@ -96,7 +96,7 @@ void main() {
         ..atKey.key = 'phone'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommandForMeta(),
-          'update:meta:phone@alice:ttl:60000\n');
+          'update:meta:phone@alice:ttl:60000:isEncrypted:false\n');
     });
 
     test('verify ttr metadata', () {
@@ -105,7 +105,7 @@ void main() {
         ..atKey.key = 'phone'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommandForMeta(),
-          'update:meta:phone@alice:ttr:50000\n');
+          'update:meta:phone@alice:ttr:50000:isEncrypted:false\n');
     });
 
     test('verify ttb metadata', () {
@@ -114,7 +114,7 @@ void main() {
         ..atKey.key = 'phone'
         ..atKey.sharedBy = '@alice';
       expect(updateBuilder.buildCommandForMeta(),
-          'update:meta:phone@alice:ttb:80000\n');
+          'update:meta:phone@alice:ttb:80000:isEncrypted:false\n');
     });
 
     test(
@@ -351,7 +351,8 @@ void main() {
         ..atKey.sharedBy = '@bob'
         ..value = '+445 334 3423';
       var command = updateVerbBuilder.buildCommand();
-      expect(command, 'update:local:phone@bob +445 334 3423\n');
+      expect(
+          command, 'update:isEncrypted:false:local:phone@bob +445 334 3423\n');
       expect(() => updateVerbBuilder.atKey.sharedWith = '@alice',
           throwsA(predicate((dynamic e) => e is InvalidAtKeyException)));
     });
@@ -534,12 +535,11 @@ void main() {
         ..atKey.sharedBy = '@alice';
       var updateCommand = updateBuilder.buildCommand();
       expect(updateCommand,
-          'update:ttl:5000:public:email@alice alice@gmail.com\n');
+          'update:ttl:5000:isEncrypted:false:public:email@alice alice@gmail.com\n');
       var updateVerbParams =
           getVerbParams(VerbSyntax.update, updateCommand.trim());
       print(updateVerbParams);
-      // existing behaviour. TODO change to false after changes for update verb isEncrypted flag
-      expect(updateVerbParams['isEncrypted'], null);
+      expect(updateVerbParams['isEncrypted'], 'false');
     });
     test('for shared key - isEncrypted is true if set in metadata', () {
       var updateBuilder = UpdateVerbBuilder()
@@ -567,14 +567,12 @@ void main() {
         ..atKey.sharedWith = '@bob';
       var updateCommand = updateBuilder.buildCommand();
       print(updateCommand);
-      // existing behaviour. TODO Should contain isEncrypted:false after changes for update verb isEncrypted flag
       expect(updateCommand,
-          'update:ttl:5000:@bob:email@alice sampleEncryptedValue\n');
+          'update:ttl:5000:isEncrypted:false:@bob:email@alice sampleEncryptedValue\n');
       var updateVerbParams =
           getVerbParams(VerbSyntax.update, updateCommand.trim());
       print(updateVerbParams);
-      // existing behaviour. TODO Should be false after changes for update verb isEncrypted flag
-      expect(updateVerbParams['isEncrypted'], null);
+      expect(updateVerbParams['isEncrypted'], 'false');
     });
 
     test('for shared key - isEncrypted is false if set to false in metadata',
@@ -588,14 +586,12 @@ void main() {
         ..atKey.sharedWith = '@bob';
       var updateCommand = updateBuilder.buildCommand();
       print(updateCommand);
-      // existing behaviour. TODO Should contain isEncrypted:false after changes for update verb isEncrypted flag
       expect(updateCommand,
-          'update:ttl:5000:@bob:email@alice sampleEncryptedValue\n');
+          'update:ttl:5000:isEncrypted:false:@bob:email@alice sampleEncryptedValue\n');
       var updateVerbParams =
           getVerbParams(VerbSyntax.update, updateCommand.trim());
       print(updateVerbParams);
-      // existing behaviour. TODO Should be false after changes for update verb isEncrypted flag
-      expect(updateVerbParams['isEncrypted'], null);
+      expect(updateVerbParams['isEncrypted'], 'false');
     });
   });
 }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -18,6 +18,10 @@ dependencies:
   meta: ^1.8.0
   at_chops: ^2.0.0
 
+dependency_overrides:
+  at_commons:
+    path: ../at_commons
+
 dev_dependencies:
   mocktail: ^1.0.1
   lints: ^1.0.1

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -18,10 +18,6 @@ dependencies:
   meta: ^1.8.0
   at_chops: ^2.0.0
 
-dependency_overrides:
-  at_commons:
-    path: ../at_commons
-
 dev_dependencies:
   mocktail: ^1.0.1
   lints: ^1.0.1


### PR DESCRIPTION
**- What I did**
- changes for setting isEncrypted in metadata for update verb for both true and false. Previously isEncrypted is set only when true
**- How I did it**
- modified atKey.metadata.toProtocolFragment
- removed adhoc code for notify
- modified test assertions
**- How to verify it**
- tests should pass

