### PR TITLE
fix: Changes in at_commons related to public key hash and implement sha512 hashing algo in at_chops

### DIFF
--- a/packages/at_chops/lib/src/algorithm/default_hashing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_hashing_algo.dart
@@ -8,3 +8,11 @@ class DefaultHash implements AtHashingAlgorithm<List<int>, String> {
     return md5.convert(data).toString();
   }
 }
+
+class SHA512HashingAlgo implements AtHashingAlgorithm<List<int>, String> {
+  @override
+  String hash(List<int> data, {covariant HashParams? hashParams}) {
+    Digest digest = sha512.convert(data);
+    return digest.toString();
+  }
+}

--- a/packages/at_chops/lib/src/at_chops_base.dart
+++ b/packages/at_chops/lib/src/at_chops_base.dart
@@ -1,14 +1,9 @@
 import 'dart:typed_data';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/algorithm/at_iv.dart';
-import 'package:at_chops/src/algorithm/rsa_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/default_hashing_algo.dart';
-import 'package:at_chops/src/key/impl/at_chops_keys.dart';
-import 'package:at_chops/src/key/key_type.dart';
-import 'package:at_chops/src/metadata/at_signing_input.dart';
-import 'package:at_chops/src/metadata/encryption_result.dart';
-import 'package:at_chops/src/metadata/signing_result.dart';
+import 'package:at_chops/src/factory/at_hashing_algo_factory.dart';
 
 /// Base class for all Cryptographic and Hashing Operations. Callers have to either implement
 /// specific encryption, signing or hashing algorithms. Otherwise default implementation of specific algorithms will be used.
