### PR TITLE
build: Set at_onboarding_cli version to 1.8.0

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,12 +1,11 @@
-## 1.8.1
-- build[deps]: upgrade: \
-  at_auth to 2.0.9 | at_chops to 2.2.0 | at_client to 3.3.0 \
-  at_commons to 5.0.2 | at_cli_commons to 1.2.1 | at_persistence_secondary_server to 3.0.65
-- feat: Support password protection of atKeys file with a pass phrase
 ## 1.8.0
 - feat: add `unrevoke` command to the activate CLI
 - feat: add `delete` command to the activate CLI
 - fix: When submitting an enrollment request, check for write permissions of AtKeys file path.
+- build[deps]: upgrade: \
+  at_auth to 2.0.9 | at_chops to 2.2.0 | at_client to 3.3.0 \
+  at_commons to 5.0.2 | at_cli_commons to 1.2.1 | at_persistence_secondary_server to 3.0.65
+- feat: Support password protection of atKeys file with a pass phrase
 ## 1.7.0
 - feat: add `auto` command to the activate CLI 
 ## 1.6.4

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.8.1
+version: 1.8.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -34,7 +34,7 @@ dependencies:
    chalkdart: ^2.0.9
 
 dev_dependencies:
-  lints: ^2.1.0
-  test: ^1.24.2
+  lints: ^5.0.0
+  test: ^1.25.8
   at_demo_data: ^1.0.0
   mocktail: ^1.0.3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Set at_onboarding_cli from v1.8.1 back to v1.8.0 because 1.8.0 is not yet published.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
