### PR TITLE
fix: Check of write permission of atKeys file path when submitting enroll request

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.7.1
-- When submitting an enrollment request, check for write permissions of AtKeys file path.
+
+- fix: When submitting an enrollment request, check for write permissions of AtKeys file path.
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.7.1
+- When submitting an enrollment request, check for write permissions of AtKeys file path.
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -460,6 +460,9 @@ bool canCreateFile(File file) {
     // This does not delete the existing file. Deletes only if the new file is created to verify write permissions.
     file.deleteSync();
     return true;
+  } on PathExistsException {
+    stderr.writeln('Error : atKeys file ${file.path} already exists');
+    rethrow;
   } on PathAccessException {
     stderr.writeln(
         'Error : atKeys file ${file.path} does not have write permissions');

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -351,6 +351,11 @@ Future<void> enroll(ArgResults argResults, {AtOnboardingService? svc}) async {
 
   File f = File(argResults[AuthCliArgs.argNameAtKeys]);
 
+  if (f.existsSync()) {
+    stderr.writeln('Error: atKeys file ${f.path} already exists');
+    return;
+  }
+
   // "_isWritable" attempts to create the directories for the given [file] if they do not exist,
   // and then tries to open the file in write mode to verify write permissions.
   //
@@ -430,7 +435,6 @@ Future<void> enroll(ArgResults argResults, {AtOnboardingService? svc}) async {
 /// [file]: The [File] instance to check for write access.
 ///
 /// Exceptions:
-/// - If the file already exists, a [PathExistsException] is caught, and an error message is printed to stderr.
 /// - If the file does not have write permissions, a [PathAccessException] is caught, and an error message is printed to stderr.
 /// - Any other exceptions are caught and logged, indicating a failure to determine write access.
 @visibleForTesting
@@ -438,9 +442,7 @@ bool isWritable(File file) {
   try {
     // If the directories do not exist, create them.
     // "recursive" is set to true to ensure that any missing parent directories are created.
-    // "exclusive" is set to true to check if the file already exists; if it does,
-    // an error will be logged and returned.
-    file.createSync(recursive: true, exclusive: true);
+    file.createSync(recursive: true);
     // Try opening the file in write mode, which requires write permissions
     RandomAccessFile raf = file.openSync(mode: FileMode.write);
     raf.closeSync();
@@ -448,9 +450,6 @@ bool isWritable(File file) {
     // if the file already exists. Therefore, delete the file here after checking for write permissions.
     file.deleteSync();
     return true;
-  } on PathExistsException {
-    stderr.writeln('Error: atKeys file ${file.path} already exists');
-    return false;
   } on PathAccessException {
     stderr.writeln(
         'Error : atKeys file ${file.path} does not have write permissions');

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.7.0
+version: 1.7.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -16,13 +16,13 @@ void main() {
       await directory.create(recursive: true);
       // Set permission to read only.
       await Process.run('chmod', ['444', baseDirPath]);
-      expect(isWritable(File(dirPath)), false);
+      expect(canCreateFile(File(dirPath)), false);
     });
 
     test(
         'A test verify isWritable returns true if directory does not have a file already',
         () {
-      expect(isWritable(File(dirPath)), true);
+      expect(canCreateFile(File(dirPath)), true);
     });
   });
 

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -20,15 +20,6 @@ void main() {
     });
 
     test(
-        'A test to verify isWritable returns false if file already exists in the directory',
-        () async {
-      final directory = Directory(dirPath);
-      // Create the directory first to ensure it exists before calling isWritable.
-      await directory.create(recursive: true);
-      expect(isWritable(File(dirPath)), false);
-    });
-
-    test(
         'A test verify isWritable returns true if directory does not have a file already',
         () {
       expect(isWritable(File(dirPath)), true);

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:at_onboarding_cli/src/cli/auth_cli.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final baseDirPath = 'test/keys';
+  group('A group of tests to verify write permission of apkam file path', () {
+    final dirPath = '$baseDirPath/@alice-apkam-keys.atKeys';
+
+    test(
+        'A test to verify isWritable returns false if directory has read-only permissions',
+        () async {
+      final directory = Directory(dirPath);
+      // Create the directory first to ensure it exists before calling isWritable.
+      await directory.create(recursive: true);
+      // Set permission to read only.
+      await Process.run('chmod', ['444', baseDirPath]);
+      expect(isWritable(File(dirPath)), false);
+    });
+
+    test(
+        'A test to verify isWritable returns false if file already exists in the directory',
+        () async {
+      final directory = Directory(dirPath);
+      // Create the directory first to ensure it exists before calling isWritable.
+      await directory.create(recursive: true);
+      expect(isWritable(File(dirPath)), false);
+    });
+
+    test(
+        'A test verify isWritable returns true if directory does not have a file already',
+        () {
+      expect(isWritable(File(dirPath)), true);
+    });
+  });
+
+  tearDown(() async {
+    // Set full permissions to delete the directory.
+    await Process.run('chmod', ['777', baseDirPath]);
+    Directory(baseDirPath).deleteSync(recursive: true);
+  });
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- When submitting the enrollment request, checks for the write permissions of the atKeys filepath. If the filePath has write permission, then continues with submission of enrollment request, else logs error and quits.

**- How I did it**
- Introduce "isWritable" method which attempts to create the directories for the given file if they do not exist, and then tries to open the file in write mode to verify write permissions. If the file can be opened for writing, it is immediately closed and deleted. In `AtOnboardingServiceImpl._generateAtKeysFile` method, there is a check which returns error if the file already exists. Therefore, delete the file here after checking for write permissions.
- Removed the logic that checks for the existence of the atKeys file from the enroll method, as this verification will now be handled by the isWritable method when creating the atKeys file to confirm write permissions.

**- How to verify it**
- Added the below unit tests to assert the behavior of the isWritable method:
   -  A test to verify isWritable returns false if directory has only read-only permissions
   - A test to verify isWritable returns false if file already exists in the directory
   - A test verify isWritable returns true if directory does not have a file already

**- Description for the changelog**
- fix: Check of write permission of atKeys file path when submitting enroll request
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