@@ -18,6 +13,25 @@ abstract class AtChops {
   AtChopsKeys get atChopsKeys => _atChopsKeys;
 
   AtChops(this._atChopsKeys);
+
+  /// Returns an instance of [AtHashingAlgorithm] based on the provided [hashingAlgoType].
+  ///
+  /// This static method acts as a factory to create a hashing algorithm object, which
+  /// can be used to hash data using the specified hashing algorithm type.
+  ///
+  /// The [hashingAlgoType] parameter defines the type of hashing algorithm to be used.
+  /// It should be an instance of [HashingAlgoType], which represents different supported
+  /// hashing algorithms like SHA512, MD5, etc.
+  ///
+  /// Example usage:
+  /// ```dart
+  /// String hashedValue = AtChops.hashWith(HashingAlgoType.sha512).hash('some-text');
+  /// ```
+  ///
+  /// [hashingAlgoType]: The type of the hashing algorithm (e.g., SHA256, MD5).
+  /// Returns an [AtHashingAlgorithm] instance based on the provided [hashingAlgoType].
+  static AtHashingAlgorithm hashWith(HashingAlgoType hashingAlgoType) =>
+      AtHashingAlgorithmFactory.withHashingAlgorithm(hashingAlgoType);
 
   /// Encrypts the input bytes [data] using an [encryptionAlgorithm] and returns [AtEncryptionResult].
   /// If [encryptionKeyType] is [EncryptionKeyType.rsa2048] then [encryptionAlgorithm] will be set to [RsaEncryptionAlgo]

--- a/packages/at_chops/lib/src/at_keys_crypto.dart
+++ b/packages/at_chops/lib/src/at_keys_crypto.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops.dart';
-import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:at_chops/src/algorithm/at_hashing_algo_factory.dart';
+import 'package:at_chops/src/factory/at_hashing_algo_factory.dart';
 import 'package:at_chops/src/model/hash_params.dart';
 import 'package:at_commons/at_commons.dart';
 
@@ -110,8 +109,7 @@ class _AtKeysCryptoImpl implements AtKeysCrypto {
   /// hashed key.
   Future<String> _getHashKey(String passPhrase, HashingAlgoType hashingAlgoType,
       {HashParams? hashParams}) async {
-    AtHashingAlgorithm atHashingAlgorithm =
-        AtHashingAlgorithmFactory.getHashingAlgorithm(hashingAlgoType);
-    return await atHashingAlgorithm.hash(passPhrase, hashParams: hashParams);
+    return await AtHashingAlgorithmFactory.withHashingAlgorithm(hashingAlgoType)
+        .hash(passPhrase, hashParams: hashParams);
   }
 }

--- a/packages/at_chops/lib/src/factory/at_hashing_algo_factory.dart
+++ b/packages/at_chops/lib/src/factory/at_hashing_algo_factory.dart
@@ -8,7 +8,7 @@ import 'package:at_commons/at_commons.dart';
 /// based on the specified [HashingAlgoType].
 ///
 /// The [AtHashingAlgorithmFactory] class provides a static method
-/// [getHashingAlgorithm] which returns the appropriate hashing algorithm
+/// [withHashingAlgorithm] which returns the appropriate hashing algorithm
 /// implementation corresponding to the provided [HashingAlgoType].
 class AtHashingAlgorithmFactory {
   /// Returns an instance of [AtHashingAlgorithm] based on the provided [HashingAlgoType].
@@ -18,10 +18,12 @@ class AtHashingAlgorithmFactory {
   /// - [HashingAlgoType.argon2id]: returns an instance of [Argon2idHashingAlgo] (Argon2id hashing).
   ///
   /// Throws an [AtException] if an unsupported hashing algorithm is passed.
-  static AtHashingAlgorithm getHashingAlgorithm(HashingAlgoType algoType) {
+  static AtHashingAlgorithm withHashingAlgorithm(HashingAlgoType algoType) {
     switch (algoType) {
       case HashingAlgoType.argon2id:
         return Argon2idHashingAlgo();
+      case HashingAlgoType.sha512:
+        return SHA512HashingAlgo();
       default:
         throw AtException('Unsupported hashing algorithm');
     }

--- a/packages/at_chops/test/hashing_algo_test.dart
+++ b/packages/at_chops/test/hashing_algo_test.dart
@@ -1,13 +1,14 @@
 import 'package:at_chops/at_chops.dart';
-import 'package:at_commons/at_commons.dart';
+import 'package:crypto/crypto.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('A group of tests related to hashing of the data', () {
     test('A test to verify hashing of data with SHA512', () async {
-      String hashedValue =
-          await AtChops.hashWith(HashingAlgoType.sha512).hash('some-data'.codeUnits);
-      expect(hashedValue.isNotNullOrEmpty, true);
+      String expectedHashValue = await AtChops.hashWith(HashingAlgoType.sha512)
+          .hash('some-data'.codeUnits);
+      String actualHashValue = sha512.convert('some-data'.codeUnits).toString();
+      expect(expectedHashValue, actualHashValue);
     });
   });
 }

--- a/packages/at_chops/test/hashing_algo_test.dart
+++ b/packages/at_chops/test/hashing_algo_test.dart
@@ -1,0 +1,13 @@
+import 'package:at_chops/at_chops.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests related to hashing of the data', () {
+    test('A test to verify hashing of data with SHA512', () async {
+      String hashedValue =
+          await AtChops.hashWith(HashingAlgoType.sha512).hash('some-data'.codeUnits);
+      expect(hashedValue.isNotNullOrEmpty, true);
+    });
+  });
+}

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -64,7 +64,7 @@ class AtConstants {
   static const String sharedWithPublicKeyCheckSum = 'pubKeyCS';
   static const String sharedWithPublicKeyHash = 'pubKeyHash';
   static const String sharedWithPublicKeyHashValue = 'hash';
-  static const String sharedWithPublicKeyHashAlgo = 'algo';
+  static const String sharedWithPublicKeyHashingAlgo = 'hashingAlgo';
   static const String sharedKeyEncryptedEncryptingKeyName = 'skeEncKeyName';
   static const String sharedKeyEncryptedEncryptingAlgo = 'skeEncAlgo';
   static const String firstByte = '#';

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -566,8 +566,7 @@ class Metadata {
       sb.write(':${AtConstants.sharedWithPublicKeyCheckSum}:$pubKeyCS');
     }
     if (pubKeyHash != null) {
-      sb.write(
-          ':${AtConstants.sharedWithPublicKeyHashValue}:${pubKeyHash!.hash}');
+      sb.write(':${AtConstants.sharedWithPublicKeyHash}:${pubKeyHash!.hash}');
       sb.write(
           ':${AtConstants.sharedWithPublicKeyHashingAlgo}:${pubKeyHash!.hashingAlgo}');
     }

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -1,7 +1,9 @@
+import 'dart:convert';
+
 import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
+import 'package:at_commons/src/keystore/public_key_hash.dart';
 import 'package:at_commons/src/utils/at_key_regex_utils.dart';
 import 'package:at_commons/src/utils/string_utils.dart';
-import 'package:at_commons/src/keystore/public_key_hash.dart';
 import 'package:meta/meta.dart';
 
 import '../at_constants.dart';
@@ -521,14 +523,7 @@ class Metadata {
 
   @override
   String toString() {
-    return 'Metadata{ttl: $ttl, ttb: $ttb, ttr: $ttr,ccd: $ccd, isPublic: $isPublic, isHidden: $isHidden'
-        ', availableAt : ${availableAt?.toUtc().toString()}, expiresAt : ${expiresAt?.toUtc().toString()}'
-        ', refreshAt : ${refreshAt?.toUtc().toString()}, createdAt : ${createdAt?.toUtc().toString()}'
-        ', updatedAt : ${updatedAt?.toUtc().toString()}, isBinary : $isBinary, isEncrypted : $isEncrypted'
-        ', isCached : $isCached, dataSignature: $dataSignature, sharedKeyStatus: $sharedKeyStatus'
-        ', encryptedSharedKey: $sharedKeyEnc, pubKeyHash: $pubKeyHash, encoding: $encoding'
-        ', encKeyName: $encKeyName, encAlgo: $encAlgo, ivNonce: $ivNonce'
-        ', skeEncKeyName: $skeEncKeyName, skeEncAlgo: $skeEncAlgo}';
+    return 'Metadata{${jsonEncode(toJson())}}';
   }
 
   /// Creates a fragment which can be included in any atProtocol commands which use
@@ -574,7 +569,7 @@ class Metadata {
       sb.write(
           ':${AtConstants.sharedWithPublicKeyHashValue}:${pubKeyHash!.hash}');
       sb.write(
-          ':${AtConstants.sharedWithPublicKeyHashAlgo}:${pubKeyHash!.publicKeyHashingAlgo.name}');
+          ':${AtConstants.sharedWithPublicKeyHashingAlgo}:${pubKeyHash!.hashingAlgo}');
     }
     if (encoding.isNotNullOrEmpty) {
       sb.write(':${AtConstants.encoding}:$encoding');

--- a/packages/at_commons/lib/src/keystore/public_key_hash.dart
+++ b/packages/at_commons/lib/src/keystore/public_key_hash.dart
@@ -1,19 +1,26 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+
 /// Represents hash of an atsign's public encryption key and the hashing algorithm used
 class PublicKeyHash {
+  // Holds the hashed value of the data.
   String hash;
-  PublicKeyHashingAlgo publicKeyHashingAlgo;
 
-  PublicKeyHash(this.hash, this.publicKeyHashingAlgo);
+  // Holds the algorithm used to the hash the data.
+  String hashingAlgo;
+
+  PublicKeyHash(this.hash, this.hashingAlgo);
 
   @override
   String toString() {
-    return 'PublicKeyHash{hash: $hash, publicKeyHashingAlgo: $publicKeyHashingAlgo}';
+    return jsonEncode(toJson());
   }
 
   Map toJson() {
     var map = {};
-    map['hash'] = hash;
-    map['algo'] = publicKeyHashingAlgo.name;
+    map[AtConstants.sharedWithPublicKeyHashValue] = hash;
+    map[AtConstants.sharedWithPublicKeyHashingAlgo] = hashingAlgo;
     return map;
   }
 
@@ -21,8 +28,8 @@ class PublicKeyHash {
     if (json == null) {
       return null;
     }
-    return PublicKeyHash(
-        json['hash'], PublicKeyHashingAlgo.values.byName(json['algo']));
+    return PublicKeyHash(json[AtConstants.sharedWithPublicKeyHashValue],
+        json[AtConstants.sharedWithPublicKeyHashingAlgo]);
   }
 
   @override
@@ -31,10 +38,8 @@ class PublicKeyHash {
       other is PublicKeyHash &&
           runtimeType == other.runtimeType &&
           hash == other.hash &&
-          publicKeyHashingAlgo == other.publicKeyHashingAlgo;
+          hashingAlgo == other.hashingAlgo;
 
   @override
-  int get hashCode => hash.hashCode ^ publicKeyHashingAlgo.hashCode;
+  int get hashCode => hash.hashCode ^ hashingAlgo.hashCode;
 }
-
-enum PublicKeyHashingAlgo { sha256, sha512 }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -39,6 +39,8 @@ class VerbSyntax {
       r'(:isEncrypted:(?<isEncrypted>true|false))?'
       r'(:sharedKeyEnc:(?<sharedKeyEnc>[^:@\s]+))?'
       r'(:pubKeyCS:(?<pubKeyCS>[^:@\s]+))?'
+      r'(:pubKeyHash:(?<pubKeyHash>[^:@\s]+))?'
+      r'(:hashingAlgo:(?<hashingAlgo>[^:@\s]+))?'
       r'(:encoding:(?<encoding>[^:@\s]+))?'
       r'(:encKeyName:(?<encKeyName>[^:@\s]+))?'
       r'(:encAlgo:(?<encAlgo>[^:@\s]+))?'

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -155,6 +155,13 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
     builder.atKey.metadata.skeEncAlgo =
         verbParams[AtConstants.sharedKeyEncryptedEncryptingAlgo];
 
+    if (verbParams[AtConstants.sharedWithPublicKeyHash] != null &&
+        verbParams[AtConstants.sharedWithPublicKeyHashingAlgo] != null) {
+      builder.atKey.metadata.pubKeyHash = PublicKeyHash(
+          verbParams[AtConstants.sharedWithPublicKeyHash]!,
+          verbParams[AtConstants.sharedWithPublicKeyHashingAlgo]!);
+    }
+
     builder.value = verbParams[AtConstants.value];
 
     return builder;

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -937,7 +937,7 @@ void main() {
         ..ttr = -1;
       var metadataFragment = metadata.toAtProtocolFragment();
       expect(metadataFragment,
-          contains('${AtConstants.sharedWithPublicKeyHashValue}:randomhash'));
+          contains('${AtConstants.sharedWithPublicKeyHash}:randomhash'));
       expect(metadataFragment,
           contains('${AtConstants.sharedWithPublicKeyHashingAlgo}:sha512'));
     });

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -919,25 +919,27 @@ void main() {
     test('Test to verify metadata toJson method when public key hash is set',
         () {
       var metadata = Metadata()
-        ..pubKeyHash = PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512)
+        ..pubKeyHash = PublicKeyHash('randomhash', 'sha512')
         ..isPublic = false
         ..ttr = -1;
       var metadataJson = metadata.toJson();
       expect(metadataJson[AtConstants.sharedWithPublicKeyHash]['hash'],
           'randomhash');
-      expect(metadataJson[AtConstants.sharedWithPublicKeyHash]['algo'],
-          PublicKeyHashingAlgo.sha512.name);
+      expect(metadataJson[AtConstants.sharedWithPublicKeyHash]['hashingAlgo'],
+          'sha512');
     });
     test(
         'Test to verify metadata toProtocol fragment method when public key hash is set',
         () {
       var metadata = Metadata()
-        ..pubKeyHash = PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512)
+        ..pubKeyHash = PublicKeyHash('randomhash', 'sha512')
         ..isPublic = false
         ..ttr = -1;
       var metadataFragment = metadata.toAtProtocolFragment();
-      expect(metadataFragment, contains('hash:randomhash'));
-      expect(metadataFragment, contains('algo:sha512'));
+      expect(metadataFragment,
+          contains('${AtConstants.sharedWithPublicKeyHashValue}:randomhash'));
+      expect(metadataFragment,
+          contains('${AtConstants.sharedWithPublicKeyHashingAlgo}:sha512'));
     });
     test('Test to verify metadata fromJson method when public key hash is set',
         () {
@@ -946,12 +948,14 @@ void main() {
       jsonMap['isBinary'] = false;
       jsonMap['isEncrypted'] = true;
       jsonMap['isPublic'] = false;
-      jsonMap['pubKeyHash'] = {'hash': 'randomhash', 'algo': 'sha512'};
+      jsonMap['pubKeyHash'] = {
+        AtConstants.sharedWithPublicKeyHashValue: 'randomhash',
+        AtConstants.sharedWithPublicKeyHashingAlgo: 'sha512'
+      };
       var metadataObject = Metadata.fromJson(jsonMap);
       expect(metadataObject.pubKeyHash, isNotNull);
       expect(metadataObject.pubKeyHash!.hash, 'randomhash');
-      expect(metadataObject.pubKeyHash!.publicKeyHashingAlgo,
-          PublicKeyHashingAlgo.sha512);
+      expect(metadataObject.pubKeyHash!.hashingAlgo, 'sha512');
     });
     test(
         'Test to verify metadata fromJson method when public key hash is not set',
@@ -1017,7 +1021,7 @@ void main() {
         ..isEncrypted = true
         ..isCached = false
         ..sharedKeyEnc = 'dummy_shared_key_enc'
-        ..pubKeyHash = PublicKeyHash('test_hash', PublicKeyHashingAlgo.sha256)
+        ..pubKeyHash = PublicKeyHash('test_hash', 'sha256')
         ..encoding = 'base64'
         ..encKeyName = 'key_12345.__shared_keys.wavi'
         ..encAlgo = 'RSA'
@@ -1042,8 +1046,12 @@ void main() {
       expect(metadataMap['isEncrypted'], true);
       expect(metadataMap['isCached'], false);
       expect(metadataMap['sharedKeyEnc'], 'dummy_shared_key_enc');
-      expect(metadataMap['pubKeyHash']['hash'], 'test_hash');
-      expect(metadataMap['pubKeyHash']['algo'], 'sha256');
+      expect(
+          metadataMap['pubKeyHash'][AtConstants.sharedWithPublicKeyHashValue],
+          'test_hash');
+      expect(
+          metadataMap['pubKeyHash'][AtConstants.sharedWithPublicKeyHashingAlgo],
+          'sha256');
       expect(metadataMap['encoding'], 'base64');
       expect(metadataMap['encKeyName'], 'key_12345.__shared_keys.wavi');
       expect(metadataMap['encAlgo'], 'RSA');

--- a/packages/at_commons/test/public_key_hash_test.dart
+++ b/packages/at_commons/test/public_key_hash_test.dart
@@ -4,64 +4,51 @@ import 'package:test/test.dart';
 void main() {
   group('A group of tests to verify public key hash methods', () {
     test('Test to verify toJson method', () {
-      final publicKeyHash =
-          PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512);
+      final publicKeyHash = PublicKeyHash('randomhash', 'sha512');
       var toJson = publicKeyHash.toJson();
-      expect(toJson['hash'], 'randomhash');
-      expect(toJson['algo'], 'sha512');
+      expect(toJson[AtConstants.sharedWithPublicKeyHashValue], 'randomhash');
+      expect(toJson[AtConstants.sharedWithPublicKeyHashingAlgo], 'sha512');
     });
     test('Test to verify fromJson method', () {
       var jsonMap = {};
-      jsonMap['hash'] = 'randomhash';
-      jsonMap['algo'] = 'sha256';
+      jsonMap[AtConstants.sharedWithPublicKeyHashValue] = 'randomhash';
+      jsonMap[AtConstants.sharedWithPublicKeyHashingAlgo] = 'sha256';
       final publicKeyHash = PublicKeyHash.fromJson(jsonMap);
       expect(publicKeyHash, isNotNull);
       expect(publicKeyHash?.hash, 'randomhash');
-      expect(publicKeyHash?.publicKeyHashingAlgo, PublicKeyHashingAlgo.sha256);
+      expect(publicKeyHash?.hashingAlgo, 'sha256');
     });
     test('Test to verify equals operator two objects equals', () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512);
+      final publicKeyHash_1 = PublicKeyHash('randomhash', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash', 'sha512');
       expect(publicKeyHash_1 == publicKeyHash_2, true);
     });
     test('Test to verify equals operator two objects different hash', () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash_1', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash_2', PublicKeyHashingAlgo.sha512);
+      final publicKeyHash_1 = PublicKeyHash('randomhash_1', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash_2', 'sha512');
       expect(publicKeyHash_1 == publicKeyHash_2, false);
     });
     test('Test to verify equals operator two objects different hash algo', () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash_1', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash_2', PublicKeyHashingAlgo.sha256);
+      final publicKeyHash_1 = PublicKeyHash('randomhash_1', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash_2', 'sha256');
       expect(publicKeyHash_1 == publicKeyHash_2, false);
     });
     test('Test to verify hashcodes are same - two objects equals', () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash', PublicKeyHashingAlgo.sha512);
+      final publicKeyHash_1 = PublicKeyHash('randomhash', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash', 'sha512');
       equals(publicKeyHash_1.hashCode, publicKeyHash_2.hashCode);
     });
     test('Test to verify hashcodes are different - two objects different hash',
         () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash_1', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash_2', PublicKeyHashingAlgo.sha512);
+      final publicKeyHash_1 = PublicKeyHash('randomhash_1', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash_2', 'sha512');
       expect(publicKeyHash_1.hashCode == publicKeyHash_2.hashCode, false);
     });
     test(
         'Test to verify hashcodes are different - two objects different hash algo',
         () {
-      final publicKeyHash_1 =
-          PublicKeyHash('randomhash_1', PublicKeyHashingAlgo.sha512);
-      final publicKeyHash_2 =
-          PublicKeyHash('randomhash_2', PublicKeyHashingAlgo.sha256);
+      final publicKeyHash_1 = PublicKeyHash('randomhash_1', 'sha512');
+      final publicKeyHash_2 = PublicKeyHash('randomhash_2', 'sha256');
       expect(publicKeyHash_1.hashCode == publicKeyHash_2.hashCode, false);
     });
   });


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changes in at_chops:

 - Implement SHA512 hashing algorithm in at_chops.
 - In at_chops_impl.dart, introduce "hashWith" static method which will take a hashing algorithm as input and return the hashed value the given input.

Changes in at_commons:
 - In PublicKeyHash.dart,  replace "PublicKeyHashingAlgo" enum with String which holds the hashing algo. This is because the "PublicKeyHashingAlgo" is a duplicate of "HashingAlgoType" enum and have an overhead of converting PublicKeyHashingAlgo type to HashingAlgoType in at_chops to hash the data. 
- Updated the existing unit tests accordingly.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
