### PR TITLE
fix: set ttr in encryption public key during onboard

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.0.9
-- fix: Set ttr=-1 for encryption publickey during onboard
+- fix:Enable caching of encryption public key
 ## 2.0.8
 - feat: Add "passPhrase" in "AtAuthRequest" to support password protected atKeys file
 - build[deps]: Upgraded the following packages:

--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.9
+- fix: Set ttr=-1 for encryption publickey during onboard
 ## 2.0.8
 - feat: Add "passPhrase" in "AtAuthRequest" to support password protected atKeys file
 - build[deps]: Upgraded the following packages:

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -164,7 +164,9 @@ class AtAuthImpl implements AtAuth {
       ..atKey = (AtKey()
         ..key = 'publickey'
         ..sharedBy = atOnboardingRequest.atSign
-        ..metadata = (Metadata()..isPublic = true))
+        ..metadata = (Metadata()
+          ..isPublic = true
+          ..ttr = -1))
       ..value = encryptionPublicKey;
     String? encryptKeyUpdateResult = await atLookUp!.executeVerb(updateBuilder);
     _logger.info('Encryption public key update result $encryptKeyUpdateResult');

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.0.8
+version: 2.0.9
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -155,7 +155,7 @@ void main() {
       expect(encryptionPublicKey, isNotNull);
       encryptionPublicKey = encryptionPublicKey?.replaceFirst('data:', '');
       expect(jsonDecode(encryptionPublicKey!)['metaData'], isNotNull);
-      expect(jsonDecode(encryptionPublicKey)['metaData']['ttr'], '-1');
+      expect(jsonDecode(encryptionPublicKey)['metaData']['ttr'], -1);
       print('encryptionPublicKey: $encryptionPublicKey');
       bool status2 = await atOnboardingService.authenticate();
       expect(status2, true);

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -148,10 +148,10 @@ void main() {
       bool status = await atOnboardingService.onboard();
       expect(status, true);
       // verify whether ttr is set in public encryption key
-      final atClient = await atOnboardingService.atClient;
-      final encryptionPublicKey = await atClient!
-          .getRemoteSecondary()
-          ?.executeCommand('lookup:all:publickey$atSign\n');
+      final atLookup = AtLookupImpl(atSign, atOnboardingPreference.rootDomain,
+          atOnboardingPreference.rootPort);
+      final encryptionPublicKey =
+          await atLookup.executeCommand('lookup:all:publickey$atSign\n');
       print('encryptionPublicKey: $encryptionPublicKey');
       bool status2 = await atOnboardingService.authenticate();
       expect(status2, true);
@@ -159,6 +159,7 @@ void main() {
 
       /// Assert .atKeys file is generated for the atSign
       expect(await File(atOnboardingPreference.atKeysFilePath!).exists(), true);
+      await atLookup.close();
     });
 
     tearDown(() async {

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -150,8 +150,12 @@ void main() {
       // verify whether ttr is set in public encryption key
       final atLookup = AtLookupImpl(atSign, atOnboardingPreference.rootDomain,
           atOnboardingPreference.rootPort);
-      final encryptionPublicKey =
+      var encryptionPublicKey =
           await atLookup.executeCommand('lookup:all:publickey$atSign\n');
+      expect(encryptionPublicKey, isNotNull);
+      encryptionPublicKey = encryptionPublicKey?.replaceFirst('data:', '');
+      expect(jsonDecode(encryptionPublicKey!)['metaData'], isNotNull);
+      expect(jsonDecode(encryptionPublicKey)['metaData']['ttr'], '-1');
       print('encryptionPublicKey: $encryptionPublicKey');
       bool status2 = await atOnboardingService.authenticate();
       expect(status2, true);

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -147,6 +147,12 @@ void main() {
           AtOnboardingServiceImpl(atSign, atOnboardingPreference);
       bool status = await atOnboardingService.onboard();
       expect(status, true);
+      // verify whether ttr is set in public encryption key
+      final atClient = await atOnboardingService.atClient;
+      final encryptionPublicKey = await atClient!
+          .getRemoteSecondary()
+          ?.executeCommand('lookup:all:publickey$atSign\n');
+      print('encryptionPublicKey: $encryptionPublicKey');
       bool status2 = await atOnboardingService.authenticate();
       expect(status2, true);
       expect(await atOnboardingService.isOnboarded(), true);


### PR DESCRIPTION
Fixes https://github.com/atsign-foundation/at_libraries/issues/297

**- What I did**
- Fixed a bug in onboarding_cli where ttr was not set for encryption public key
**- How I did it**
- set the ttr in at_auth --> onboard method
- added a check in functional test which retrieves publickey from server and checks the metadata
- changes to publish at_auth
**- How to verify it**
- tests should pass
