### PR TITLE
fix: Add retry logic in "_waitForPkamAuthSuccess" to retry when secondary is temporarily not reachable

### DIFF
--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -332,8 +332,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       try {
         // _attemptPkamAuth returns boolean value true when authentication is successful.
         // Returns UnAuthenticatedException when authentication fails.
-        pkamAuthSucceeded =
-            await _attemptPkamAuth(atLookUp, enrollmentIdFromServer);
+        pkamAuthSucceeded = await atLookUp.pkamAuthenticate(
+            enrollmentId: enrollmentIdFromServer);
       } on UnAuthenticatedException catch (e) {
         // Error codes AT0401 and AT0026 indicate authentication failure due to unapproved enrollment. Retry until the enrollment is approved.
         // The variable _pkamAuthSucceeded is false, allowing for PKAM authentication retries.
@@ -375,23 +375,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         await Future.delayed(retryInterval); // Delay and retry
       }
     }
-  }
-
-  /// Executes PKAM authentication on the secondary server.
-  ///
-  /// Returns `true` if the authentication is successful.
-  ///
-  /// Returns UnAuthenticated Exception when authentication fails.
-  Future<bool> _attemptPkamAuth(AtLookUp atLookUp, String enrollmentId) async {
-    logger.finer('_attemptPkamAuth: Calling atLookUp.pkamAuthenticate');
-    // atLookUp.pkamAuthenticate returns true when authentication is successful.
-    // when authentication fails, returns UnAuthenticatedException.
-    var pkamResult =
-        await atLookUp.pkamAuthenticate(enrollmentId: enrollmentId);
-    logger.finer(
-        '_attemptPkamAuth: atLookUp.pkamAuthenticate returned $pkamResult');
-
-    return pkamResult;
   }
 
   ///write newly created encryption keypairs into atKeys file

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -237,10 +237,14 @@ void main() {
       var completer = Completer<void>(); // Create a Completer
 
       //4. Subscribe to enrollment notifications; we will deny it when it arrives
+      String enrollmentId = '';
       onboardingService_1.atClient!.notificationService
           .subscribe(regex: '.__manage')
           .listen(expectAsync1((notification) async {
             logger.finer('got enroll notification');
+            final notificationKey = notification.key;
+            enrollmentId = notificationKey.substring(
+                0, notificationKey.indexOf('.new.enrollments'));
             expect(notification.value, isNotNull);
             var notificationValueJson = jsonDecode(notification.value!);
             expect(notificationValueJson['encryptedApkamSymmetricKey'],
@@ -258,7 +262,7 @@ void main() {
       AtOnboardingServiceImpl? onboardingService_2 =
           AtOnboardingServiceImpl(atSign, preference_1);
 
-      Future<dynamic> expectLaterFuture = expectLater(
+      expectLater(
           onboardingService_2.enroll(
             'buzz',
             'iphone',
@@ -267,8 +271,8 @@ void main() {
             retryInterval: Duration(seconds: 5),
           ),
           throwsA(predicate((dynamic e) =>
-              e is AtEnrollmentException && e.message == 'enrollment denied')));
-      print(await expectLaterFuture);
+              e is AtEnrollmentException &&
+              e.message == 'The enrollment: $enrollmentId is denied')));
       await completer.future;
 
       await onboardingService_1.close();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- After submitting an enrollment request, retry for couple of times when secondary server is temporarily not reachable.

**- How I did it**
- Introduce a new variable "_maxActivationRetries" which is a final variable which represents the maximum retries
- In "_waitForPkamAuthSuccess" method, catch if an exception is thrown and increment the "retryCounter" until it "maxActivationRetry" is reached. After that re-throw the exception.
- In the `_attemptPkamAuth` method, if enrollment is denied, it returns an `AtEnrollmentException`.  This exception is caught in the catch block of `_waitForPkamAuthSuccess` (which calls `_attemptPkamAuth`),  triggering the retry logic that we want to avoid.  To prevent this, we need to handle `AtEnrollmentException` separately here, which introduces code duplication.
- To handle all the exceptions in one place, moved the existing exception handing logic in _attemptPkamAuth here. With the changes, _attemptPkamAuth do not handle exception. It rethrows and all the exceptions are handled in the _waitForPkamAuthSuccess.

**- How to verify it**
- Tested the changes manually and attaching the test log:

```
/usr/lib/dart/bin/dart --enable-asserts --no-serve-devtools /home/sitaram/IdeaProjects/atsign/core/at_libraries/packages/at_onboarding_cli/bin/activate_cli.dart enroll -s ABC123 -n wavi:rw -p wavi -a @alice🛠 -r vip.ve.atsign.zone -k ~/.atsign/keys/@alice-pkam-local.atKeys -d local-17
Submitting enrollment request
Waiting for approval; will check every 10 seconds
Checking ... Enrollment ID: 0d387d23-e38d-4404-b297-f11adfdd1685
 not approved. Will retry in 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ...  not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:36:23.447566|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake. Attempting to retry for 1 attempt 
 not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:36:33.462455|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake. Attempting to retry for 2 attempt 
 not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:46:06.025958|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake. Attempting to retry for 3 attempt 
 not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:46:16.032858|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake. Attempting to retry for 4 attempt 
 not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:46:26.040091|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake. Attempting to retry for 5 attempt 
 not approved. Will retry in 10 seconds
Checking ... SEVERE|2024-10-07 15:46:36.047084|OnboardingCli|Exception occurred when authenticating the atSign: @alice🛠 caused by HandshakeException: Connection terminated during handshake Activation failed after 5 attempts 
[Error] HandshakeException: Connection terminated during handshake
[Error] Enrollment failed.
  Cause: HandshakeException: Connection terminated during handshake
  Please try again or contact support@atsign.com

Process finished with exit code 0

```

**- Description for the changelog**
- fix: Add retry logic in "_waitForPkamAuthSuccess" to retry when secondary is temporarily not reachable
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
