### PR TITLE
fix: standardAtClientStoragePath

### DIFF
--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -65,6 +65,7 @@ jobs:
           - at_onboarding_cli
           - at_commons
           - at_utils
+          - at_cli_commons
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+- fix: fix impl of `standardAtClientStoragePath`
+
 ## 1.2.0
 - feat: Add `standardAtClientStoragePath` and `standardAtClientStorageDir` 
   to utils.dart

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -12,6 +12,7 @@ import 'package:version/version.dart';
 
 class CLIBase {
   static const defaultMaxConnectAttempts = 20;
+
   /// An ArgParser which has all of the options and flags required by [CLIBase]
   /// Used by [fromCommandLineArgs] if the `parser` parameter isn't supplied.
   static final ArgParser argsParser = ArgParser()
@@ -19,31 +20,27 @@ class CLIBase {
     ..addOption('atsign',
         abbr: 'a', mandatory: true, help: 'This client\'s atSign')
     ..addOption('namespace', abbr: 'n', mandatory: true, help: 'Namespace')
-    ..addOption(
-      'key-file',
-      abbr: 'k',
-      mandatory: false,
+    ..addOption('key-file',
+        abbr: 'k',
+        mandatory: false,
         help: 'Your atSign\'s atKeys file if not in ~/.atsign/keys/')
     ..addOption('cram-secret',
         abbr: 'c', mandatory: false, help: 'atSign\'s cram secret')
     ..addOption('home-dir', abbr: 'h', mandatory: false, help: 'home directory')
-    ..addOption(
-      'storage-dir',
-      abbr: 's',
-      mandatory: false,
+    ..addOption('storage-dir',
+        abbr: 's',
+        mandatory: false,
         help: 'directory for this client\'s local storage files')
-    ..addOption(
-      'root-domain',
-      abbr: 'd',
-      mandatory: false,
-      help: 'Root Domain',
+    ..addOption('root-domain',
+        abbr: 'd',
+        mandatory: false,
+        help: 'Root Domain',
         defaultsTo: 'root.atsign.org')
     ..addFlag('verbose', abbr: 'v', negatable: false, help: 'More logging')
     ..addFlag('never-sync', negatable: false, help: 'Do not run sync')
-    ..addOption(
-      'max-connect-attempts',
-      help: 'Number of times to attempt to initially connect to atServer.'
-          ' Note: there is a 3-second delay between connection attempts.',
+    ..addOption('max-connect-attempts',
+        help: 'Number of times to attempt to initially connect to atServer.'
+            ' Note: there is a 3-second delay between connection attempts.',
         defaultsTo: defaultMaxConnectAttempts.toString());
 
   /// Constructs a CLIBase from a list of command-line arguments
@@ -193,7 +190,8 @@ class CLIBase {
       ..namespace = nameSpace
       ..downloadPath = downloadPathToUse
       ..isLocalStoreRequired = true
-      ..commitLogPath = '$localStoragePathToUse/commitLog'.replaceAll('/', Platform.pathSeparator)
+      ..commitLogPath = '$localStoragePathToUse/commitLog'
+          .replaceAll('/', Platform.pathSeparator)
       ..rootDomain = rootDomain
       ..fetchOfflineNotifications = true
       ..atKeysFilePath = atKeysFilePathToUse

--- a/packages/at_cli_commons/lib/src/utils.dart
+++ b/packages/at_cli_commons/lib/src/utils.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 import 'package:at_client/at_client.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+
+const String defaultPathUniqueID = 'singleton';
 
 /// Generate a path like this:
 /// $baseDir/.atsign/storage/$atSign/$progName/$uniqueID
@@ -9,7 +12,7 @@ String standardAtClientStoragePath({
   required String baseDir,
   required String atSign,
   required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
-  String uniqueID = 'single',
+  String uniqueID = defaultPathUniqueID,
 }) {
   return path.normalize('$baseDir'
           '/.atsign'
@@ -20,18 +23,37 @@ String standardAtClientStoragePath({
       .replaceAll('/', Platform.pathSeparator));
 }
 
+@visibleForTesting
+Directory standardWindowsAtClientStorageDir({
+  required String atSign,
+  required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
+  required String uniqueID,
+}) {
+  return Directory(standardAtClientStoragePath(
+    baseDir: Platform.environment['TEMP']!,
+    atSign: atSign,
+    progName: progName,
+    uniqueID: uniqueID,
+  ));
+}
+
+/// Generate a path like this:
+/// $baseDir/.atsign/storage/$atSign/$progName/$uniqueID
+/// (normalized to use platform-specific path separator)
+/// where baseDir is either
+/// - for Windows: `Platform.environment['TEMP']`
+/// - for others: [getHomeDirectory]
 Directory standardAtClientStorageDir({
   required String atSign,
   required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
   required String uniqueID,
 }) {
   if (Platform.isWindows) {
-    return Directory(standardAtClientStoragePath(
-      baseDir: Platform.environment['TEMP']!,
+    return standardAtClientStorageDir(
       atSign: atSign,
       progName: progName,
       uniqueID: uniqueID,
-    ));
+    );
   } else {
     return Directory(standardAtClientStoragePath(
       baseDir: getHomeDirectory()!,
@@ -101,11 +123,13 @@ bool checkNonAscii(String test) {
   }
 }
 
+/// $homeDirectory/.atsign/keys/${atSign}_key.atKeys
 String getDefaultAtKeysFilePath(String homeDirectory, String atSign) {
   return '$homeDirectory/.atsign/keys/${atSign}_key.atKeys'
       .replaceAll('/', Platform.pathSeparator);
 }
 
+/// '$homeDirectory/.ssh/'
 String getDefaultSshDirectory(String homeDirectory) {
   return '$homeDirectory/.ssh/'.replaceAll('/', Platform.pathSeparator);
 }

--- a/packages/at_cli_commons/lib/src/utils.dart
+++ b/packages/at_cli_commons/lib/src/utils.dart
@@ -2,6 +2,9 @@ import 'dart:io';
 import 'package:at_client/at_client.dart';
 import 'package:path/path.dart' as path;
 
+/// Generate a path like this:
+/// $baseDir/.atsign/storage/$atSign/$progName/$uniqueID
+/// (normalized to use platform-specific path separator)
 String standardAtClientStoragePath({
   required String baseDir,
   required String atSign,
@@ -12,7 +15,7 @@ String standardAtClientStoragePath({
           '/.atsign'
           '/storage'
           '/$atSign'
-          '/.$progName'
+          '/$progName'
           '/$uniqueID'
       .replaceAll('/', Platform.pathSeparator));
 }

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 1.2.0
+version: 1.2.1
 
 repository: https://github.com/atsign-foundation/at_libraries/tree/trunk/packages/at_cli_commons
 homepage: https://docs.atsign.com/

--- a/packages/at_cli_commons/test/utils_test.dart
+++ b/packages/at_cli_commons/test/utils_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:at_cli_commons/at_cli_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  String atSign = '@alice';
+  String progName = 'test';
+  String uniqueID = '${DateTime.now().millisecondsSinceEpoch}';
+
+  test('test standardAtClientStoragePath without uniqueID', () {
+    expect(
+        standardAtClientStoragePath(
+          baseDir: '/tmp',
+          atSign: '@alice',
+          progName: 'test',
+        ),
+        '/tmp/.atsign/storage/$atSign/$progName/$defaultPathUniqueID'
+            .replaceAll('/', Platform.pathSeparator));
+  });
+
+  test('test standardAtClientStoragePath with uniqueID', () {
+    expect(
+        standardAtClientStoragePath(
+          baseDir: '/tmp',
+          atSign: '@alice',
+          progName: 'test',
+          uniqueID: uniqueID,
+        ),
+        '/tmp/.atsign/storage/$atSign/$progName/$uniqueID'
+            .replaceAll('/', Platform.pathSeparator));
+  });
+
+  test('test standardAtClientStorageDir', () {
+    Directory dir = standardAtClientStorageDir(
+      atSign: atSign,
+      progName: progName,
+      uniqueID: uniqueID,
+    );
+    if (Platform.isWindows) {
+      expect(
+          dir,
+          standardWindowsAtClientStorageDir(
+            atSign: atSign,
+            progName: progName,
+            uniqueID: uniqueID,
+          ));
+    } else {
+      expect(
+          dir.path,
+          '${getHomeDirectory()}/.atsign/storage/$atSign/$progName/$uniqueID'
+              .replaceAll('/', Platform.pathSeparator));
+    }
+  });
+}


### PR DESCRIPTION
**- What I did**
- fix standardAtClientStoragePath
- test: add some basic tests of at_cli_commons utils.dart
- build: add at_cli_commons to the matrix in the GH actions workflow

**- How to verify it**
- tests pass
- the `build_and_test` job is run for the `at_cli_commons` package

