### PR TITLE
feat: at_cli_commons : Add "passPhrase" in "CLIBase" to support password protected atKeys file

### DIFF
--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.0
+- feat: Add passPhrase as optional argument to "CLIBase" to support password protected atKeys file.
+- build: Upgraded the following dependencies
+  - args to v2.6.0
+  - at_client to v3.3.0
+  - at_onboarding_cli to v1.8.0
+  - test to v1.25.9
+
 ## 1.2.1
 - fix: fix impl of `standardAtClientStoragePath`
 

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -41,7 +41,12 @@ class CLIBase {
     ..addOption('max-connect-attempts',
         help: 'Number of times to attempt to initially connect to atServer.'
             ' Note: there is a 3-second delay between connection attempts.',
-        defaultsTo: defaultMaxConnectAttempts.toString());
+        defaultsTo: defaultMaxConnectAttempts.toString())..addOption(
+        'passPhrase',
+        abbr: 'P',
+        help:
+            'Pass Phrase to encrypt/decrypt the password protected atKeys file',
+        mandatory: false);
 
   /// Constructs a CLIBase from a list of command-line arguments
   /// and calls [init] on it.
@@ -67,17 +72,17 @@ class CLIBase {
     }
 
     CLIBase cliBase = CLIBase(
-      atSign: parsedArgs['atsign'],
-      atKeysFilePath: parsedArgs['key-file'],
-      nameSpace: parsedArgs['namespace'],
-      rootDomain: parsedArgs['root-domain'],
-      homeDir: getHomeDirectory(),
-      storageDir: parsedArgs['storage-dir'],
-      verbose: parsedArgs['verbose'],
-      cramSecret: parsedArgs['cram-secret'],
-      syncDisabled: parsedArgs['never-sync'],
-      maxConnectAttempts: int.parse(parsedArgs['max-connect-attempts']),
-    );
+        atSign: parsedArgs['atsign'],
+        atKeysFilePath: parsedArgs['key-file'],
+        nameSpace: parsedArgs['namespace'],
+        rootDomain: parsedArgs['root-domain'],
+        homeDir: getHomeDirectory(),
+        storageDir: parsedArgs['storage-dir'],
+        verbose: parsedArgs['verbose'],
+        cramSecret: parsedArgs['cram-secret'],
+        syncDisabled: parsedArgs['never-sync'],
+        maxConnectAttempts: int.parse(parsedArgs['max-connect-attempts']),
+        passPhrase: parsedArgs['passPhrase']);
 
     await cliBase.init();
 
@@ -92,6 +97,7 @@ class CLIBase {
   final String? storageDir;
   final String? downloadDir;
   final String? cramSecret;
+  final String? passPhrase;
   final bool syncDisabled;
   final int maxConnectAttempts;
 
@@ -120,19 +126,19 @@ class CLIBase {
   ///     cliBase.logger.logger.level = Level.FINEST;
   /// ```
   /// Throws an [IllegalArgumentException] if the parameters fail validation.
-  CLIBase({
-    required String atSign,
-    required this.nameSpace,
-    required this.rootDomain,
-    this.homeDir,
-    this.verbose = false,
-    this.atKeysFilePath,
-    this.storageDir,
-    this.downloadDir,
-    this.cramSecret,
-    this.syncDisabled = false,
-    this.maxConnectAttempts = defaultMaxConnectAttempts,
-  }) {
+  CLIBase(
+      {required String atSign,
+      required this.nameSpace,
+      required this.rootDomain,
+      this.homeDir,
+      this.verbose = false,
+      this.atKeysFilePath,
+      this.storageDir,
+      this.downloadDir,
+      this.cramSecret,
+      this.syncDisabled = false,
+      this.maxConnectAttempts = defaultMaxConnectAttempts,
+      this.passPhrase}) {
     this.atSign = AtUtils.fixAtSign(atSign);
     if (homeDir == null) {
       if (atKeysFilePath == null) {
@@ -196,7 +202,8 @@ class CLIBase {
       ..fetchOfflineNotifications = true
       ..atKeysFilePath = atKeysFilePathToUse
       ..cramSecret = cramSecret
-      ..atProtocolEmitted = Version(2, 0, 0);
+      ..atProtocolEmitted = Version(2, 0, 0)
+      ..passPhrase = passPhrase;
 
     AtOnboardingService onboardingService = AtOnboardingServiceImpl(
         atSign, atOnboardingConfig,

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -41,8 +41,8 @@ class CLIBase {
     ..addOption('max-connect-attempts',
         help: 'Number of times to attempt to initially connect to atServer.'
             ' Note: there is a 3-second delay between connection attempts.',
-        defaultsTo: defaultMaxConnectAttempts.toString())..addOption(
-        'passPhrase',
+        defaultsTo: defaultMaxConnectAttempts.toString())
+    ..addOption('passPhrase',
         abbr: 'P',
         help:
             'Pass Phrase to encrypt/decrypt the password protected atKeys file',

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 1.2.1
+version: 1.3.0
 
 repository: https://github.com/atsign-foundation/at_libraries/tree/trunk/packages/at_cli_commons
 homepage: https://docs.atsign.com/
@@ -9,10 +9,10 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  args: ^2.4.2
-  at_client: ^3.0.68
-  at_onboarding_cli: ^1.4.0
-  at_utils: ^3.0.15
+  args: ^2.6.0
+  at_client: ^3.3.0
+  at_onboarding_cli: ^1.8.0
+  at_utils: ^3.0.19
   chalkdart: ^2.0.9
   version: ^3.0.2
   logging: ^1.2.0
@@ -20,5 +20,5 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
-  lints: ^3.0.0
-  test: ^1.24.9
+  lints: ^5.0.0
+  test: ^1.25.9


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add passPhrase to the CLIBase to support password protected atKeys file.
- Upgrade the dependencies

Tested the changes with No-Ports pointing to this version of at_cli_commons and works expected.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
