### PR TITLE
fix: export regex utils to fix _specialKey bug in at_persistence

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.1
+- fix: export regex utils class
 ## 5.0.0
 - [Breaking Change]feat: Emit the isEncrypted value in the metadata if it is false
 - fix: update pkam regex to accept sha512 as hashing algo

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -29,6 +29,7 @@ export 'package:at_commons/src/verb/verb_util.dart';
 export 'package:at_commons/src/auth/auth_mode.dart';
 export 'package:at_commons/src/verb/enroll_params.dart';
 export 'package:at_commons/src/enroll/enrollment.dart';
+export 'package:at_commons/src/utils/at_key_regex_utils.dart';
 @experimental
 export 'package:at_commons/src/telemetry/at_telemetry.dart';
 export 'package:at_commons/src/utils/string_utils.dart';

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.0.0
+version: 5.0.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
- exported regex util class from at_commons
**- How I did it**
- added export statement in at_commons.dart
- modified pubspec and changelog
**- How to verify it**
- tests should pass in at_server and at_client using dependency overrides
