### PR TITLE
feat: at_cli_commons: Add `standardAtClientStoragePath` and `standardAtClientStorageDir` to utils.dart

### DIFF
--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+- feat: Add `standardAtClientStoragePath` and `standardAtClientStorageDir` 
+  to utils.dart
+
 ## 1.1.0
 
 - feat: Add `maxConnectAttempts` parameter to CLIBase. The default is 20,

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -19,27 +19,31 @@ class CLIBase {
     ..addOption('atsign',
         abbr: 'a', mandatory: true, help: 'This client\'s atSign')
     ..addOption('namespace', abbr: 'n', mandatory: true, help: 'Namespace')
-    ..addOption('key-file',
-        abbr: 'k',
-        mandatory: false,
+    ..addOption(
+      'key-file',
+      abbr: 'k',
+      mandatory: false,
         help: 'Your atSign\'s atKeys file if not in ~/.atsign/keys/')
     ..addOption('cram-secret',
         abbr: 'c', mandatory: false, help: 'atSign\'s cram secret')
     ..addOption('home-dir', abbr: 'h', mandatory: false, help: 'home directory')
-    ..addOption('storage-dir',
-        abbr: 's',
-        mandatory: false,
+    ..addOption(
+      'storage-dir',
+      abbr: 's',
+      mandatory: false,
         help: 'directory for this client\'s local storage files')
-    ..addOption('root-domain',
-        abbr: 'd',
-        mandatory: false,
-        help: 'Root Domain',
+    ..addOption(
+      'root-domain',
+      abbr: 'd',
+      mandatory: false,
+      help: 'Root Domain',
         defaultsTo: 'root.atsign.org')
     ..addFlag('verbose', abbr: 'v', negatable: false, help: 'More logging')
     ..addFlag('never-sync', negatable: false, help: 'Do not run sync')
-    ..addOption('max-connect-attempts',
-        help: 'Number of times to attempt to initially connect to atServer.'
-            ' Note: there is a 3-second delay between connection attempts.',
+    ..addOption(
+      'max-connect-attempts',
+      help: 'Number of times to attempt to initially connect to atServer.'
+          ' Note: there is a 3-second delay between connection attempts.',
         defaultsTo: defaultMaxConnectAttempts.toString());
 
   /// Constructs a CLIBase from a list of command-line arguments
@@ -149,11 +153,19 @@ class CLIBase {
     }
 
     atKeysFilePathToUse =
-        atKeysFilePath ?? '$homeDir/.atsign/keys/${this.atSign}_key.atKeys';
-    localStoragePathToUse =
-        storageDir ?? '$homeDir/.$nameSpace/${this.atSign}/storage';
+        (atKeysFilePath ?? '$homeDir/.atsign/keys/${this.atSign}_key.atKeys')
+            .replaceAll('/', Platform.pathSeparator);
+    localStoragePathToUse = (storageDir ??
+            standardAtClientStoragePath(
+              baseDir: homeDir!,
+              atSign: this.atSign,
+              progName: nameSpace,
+              uniqueID: 'single',
+            ))
+        .replaceAll('/', Platform.pathSeparator);
     downloadPathToUse =
-        downloadDir ?? '$homeDir/.$nameSpace/${this.atSign}/files';
+        (downloadDir ?? '$homeDir!/.atsign/downloads/${this.atSign}/$nameSpace')
+            .replaceAll('/', Platform.pathSeparator);
 
     AtSignLogger.defaultLoggingHandler = AtSignLogger.stdErrLoggingHandler;
 
@@ -181,7 +193,7 @@ class CLIBase {
       ..namespace = nameSpace
       ..downloadPath = downloadPathToUse
       ..isLocalStoreRequired = true
-      ..commitLogPath = '$localStoragePathToUse/commitLog'
+      ..commitLogPath = '$localStoragePathToUse/commitLog'.replaceAll('/', Platform.pathSeparator)
       ..rootDomain = rootDomain
       ..fetchOfflineNotifications = true
       ..atKeysFilePath = atKeysFilePathToUse

--- a/packages/at_cli_commons/lib/src/utils.dart
+++ b/packages/at_cli_commons/lib/src/utils.dart
@@ -1,5 +1,43 @@
 import 'dart:io';
 import 'package:at_client/at_client.dart';
+import 'package:path/path.dart' as path;
+
+String standardAtClientStoragePath({
+  required String baseDir,
+  required String atSign,
+  required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
+  String uniqueID = 'single',
+}) {
+  return path.normalize('$baseDir'
+          '/.atsign'
+          '/storage'
+          '/$atSign'
+          '/.$progName'
+          '/$uniqueID'
+      .replaceAll('/', Platform.pathSeparator));
+}
+
+Directory standardAtClientStorageDir({
+  required String atSign,
+  required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
+  required String uniqueID,
+}) {
+  if (Platform.isWindows) {
+    return Directory(standardAtClientStoragePath(
+      baseDir: Platform.environment['TEMP']!,
+      atSign: atSign,
+      progName: progName,
+      uniqueID: uniqueID,
+    ));
+  } else {
+    return Directory(standardAtClientStoragePath(
+      baseDir: getHomeDirectory()!,
+      atSign: atSign,
+      progName: progName,
+      uniqueID: uniqueID,
+    ));
+  }
+}
 
 /// Get the home directory or null if unknown.
 String? getHomeDirectory({bool throwIfNull = false}) {

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 1.1.0
+version: 1.2.0
 
 repository: https://github.com/atsign-foundation/at_libraries/tree/trunk/packages/at_cli_commons
 homepage: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
feat: at_cli_commons: Add `standardAtClientStoragePath` and `standardAtClientStorageDir` to utils.dart
refactor: use standardAtClientStoragePath in CLIBase constructor
fix: use platform path separators in CLIBase constructor
