### PR TITLE
feat: Introduce option to delete enrollment requests that are denied/revoked

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## #NEXT
+- feat: add `delete` command to the activate CLI
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -736,22 +736,12 @@ Future<void> revoke(ArgResults ar, AtClient atClient) async {
 Future<void> deleteDeniedEnrollment(ArgResults ar, AtClient atClient) async {
   AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
   String eId = ar[AuthCliArgs.argNameEnrollmentId];
-  String atsign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
-
-  Map? er = await _fetch(eId, atLookup);
-  if (er == null) {
-    stderr.writeln('Could not fetch enrollment: $eId');
-    return;
-  }
-  if (er['status'] != null && er['status'] != EnrollmentStatus.denied) {
-    stderr.writeln('Cannot delete a ${er['status']} enrollment');
-    // exit(1);
-  }
-  AtKey enrollmentKey = AtKey.fromString('$eId.new.__manage$atsign');
-  DeleteVerbBuilder deleteVerbBuilder = DeleteVerbBuilder()
-    ..atKey = enrollmentKey;
+  EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
+    ..enrollmentId = eId
+    ..operation = EnrollOperationEnum.delete;
   stdout.writeln('Sending delete request');
-  var response = await atLookup.executeVerb(deleteVerbBuilder);
+  String? response = await atLookup.executeVerb(enrollVerbBuilder);
+  response = response?.replaceFirst('data:', '');
   stdout.writeln('Server response: $response');
 }
 

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -174,7 +174,7 @@ Future<int> _main(List<String> arguments) async {
         await enroll(commandArgResults);
 
       case AuthCliCommand.delete:
-        await deleteDeniedEnrollment(
+        await deleteEnrollment(
             commandArgResults, await createAtClient(commandArgResults));
     }
   } on ArgumentError catch (e) {
@@ -515,7 +515,7 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
           await revoke(commandArgResults, atClient);
 
         case AuthCliCommand.delete:
-          await deleteDeniedEnrollment(commandArgResults, atClient);
+          await deleteEnrollment(commandArgResults, atClient);
       }
     } on ArgumentError catch (e) {
       stderr.writeln(
@@ -749,7 +749,7 @@ Future<void> revoke(ArgResults ar, AtClient atClient) async {
   }
 }
 
-Future<void> deleteDeniedEnrollment(ArgResults ar, AtClient atClient) async {
+Future<void> deleteEnrollment(ArgResults ar, AtClient atClient) async {
   AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
   String eId = ar[AuthCliArgs.argNameEnrollmentId];
   EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -46,6 +46,10 @@ enum AuthCliCommand {
   approve(usage: 'Approve a pending enrollment request'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
+  delete(
+      usage:
+          'Delete a denied enrollment. Requires an enrollmentId to be provided'
+          '\nNOTE: Can ONLY delete denied enrollments'),
   enroll(
       usage: 'Enroll is used when a program needs to authenticate and'
           ' "atKeys" are not available, and "onboard" has already been run'
@@ -168,6 +172,9 @@ class AuthCliArgs {
 
       case AuthCliCommand.revoke:
         return createRevokeCommandParser();
+
+      case AuthCliCommand.delete:
+        return createDeleteCommandParser();
     }
   }
 
@@ -404,6 +411,15 @@ class AuthCliArgs {
     _addEnrollmentIdOption(p);
     _addAppNameRegexOption(p);
     _addDeviceNameRegexOption(p);
+    return p;
+  }
+
+  /// auth delete denied enrollment: requires enrollmentId and atKeysFile path
+  /// requires the enrollment to be denied
+  @visibleForTesting
+  ArgParser createDeleteCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true);
+    _addEnrollmentIdOption(p, mandatory: true);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -47,9 +47,8 @@ enum AuthCliCommand {
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
   delete(
-      usage:
-          'Delete a denied enrollment. Requires an enrollmentId to be provided'
-          '\nNOTE: Can ONLY delete denied enrollments'),
+      usage: 'Deletes an enrollment. Requires an enrollmentId to be provided'
+          '\nNOTE: Can ONLY delete denied and revoked enrollments'),
   enroll(
       usage: 'Enroll is used when a program needs to authenticate and'
           ' "atKeys" are not available, and "onboard" has already been run'


### PR DESCRIPTION
Closes https://github.com/atsign-foundation/at_libraries/issues/628

**- What I did**
- Introduce an option to allow deletion of enrollment requests (for denied/revoked enrollments only)

**- How I did it**
- Introduced 'delete' as an option in the at_activate argParser
- Introduced a delete-command parser which considers enrollmentId mandatory
- Introduce a new method deleteDeniedEnrollment which sends a delete request to the server and parses the server response.

**- How to verify it**
- Manual testing has been done. 
- To test the changes, send an enrollment request then deny/approve+revoke it. Then run at_activate with the delete option which requires the atsign and enrollmentId. The enrollment should be deleted.
