### PR TITLE
feat: add 'auto' approve feature to auth_cli

### DIFF
--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   version: ^3.0.2
   logging: ^1.2.0
   meta: ^1.11.0
+  path: ^1.9.0
 
 dev_dependencies:
   lints: ^3.0.0

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.7.0
+- feat: add `auto` command to the activate CLI 
 ## 1.6.4
 - build[deps]: upgrade: \
   at_client to 3.2.2 | at_commons to 5.0.0 | at_lookup to 3.0.49 | at_utils to 3.0.19 \

--- a/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
@@ -6,11 +6,13 @@ import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_utils/at_logger.dart';
 
+@Deprecated('Use auth_cli')
 Future<void> main(List<String> arguments) async {
   int exitCode = await wrappedMain(arguments);
   exit(exitCode);
 }
 
+@Deprecated('Use auth_cli')
 Future<int> wrappedMain(List<String> arguments) async {
   //defaults
   String rootServer = 'root.atsign.org';
@@ -57,6 +59,7 @@ Future<int> wrappedMain(List<String> arguments) async {
   return await activate(argResults);
 }
 
+@Deprecated('Use auth_cli')
 Future<int> activate(ArgResults argResults,
     {AtOnboardingService? atOnboardingService}) async {
   stdout.writeln('[Information] Root server is ${argResults['rootServer']}');

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -23,7 +23,7 @@ final aca = AuthCliArgs();
 Future<int> main(List<String> arguments) async {
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   try {
-    return await _main(arguments);
+    return await wrappedMain(arguments);
   } on ArgumentError catch (e) {
     stderr.writeln('Invalid argument: ${e.message}');
     aca.parser.printAllCommandsUsage();
@@ -35,7 +35,7 @@ Future<int> main(List<String> arguments) async {
   }
 }
 
-Future<int> _main(List<String> arguments) async {
+Future<int> wrappedMain(List<String> arguments) async {
   if (arguments.isEmpty) {
     stderr.writeln('You must supply a command.');
     aca.parser.printAllCommandsUsage(showSubCommandParams: false);

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -507,7 +507,6 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
 
         case AuthCliCommand.onboard:
         case AuthCliCommand.interactive:
-        case AuthCliCommand.auto:
         case AuthCliCommand.status:
         case AuthCliCommand.enroll:
           stderr.writeln('The "${cliCommand.name}" command'
@@ -527,6 +526,9 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
 
         case AuthCliCommand.approve:
           await approve(commandArgResults, atClient);
+
+        case AuthCliCommand.auto:
+          await autoApprove(commandArgResults, atClient);
 
         case AuthCliCommand.deny:
           await deny(commandArgResults, atClient);

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -20,10 +21,25 @@ final AtSignLogger logger = AtSignLogger(' CLI ');
 
 final aca = AuthCliArgs();
 
+Directory? storageDir;
+
+void deleteStorage() {
+  // Windows will not let us delete files that are open
+  // so will will ignore this step and leave them in %localappdata%\Temp
+  if (!Platform.isWindows) {
+    if (storageDir != null) {
+      if (storageDir!.existsSync()) {
+        // stderr.writeln('${DateTime.now()} : Cleaning up temporary files');
+        storageDir!.deleteSync(recursive: true);
+      }
+    }
+  }
+}
+
 Future<int> main(List<String> arguments) async {
   AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
   try {
-    return await _main(arguments);
+    return await wrappedMain(arguments);
   } on ArgumentError catch (e) {
     stderr.writeln('Invalid argument: ${e.message}');
     aca.parser.printAllCommandsUsage();
@@ -32,10 +48,14 @@ Future<int> main(List<String> arguments) async {
     stderr.writeln('Error: $e');
     aca.parser.printAllCommandsUsage();
     return 1;
+  } finally {
+    try {
+      deleteStorage();
+    } catch (_) {}
   }
 }
 
-Future<int> _main(List<String> arguments) async {
+Future<int> wrappedMain(List<String> arguments) async {
   if (arguments.isEmpty) {
     stderr.writeln('You must supply a command.');
     aca.parser.printAllCommandsUsage(showSubCommandParams: false);
@@ -157,6 +177,10 @@ Future<int> _main(List<String> arguments) async {
         await approve(
             commandArgResults, await createAtClient(commandArgResults));
 
+      case AuthCliCommand.auto:
+        await autoApprove(
+            commandArgResults, await createAtClient(commandArgResults));
+
       case AuthCliCommand.deny:
         await deny(commandArgResults, await createAtClient(commandArgResults));
 
@@ -248,16 +272,25 @@ Future<int> status(ArgResults ar) async {
 }
 
 Future<AtClient> createAtClient(ArgResults ar) async {
-  String nameSpace = 'at_auth_cli';
+  if (storageDir != null) {
+    throw StateError('AtClient has already been created');
+  }
+
+  String nameSpace = 'at_activate';
   String atSign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
+  storageDir = standardAtClientStorageDir(
+    atSign: atSign,
+    progName: nameSpace,
+    uniqueID: '${DateTime.now().millisecondsSinceEpoch}',
+  );
+
   CLIBase cliBase = CLIBase(
     atSign: atSign,
     atKeysFilePath: ar[AuthCliArgs.argNameAtKeys],
     nameSpace: nameSpace,
     rootDomain: ar[AuthCliArgs.argNameAtDirectoryFqdn],
     homeDir: getHomeDirectory(),
-    storageDir: '${getHomeDirectory()}/.atsign/$nameSpace/$atSign/storage'
-        .replaceAll('/', Platform.pathSeparator),
+    storageDir: storageDir!.path,
     verbose: ar[AuthCliArgs.argNameVerbose] || ar[AuthCliArgs.argNameDebug],
     syncDisabled: true,
     maxConnectAttempts: int.parse(
@@ -474,6 +507,7 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
 
         case AuthCliCommand.onboard:
         case AuthCliCommand.interactive:
+        case AuthCliCommand.auto:
         case AuthCliCommand.status:
         case AuthCliCommand.enroll:
           stderr.writeln('The "${cliCommand.name}" command'
@@ -650,7 +684,8 @@ Future<Map> _fetchOrListAndFilter(
   return enrollmentMap;
 }
 
-Future<void> approve(ArgResults ar, AtClient atClient) async {
+Future<int> approve(ArgResults ar, AtClient atClient, {int? limit}) async {
+  int approved = 0;
   AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
 
   Map toApprove = await _fetchOrListAndFilter(
@@ -663,13 +698,15 @@ Future<void> approve(ArgResults ar, AtClient atClient) async {
 
   if (toApprove.isEmpty) {
     stderr.writeln('No matching enrollment(s) found');
-    return;
+    return approved;
   }
 
   // Iterate through the requests, approve each one
   for (String eId in toApprove.keys) {
     Map er = toApprove[eId];
-    stdout.writeln('Approving enrollmentId $eId');
+    stdout.writeln('Approving enrollmentId $eId'
+        ' with appName "${er['appName']}"'
+        ' and deviceName "${er['deviceName']}"');
     // Then make a 'decision' object using data from the enrollment request
     EnrollmentRequestDecision decision = EnrollmentRequestDecision.approved(
         ApprovedRequestDecisionBuilder(
@@ -680,9 +717,119 @@ Future<void> approve(ArgResults ar, AtClient atClient) async {
     final response = await atAuthBase
         .atEnrollment(atClient.getCurrentAtSign()!)
         .approve(decision, atLookup);
-    // 'enroll:approve:{"enrollmentId":"$enrollmentId"}'
+
     stdout.writeln('Server response: $response');
+
+    approved++;
+
+    if (limit != null && approved >= limit) {
+      return approved;
+    }
   }
+  return approved;
+}
+
+Future<int> autoApprove(ArgResults ar, AtClient atClient) async {
+  int approved = 0;
+  int limit = int.parse(ar[AuthCliArgs.argNameLimit]);
+  String? arx = ar[AuthCliArgs.argNameAppNameRegex];
+  String? drx = ar[AuthCliArgs.argNameDeviceNameRegex];
+  bool approveExisting = ar[AuthCliArgs.argNameAutoApproveExisting];
+
+  if (arx == null && drx == null) {
+    throw IllegalArgumentException(
+        'You must supply ${AuthCliArgs.argNameAppNameRegex}'
+        ' and/or ${AuthCliArgs.argNameDeviceNameRegex}');
+  }
+
+  if (approveExisting) {
+    // Start by approving any which match and are already there
+    stdout.writeln('Approving any requests already there which are a match');
+    approved = await approve(ar, atClient, limit: limit);
+    stdout.writeln();
+  }
+
+  // If we've already approved our limit then we're done
+  if (approved >= limit) {
+    return approved;
+  }
+
+  Completer completer = Completer();
+
+  RegExp? appRegex;
+  RegExp? deviceRegex;
+  if (arx != null) {
+    appRegex = RegExp(arx);
+  }
+  if (drx != null) {
+    deviceRegex = RegExp(drx);
+  }
+
+  AtLookUp atLookup = atClient.getRemoteSecondary()!.atLookUp;
+
+  // listen for enrollment requests
+  stdout.writeln('Listening for new enrollment requests');
+
+  final stream = atClient.notificationService.subscribe(
+      regex: r'.*\.new\.enrollments\.__manage', shouldDecrypt: false);
+
+  final subscription = stream.listen((AtNotification n) async {
+    if (completer.isCompleted) {
+      return; // Don't handle any more if we're already done
+    }
+
+    String eId = n.key.substring(0, n.key.indexOf('.'));
+
+    final er = jsonDecode(n.value!);
+    stdout.writeln('Got enrollment request ID $eId'
+        ' with appName "${er['appName']}"'
+        ' and deviceName "${er['deviceName']}"');
+
+    // check the request matches our params
+    String appName = er['appName'];
+    String deviceName = er['deviceName'];
+    if ((appRegex?.hasMatch(appName) ?? true) &&
+        (deviceRegex?.hasMatch(deviceName) ?? true)) {
+      // request matched, let's approve it
+      stdout.writeln('Approving enrollment request'
+          ' which matched the regex filters'
+          ' (app: "$arx" and device: "$drx" respectively)');
+
+      EnrollmentRequestDecision decision = EnrollmentRequestDecision.approved(
+          ApprovedRequestDecisionBuilder(
+              enrollmentId: eId,
+              encryptedAPKAMSymmetricKey: er['encryptedAPKAMSymmetricKey']));
+
+      // Finally call approve method via an AtEnrollment object
+      final response = await atAuthBase
+          .atEnrollment(atClient.getCurrentAtSign()!)
+          .approve(decision, atLookup);
+      stdout.writeln('Approval successful.\n'
+          '\tResponse: $response');
+
+      // increment approved count
+      approved++;
+
+      // check approved vs limit
+      if (approved >= limit) {
+        // if reached limit, complete the future
+        stdout
+            .writeln('Approved $approved requests - limit was $limit - done.');
+        completer.complete();
+      }
+    } else {
+      stdout.writeln('Ignoring enrollment request'
+          ' which does not match the regex filters'
+          ' (app: "$arx" and device: "$drx" respectively)');
+    }
+    stdout.writeln();
+  });
+
+  // await future then cancel the subscription
+  await completer.future;
+  await subscription.cancel();
+
+  return approved;
 }
 
 Future<void> deny(ArgResults ar, AtClient atClient) async {

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -44,6 +44,9 @@ enum AuthCliCommand {
   list(usage: 'List enrollment requests'),
   fetch(usage: 'Fetch a specific enrollment request'),
   approve(usage: 'Approve a pending enrollment request'),
+  auto(usage: 'Listen for new enrollment requests which match the parameters'
+      ' supplied, and auto-approve them. Will exit after N (defaults to 1)'
+      ' enrollment requests have been approved.'),
   deny(usage: 'Deny a pending enrollment request'),
   revoke(usage: 'Revoke approval of a previously-approved enrollment'),
   enroll(
@@ -93,9 +96,15 @@ class AuthCliArgs {
   static const argNameEnrollmentId = 'enrollmentId';
   static const argNameEnrollmentStatus = 'enrollmentStatus';
   static const argNameAppNameRegex = 'arx';
+  static const argAbbrAppNameRegex = 'A';
   static const argNameDeviceNameRegex = 'drx';
+  static const argAbbrDeviceNameRegex = 'D';
+  static const argNameLimit = 'limit';
+  static const argAbbrLimit = 'L';
   static const argNameMaxConnectAttempts = 'mca';
   static const argNameExpiry = 'expiry';
+  static const argAbbrExpiry = 'e';
+  static const argNameAutoApproveExisting = 'approve-existing';
 
   ArgParser get parser {
     return _aap;
@@ -164,6 +173,9 @@ class AuthCliArgs {
 
       case AuthCliCommand.approve:
         return createApproveCommandParser();
+
+      case AuthCliCommand.auto:
+        return createAutoApproveCommandParser();
 
       case AuthCliCommand.deny:
         return createDenyCommandParser();
@@ -278,7 +290,7 @@ class AuthCliArgs {
       mandatory: true,
     );
     p.addOption(argNameExpiry,
-        abbr: 'e',
+        abbr: argAbbrExpiry,
         help:
             'The duration for which the SPP remains active. The time duration can be passed as "2d,1h,10m,20s,999ms" for 2 days 1 hour 10 minutes 20 seconds 999 milliseconds',
         mandatory: false);
@@ -296,7 +308,7 @@ class AuthCliArgs {
   ArgParser createOtpCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     p.addOption(argNameExpiry,
-        abbr: 'e',
+        abbr: argAbbrExpiry,
         help:
             'The duration for which the OTP remains active. The time duration can be passed as "2d,1h,10m,20s,999ms" for 2 days 1 hour 10 minutes 20 seconds 999 milliseconds',
         mandatory: false);
@@ -337,7 +349,7 @@ class AuthCliArgs {
       mandatory: true,
     );
     p.addOption(argNameExpiry,
-        abbr: 'e',
+        abbr: argAbbrExpiry,
         help:
             'The duration for which the APKAM keys remains active. The time duration can be passed as "2d,1h,10m,20s,999ms" for 2 days 1 hour 10 minutes 20 seconds 999 milliseconds',
         mandatory: false);
@@ -356,8 +368,8 @@ class AuthCliArgs {
       allowed: EnrollmentStatus.values.map((c) => c.name).toList(),
       mandatory: false,
     );
-    _addAppNameRegexOption(p);
-    _addDeviceNameRegexOption(p);
+    _addAppNameRegexOption(p, mandatory: false);
+    _addDeviceNameRegexOption(p, mandatory: false);
     return p;
   }
 
@@ -369,28 +381,35 @@ class AuthCliArgs {
     return p;
   }
 
-  void _addAppNameRegexOption(ArgParser p) {
+  void _addAppNameRegexOption(ArgParser p, {required bool mandatory}) {
     p.addOption(
       argNameAppNameRegex,
-      help: 'Filter responses via regular expression on app name',
-      mandatory: false,
+      abbr: argAbbrAppNameRegex,
+      help: 'Filter requests via regular expression on app name',
+      mandatory: mandatory,
     );
   }
 
-  void _addDeviceNameRegexOption(ArgParser p) {
+  void _addDeviceNameRegexOption(ArgParser p, {required bool mandatory}) {
     p.addOption(
       argNameDeviceNameRegex,
-      help: 'Filter responses via regular expression on device name',
-      mandatory: false,
+      abbr: argAbbrDeviceNameRegex,
+      help: 'Filter requests via regular expression on device name',
+      mandatory: mandatory,
     );
   }
 
-  void _addEnrollmentIdOption(ArgParser p, {bool mandatory = false}) {
+  void _addEnrollmentIdOption(
+    ArgParser p, {
+    bool mandatory = false,
+    bool hide = false,
+  }) {
     p.addOption(
       argNameEnrollmentId,
       abbr: 'i',
       help: 'The ID of the enrollment request',
       mandatory: mandatory,
+      hide: hide,
     );
   }
 
@@ -399,8 +418,33 @@ class AuthCliArgs {
   ArgParser createApproveCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p);
-    _addAppNameRegexOption(p);
-    _addDeviceNameRegexOption(p);
+    _addAppNameRegexOption(p, mandatory: false);
+    _addDeviceNameRegexOption(p, mandatory: false);
+    return p;
+  }
+
+  /// auth approve
+  @visibleForTesting
+  ArgParser createAutoApproveCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true);
+    _addEnrollmentIdOption(p, hide:true);
+    _addAppNameRegexOption(p, mandatory: true);
+    _addDeviceNameRegexOption(p, mandatory: true);
+    p.addOption(
+      argNameLimit,
+      abbr: argAbbrLimit,
+      help: 'Listen until this many requests have been approved',
+      mandatory: false,
+      defaultsTo: "1",
+    );
+    p.addFlag(
+      argNameAutoApproveExisting,
+      help: 'Before starting to listen, approve any matching enrollment'
+          ' requests which already exist. Note: any approvals will count'
+          ' towards the limit.',
+      negatable: false,
+      defaultsTo: false,
+    );
     return p;
   }
 
@@ -409,8 +453,8 @@ class AuthCliArgs {
   ArgParser createDenyCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p);
-    _addAppNameRegexOption(p);
-    _addDeviceNameRegexOption(p);
+    _addAppNameRegexOption(p, mandatory: false);
+    _addDeviceNameRegexOption(p, mandatory: false);
     return p;
   }
 
@@ -419,8 +463,8 @@ class AuthCliArgs {
   ArgParser createRevokeCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p);
-    _addAppNameRegexOption(p);
-    _addDeviceNameRegexOption(p);
+    _addAppNameRegexOption(p, mandatory: false);
+    _addDeviceNameRegexOption(p, mandatory: false);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/register_cli/register.dart
+++ b/packages/at_onboarding_cli/lib/src/register_cli/register.dart
@@ -3,8 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:at_client/at_client.dart';
-import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
-    as activate_cli;
+import 'package:at_onboarding_cli/src/cli/auth_cli.dart' as auth_cli;
 import 'package:at_onboarding_cli/src/util/api_call_status.dart';
 import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_onboarding_cli/src/util/register_api_result.dart';
@@ -64,8 +63,14 @@ class Register {
         .add(ValidateOtp())
         .start();
 
-    await activate_cli
-        .wrappedMain(['-a', params['atsign']!, '-c', params['cramkey']!]);
+    await auth_cli.wrappedMain(
+      [
+        '-a',
+        params['atsign']!,
+        '-c',
+        params['cramkey']!,
+      ],
+    );
   }
 }
 

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.6.4
+version: 1.7.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -31,6 +31,13 @@ dependencies:
    at_cli_commons: ^1.1.0
    at_persistence_secondary_server: ^3.0.64
    duration: ^4.0.3
+
+dependency_overrides:
+  at_cli_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_cli_commons
+      ref: feat-add-to-cli-commons-utils
 
 dev_dependencies:
   lints: ^2.1.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -28,16 +28,9 @@ dependencies:
    at_lookup: ^3.0.49
    at_server_status: ^1.0.5
    at_utils: ^3.0.19
-   at_cli_commons: ^1.1.0
+   at_cli_commons: ^1.2.0
    at_persistence_secondary_server: ^3.0.64
    duration: ^4.0.3
-
-dependency_overrides:
-  at_cli_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_cli_commons
-      ref: feat-add-to-cli-commons-utils
 
 dev_dependencies:
   lints: ^2.1.0

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -18,11 +18,6 @@ dependency_overrides:
     path: ../../packages/at_onboarding_cli
   at_commons:
     path: ../../packages/at_commons
-  at_cli_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: packages/at_cli_commons
-      ref: feat-add-to-cli-commons-utils
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -18,6 +18,11 @@ dependency_overrides:
     path: ../../packages/at_onboarding_cli
   at_commons:
     path: ../../packages/at_commons
+  at_cli_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_cli_commons
+      ref: feat-add-to-cli-commons-utils
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -5,8 +5,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_demo_data/at_demo_data.dart' as at_demos;
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_onboarding_cli/src/activate_cli/activate_cli.dart'
-    as activate_cli;
+import 'package:at_onboarding_cli/src/cli/auth_cli.dart' as auth_cli;
 import 'package:at_utils/at_utils.dart';
 import 'package:test/test.dart';
 
@@ -180,7 +179,7 @@ void main() {
         'vip.ve.atsign.zone'
       ];
       // perform activation of atSign
-      await activate_cli.wrappedMain(args);
+      await auth_cli.wrappedMain(args);
 
       /// ToDo: test should NOT exit with status 0 after activation is complete
       /// Exiting with status 0 is ideal behaviour, but for the sake of the test we need to be


### PR DESCRIPTION
**- What I did**
- feat: add --auto option to the approve command - requires an explicit number of matching enrolments to auto-approve; must be combined with the --arx and/or --drx options
- refactor: deprecate the old src/activate_cli/activate_cli.dart as it has been superseded by src/cli/auth_cli.dart
- upgraded at_cli_commons dependency to ^1.2.0

**- How I did it**
See commits

**- How to verify it**
Tests pass
