### PR TITLE
fix: Add unrevoke to the at_onboarding_cli

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## #NEXT
+- feat: add `delete` command to the activate CLI
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## #NEXT
+- feat: add `unrevoke` command to the activate CLI
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -736,22 +736,12 @@ Future<void> revoke(ArgResults ar, AtClient atClient) async {
 Future<void> deleteDeniedEnrollment(ArgResults ar, AtClient atClient) async {
   AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
   String eId = ar[AuthCliArgs.argNameEnrollmentId];
-  String atsign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
-
-  Map? er = await _fetch(eId, atLookup);
-  if (er == null) {
-    stderr.writeln('Could not fetch enrollment: $eId');
-    return;
-  }
-  if (er['status'] != null && er['status'] != EnrollmentStatus.denied) {
-    stderr.writeln('Cannot delete a ${er['status']} enrollment');
-    // exit(1);
-  }
-  AtKey enrollmentKey = AtKey.fromString('$eId.new.__manage$atsign');
-  DeleteVerbBuilder deleteVerbBuilder = DeleteVerbBuilder()
-    ..atKey = enrollmentKey;
+  EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
+    ..enrollmentId = eId
+    ..operation = EnrollOperationEnum.delete;
   stdout.writeln('Sending delete request');
-  var response = await atLookup.executeVerb(deleteVerbBuilder);
+  String? response = await atLookup.executeVerb(enrollVerbBuilder);
+  response = response?.replaceFirst('data:', '');
   stdout.writeln('Server response: $response');
 }
 

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -342,7 +342,7 @@ String parseServerResponse(String? response) {
   if (response != null && response.startsWith('data:')) {
     return response.replaceFirst('data:', '');
   } else {
-    throw('Unexpected server response: $response');
+    throw ('Unexpected server response: $response');
   }
 }
 

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -195,6 +195,7 @@ Future<int> wrappedMain(List<String> arguments) async {
         // Write keys to @atSign_keys.atKeys IFF it doesn't already exist; if
         // it does exist, then write to @atSign_appName_deviceName_keys.atKeys
         await enroll(commandArgResults);
+
       case AuthCliCommand.unrevoke:
         await unrevoke(
             commandArgResults, await createAtClient(commandArgResults));

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -174,7 +174,7 @@ Future<int> _main(List<String> arguments) async {
         await enroll(commandArgResults);
 
       case AuthCliCommand.delete:
-        await deleteDeniedEnrollment(
+        await deleteEnrollment(
             commandArgResults, await createAtClient(commandArgResults));
     }
   } on ArgumentError catch (e) {
@@ -515,7 +515,7 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
           await revoke(commandArgResults, atClient);
 
         case AuthCliCommand.delete:
-          await deleteDeniedEnrollment(commandArgResults, atClient);
+          await deleteEnrollment(commandArgResults, atClient);
       }
     } on ArgumentError catch (e) {
       stderr.writeln(
@@ -749,7 +749,7 @@ Future<void> revoke(ArgResults ar, AtClient atClient) async {
   }
 }
 
-Future<void> deleteDeniedEnrollment(ArgResults ar, AtClient atClient) async {
+Future<void> deleteEnrollment(ArgResults ar, AtClient atClient) async {
   AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
   String eId = ar[AuthCliArgs.argNameEnrollmentId];
   EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -46,6 +46,10 @@ enum AuthCliCommand {
   approve(usage: 'Approve a pending enrollment request'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
+  delete(
+      usage:
+          'Delete a denied enrollment. Requires an enrollmentId to be provided'
+          '\nNOTE: Can ONLY delete denied enrollments'),
   enroll(
       usage: 'Enroll is used when a program needs to authenticate and'
           ' "atKeys" are not available, and "onboard" has already been run'
@@ -168,6 +172,9 @@ class AuthCliArgs {
 
       case AuthCliCommand.revoke:
         return createRevokeCommandParser();
+
+      case AuthCliCommand.delete:
+        return createDeleteCommandParser();
     }
   }
 
@@ -404,6 +411,15 @@ class AuthCliArgs {
     _addEnrollmentIdOption(p);
     _addAppNameRegexOption(p);
     _addDeviceNameRegexOption(p);
+    return p;
+  }
+
+  /// auth delete denied enrollment: requires enrollmentId and atKeysFile path
+  /// requires the enrollment to be denied
+  @visibleForTesting
+  ArgParser createDeleteCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true);
+    _addEnrollmentIdOption(p, mandatory: true);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -47,9 +47,8 @@ enum AuthCliCommand {
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
   delete(
-      usage:
-          'Delete a denied enrollment. Requires an enrollmentId to be provided'
-          '\nNOTE: Can ONLY delete denied enrollments'),
+      usage: 'Deletes an enrollment. Requires an enrollmentId to be provided'
+          '\nNOTE: Can ONLY delete denied and revoked enrollments'),
   enroll(
       usage: 'Enroll is used when a program needs to authenticate and'
           ' "atKeys" are not available, and "onboard" has already been run'

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -478,8 +478,8 @@ class AuthCliArgs {
   ArgParser createUnRevokeCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p);
-    _addAppNameRegexOption(p);
-    _addDeviceNameRegexOption(p);
+    _addAppNameRegexOption(p, mandatory: false);
+    _addDeviceNameRegexOption(p, mandatory: false);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -46,6 +46,7 @@ enum AuthCliCommand {
   approve(usage: 'Approve a pending enrollment request'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
+  unrevoke(usage: 'Restores access to the previously revoked enrollment'),
   enroll(
       usage: 'Enroll is used when a program needs to authenticate and'
           ' "atKeys" are not available, and "onboard" has already been run'
@@ -170,6 +171,9 @@ class AuthCliArgs {
 
       case AuthCliCommand.revoke:
         return createRevokeCommandParser();
+
+      case AuthCliCommand.unrevoke:
+        return createUnRevokeCommandParser();
     }
   }
 
@@ -417,6 +421,16 @@ class AuthCliArgs {
   /// auth revoke
   @visibleForTesting
   ArgParser createRevokeCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true);
+    _addEnrollmentIdOption(p);
+    _addAppNameRegexOption(p);
+    _addDeviceNameRegexOption(p);
+    return p;
+  }
+
+  /// Restore the revoked enrollment Id.
+  @visibleForTesting
+  ArgParser createUnRevokeCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p);
     _addAppNameRegexOption(p);

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -44,9 +44,10 @@ enum AuthCliCommand {
   list(usage: 'List enrollment requests'),
   fetch(usage: 'Fetch a specific enrollment request'),
   approve(usage: 'Approve a pending enrollment request'),
-  auto(usage: 'Listen for new enrollment requests which match the parameters'
-      ' supplied, and auto-approve them. Will exit after N (defaults to 1)'
-      ' enrollment requests have been approved.'),
+  auto(
+      usage: 'Listen for new enrollment requests which match the parameters'
+          ' supplied, and auto-approve them. Will exit after N (defaults to 1)'
+          ' enrollment requests have been approved.'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
   unrevoke(usage: 'Restores access to the previously revoked enrollment'),
@@ -431,7 +432,7 @@ class AuthCliArgs {
   @visibleForTesting
   ArgParser createAutoApproveCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
-    _addEnrollmentIdOption(p, hide:true);
+    _addEnrollmentIdOption(p, hide: true);
     _addAppNameRegexOption(p, mandatory: true);
     _addDeviceNameRegexOption(p, mandatory: true);
     p.addOption(

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -44,9 +44,10 @@ enum AuthCliCommand {
   list(usage: 'List enrollment requests'),
   fetch(usage: 'Fetch a specific enrollment request'),
   approve(usage: 'Approve a pending enrollment request'),
-  auto(usage: 'Listen for new enrollment requests which match the parameters'
-      ' supplied, and auto-approve them. Will exit after N (defaults to 1)'
-      ' enrollment requests have been approved.'),
+  auto(
+      usage: 'Listen for new enrollment requests which match the parameters'
+          ' supplied, and auto-approve them. Will exit after N (defaults to 1)'
+          ' enrollment requests have been approved.'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
   unrevoke(usage: 'Restores access to the previously revoked enrollment'),

--- a/packages/at_onboarding_cli/lib/src/util/onboarding_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/onboarding_util.dart
@@ -116,7 +116,7 @@ class OnboardingUtil {
             'To register a new atSign to this email address, please log into the dashboard \'my.atsign.com/login\'.\n'
             'Remove at least 1 atSign from your account and then try again.\n'
             'Alternatively, you can retry this process with a different email address.');
-        exit(1);
+        throw at_client.AtClientException.message(jsonDecoded['message']);
       } else {
         throw at_client.AtClientException.message(
             '${response.statusCode} ${jsonDecoded['message']}');

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.7.0
+version: 1.8.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 void main() {
   String atSign = '@sitaram🛠';
   String apkamKeysFilePath = 'storage/keys/@sitaram-apkam.atKeys';
+  final logger = AtSignLogger('E2E Test');
 
   group('A group of tests to validate enrollment commands', () {
     /// The test verifies the following scenario's
@@ -53,6 +54,8 @@ void main() {
       AtEnrollmentResponse atEnrollmentResponse = await atOnboardingService
           .sendEnrollRequest(
               'wavi', 'local-device', 'ABC123', {'e2etest': 'rw'});
+      logger.info(
+          'Submitted enrollment successfully with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
       expect(atEnrollmentResponse.enrollStatus, EnrollmentStatus.pending);
       expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
 
@@ -68,6 +71,8 @@ void main() {
       ];
       res = await auth_cli.main(args);
       expect(res, 0);
+      logger.info(
+          'Approved enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
 
       // Generate Atkeys file for the enrollment request.
       await atOnboardingService.awaitApproval(atEnrollmentResponse);
@@ -92,6 +97,9 @@ void main() {
         atEnrollmentResponse.enrollmentId
       ];
       res = await auth_cli.main(args);
+      expect(res, 0);
+      logger.info(
+          'Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
 
       // Perform authentication with revoked enrollmentId
       expect(
@@ -110,6 +118,8 @@ void main() {
         atEnrollmentResponse.enrollmentId
       ];
       res = await auth_cli.main(args);
+      logger.info(
+          'Un-Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
       // Perform authentication with the unrevoked enrollment-id.
       authResponse = await atOnboardingService.authenticate(
           enrollmentId: atEnrollmentResponse.enrollmentId);

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_onboarding_cli/src/cli/auth_cli.dart' as auth_cli;
+import 'package:at_utils/at_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  String atSign = '@sitaram🛠';
+  String apkamKeysFilePath = 'storage/keys/@sitaram-apkam.atKeys';
+
+  group('A group of tests to validate enrollment commands', () {
+    /// The test verifies the following scenario's
+    /// 1. Onboards an atSign
+    /// 2. Sets Semi Permanent Passcode
+    /// 3. Submits an enrollment request
+    /// 4. Approves the enrollment request
+    /// 5. Performs authentication with the approved enrollment Id. Authentication should be successful.
+    /// 6. Revokes the enrollment Id.
+    /// 7. Performs authentication again with the revoked enrollment Id. Authentication fails this time.
+    /// 8. Unrevoke the enrollment Id.
+    /// 9. Performs authentication again with the unrevoked enrollment Id. Authentication should be successful.
+    test(
+        'A test to verify end-to-end flow of approve revoke unrevoke of an enrollment',
+        () async {
+      AtOnboardingService atOnboardingService = AtOnboardingServiceImpl(
+          atSign,
+          getOnboardingPreference(atSign,
+              '${Platform.environment['HOME']}/.atsign/keys/${atSign}_key.atKeys')
+            // Fetched cram key from the at_demos repo.
+            ..cramSecret =
+                '15cdce8f92bcf7e742d5b75dc51ec06d798952f8bf7e8ff4c2b6448e5f7c2c12b570fe945f04011455fdc49cacdf9393d9c1ac4609ec71c1a0b0c213578e7ec7');
+
+      bool onboardingStatus = await atOnboardingService.onboard();
+      expect(onboardingStatus, true);
+      // Set SPP
+      List<String> args = [
+        'spp',
+        '-s',
+        'ABC123',
+        '-a',
+        atSign,
+        '-r',
+        'vip.ve.atsign.zone'
+      ];
+      var res = await auth_cli.main(args);
+      // Zero indicates successful completion.
+      expect(res, 0);
+
+      // Submit enrollment request
+      AtEnrollmentResponse atEnrollmentResponse = await atOnboardingService
+          .sendEnrollRequest(
+              'wavi', 'local-device', 'ABC123', {'e2etest': 'rw'});
+      expect(atEnrollmentResponse.enrollStatus, EnrollmentStatus.pending);
+      expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
+
+      // Approve enrollment request
+      args = [
+        'approve',
+        '-a',
+        atSign,
+        '-r',
+        'vip.ve.atsign.zone',
+        '-i',
+        atEnrollmentResponse.enrollmentId
+      ];
+      res = await auth_cli.main(args);
+      expect(res, 0);
+
+      // Generate Atkeys file for the enrollment request.
+      await atOnboardingService.awaitApproval(atEnrollmentResponse);
+      await atOnboardingService.createAtKeysFile(atEnrollmentResponse,
+          atKeysFile: File(apkamKeysFilePath));
+
+      // Authenticate with APKAM keys
+      atOnboardingService = AtOnboardingServiceImpl(
+          atSign, getOnboardingPreference(atSign, apkamKeysFilePath));
+      bool authResponse = await atOnboardingService.authenticate(
+          enrollmentId: atEnrollmentResponse.enrollmentId);
+      expect(authResponse, true);
+
+      // Revoke the enrollment
+      args = [
+        'revoke',
+        '-a',
+        atSign,
+        '-r',
+        'vip.ve.atsign.zone',
+        '-i',
+        atEnrollmentResponse.enrollmentId
+      ];
+      res = await auth_cli.main(args);
+
+      // Perform authentication with revoked enrollmentId
+      expect(
+          () async => await atOnboardingService.authenticate(
+              enrollmentId: atEnrollmentResponse.enrollmentId),
+          throwsA(predicate((dynamic e) => e is AtAuthenticationException)));
+
+      // UnRevoke the enrollment
+      args = [
+        'unrevoke',
+        '-a',
+        atSign,
+        '-r',
+        'vip.ve.atsign.zone',
+        '-i',
+        atEnrollmentResponse.enrollmentId
+      ];
+      res = await auth_cli.main(args);
+      // Perform authentication with the unrevoked enrollment-id.
+      authResponse = await atOnboardingService.authenticate(
+          enrollmentId: atEnrollmentResponse.enrollmentId);
+      expect(authResponse, true);
+    });
+  });
+
+  tearDown(() {
+    File file = File(apkamKeysFilePath);
+    file.deleteSync();
+  });
+}
+
+AtOnboardingPreference getOnboardingPreference(
+    String atSign, String atKeysFilePath) {
+  atSign = AtUtils.fixAtSign(atSign);
+  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+    ..namespace = 'buzz'
+    ..atKeysFilePath = atKeysFilePath
+    ..appName = 'buzz'
+    ..deviceName = 'iphone'
+    ..rootDomain = 'vip.ve.atsign.zone';
+
+  return atOnboardingPreference;
+}

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
@@ -46,7 +46,7 @@ void main() {
         '-r',
         'vip.ve.atsign.zone'
       ];
-      var res = await auth_cli.main(args);
+      var res = await auth_cli.wrappedMain(args);
       // Zero indicates successful completion.
       expect(res, 0);
 
@@ -69,7 +69,7 @@ void main() {
         '-i',
         atEnrollmentResponse.enrollmentId
       ];
-      res = await auth_cli.main(args);
+      res = await auth_cli.wrappedMain(args);
       expect(res, 0);
       logger.info(
           'Approved enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
@@ -96,7 +96,7 @@ void main() {
         '-i',
         atEnrollmentResponse.enrollmentId
       ];
-      res = await auth_cli.main(args);
+      res = await auth_cli.wrappedMain(args);
       expect(res, 0);
       logger.info(
           'Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
@@ -117,7 +117,7 @@ void main() {
         '-i',
         atEnrollmentResponse.enrollmentId
       ];
-      res = await auth_cli.main(args);
+      res = await auth_cli.wrappedMain(args);
       logger.info(
           'Un-Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
       // Perform authentication with the unrevoked enrollment-id.


### PR DESCRIPTION
Closes #627 and #628

This PR includes everything from #670 

**- What I did**
- Add "unrevoke" to auth_cli commands which will restore the revoked enrollmentId.
- Add "delete" to auth_cli commands which will permanently delete enrollment requests (only denied/revoked enrollments may be deleted)
- Made various changes (replacing `exit` with `throw`, etc) to ensure that the tests in enrollment_cli_commands_test.dart behave as they should

**- How I did it**
- Introduced 'delete' as an option in the at_activate argParser
- Introduced a delete-command parser which considers enrollmentId mandatory
- Introduce a new method deleteDeniedEnrollment which sends a delete request to the server and parses the server response.
- Add "unrevoke" command to auth_cli_args list.
- Add "unrevoke" method in auth_cli which will do the necessary work to unrevoke the enrollment Id.

**- How to verify it**
- Added an End-to-End test in "enrollment_cli_commands_test.dart" file which covers unrevoke functionality.
- Manual testing has been done. 
- To test the changes, send an enrollment request then deny/approve+revoke it. Then run at_activate with the delete option which requires the atsign and enrollmentId. The enrollment should be deleted.
