### PR TITLE
fix: add IV params in EnrollParams and enroll verb builder

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.1.1
+- fix: Introduce IV params for apkam enrollment flow
 ## 5.1.0
 - feat: Introduce skipDeletesUntil for sync:from verb
 ## 5.0.2

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -106,7 +106,9 @@ class AtConstants {
       'encryptedDefaultEncPrivateKey';
   static const String apkamEncryptedDefaultSelfEncryptionKey =
       'encryptedDefaultSelfEncryptionKey';
+  static const String apkamEncryptionPrivateKeyIV = 'encPrivateKeyIV';
   static const String apkamEncryptedSymmetricKey = 'encryptedApkamSymmetricKey';
+  static const String apkamSelfEncryptionKeyIV = 'selfEncKeyIV';
   static const String apkamPublicKey = 'apkamPublicKey';
   static const String apkamNamespaces = 'namespaces';
   static const String defaultEncryptionPrivateKey = 'default_enc_private_key';

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -11,7 +11,9 @@ class EnrollParams {
   Map<String, String>? namespaces;
   String? otp;
   String? encryptedDefaultEncryptionPrivateKey;
+  String? encPrivateKeyIV;
   String? encryptedDefaultSelfEncryptionKey;
+  String? selfEncKeyIV;
   String? encryptedAPKAMSymmetricKey;
   String? apkamPublicKey;
   List<EnrollmentStatus>? enrollmentStatusFilter;

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -1,4 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// dart run build_runner build - to generate this file
+// After generating, revert changes for apkamKeysExpiryInMillis since value has to be in milliseconds
 
 part of 'enroll_params.dart';
 
@@ -16,8 +18,10 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..otp = json['otp'] as String?
   ..encryptedDefaultEncryptionPrivateKey =
       json['encryptedDefaultEncryptionPrivateKey'] as String?
+  ..encPrivateKeyIV = json['encPrivateKeyIV'] as String?
   ..encryptedDefaultSelfEncryptionKey =
       json['encryptedDefaultSelfEncryptionKey'] as String?
+  ..selfEncKeyIV = json['selfEncKeyIV'] as String?
   ..encryptedAPKAMSymmetricKey = json['encryptedAPKAMSymmetricKey'] as String?
   ..apkamPublicKey = json['apkamPublicKey'] as String?
   ..enrollmentStatusFilter = (json['enrollmentStatusFilter'] as List<dynamic>?)
@@ -36,8 +40,10 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'otp': instance.otp,
       'encryptedDefaultEncryptionPrivateKey':
           instance.encryptedDefaultEncryptionPrivateKey,
+      'encPrivateKeyIV': instance.encPrivateKeyIV,
       'encryptedDefaultSelfEncryptionKey':
           instance.encryptedDefaultSelfEncryptionKey,
+      'selfEncKeyIV': instance.selfEncKeyIV,
       'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,
       'apkamPublicKey': instance.apkamPublicKey,
       'enrollmentStatusFilter': instance.enrollmentStatusFilter

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -33,7 +33,15 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   String? encryptedDefaultEncryptedPrivateKey;
 
   String? encryptedDefaultEncryptionPrivateKey;
+
+  /// Initialisation vector used during symmetric encryption of the default encryption key.
+  String? encPrivateKeyIV;
+
   String? encryptedDefaultSelfEncryptionKey;
+
+  /// Initialisation vector used during symmetric encryption of the default self encryption key.
+  String? selfEncKeyIV;
+
   String? encryptedAPKAMSymmetricKey;
 
   /// Used to force revoke the enrollment request.
@@ -64,7 +72,9 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       ..namespaces = namespaces
       ..encryptedDefaultEncryptionPrivateKey =
           encryptedDefaultEncryptionPrivateKey
+      ..encPrivateKeyIV = encPrivateKeyIV
       ..encryptedDefaultSelfEncryptionKey = encryptedDefaultSelfEncryptionKey
+      ..selfEncKeyIV = selfEncKeyIV
       ..encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey
       ..enrollmentStatusFilter = enrollmentStatusFilter
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.1.0
+version: 5.1.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('A group of tests related to enroll verb', () {
     test('A test to verify enroll request params', () {
       String command =
-          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+          'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key", "encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
       expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:request:', '');
       var enrollParams = jsonDecode(command);
@@ -28,7 +28,7 @@ void main() {
 
     test('A test to verify enroll approve params', () {
       String command =
-          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
+          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encPrivateKeyIV":"MHz0FJD63Dm3y5/w2fc+qw==","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","selfEncKeyIV":"G7GXk44cpIFACy31MSaUkA==","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}';
       expect(RegExp(VerbSyntax.enroll).hasMatch(command), true);
       command = command.replaceAll('enroll:approve:', '');
       var enrollParams = jsonDecode(command);
@@ -38,8 +38,10 @@ void main() {
       expect(enrollParams['namespaces']['wavi'], 'rw');
       expect(enrollParams['encryptedDefaultEncryptionPrivateKey'],
           'dummy_encrypted_private_key');
+      expect(enrollParams['encPrivateKeyIV'], 'MHz0FJD63Dm3y5/w2fc+qw==');
       expect(enrollParams['encryptedDefaultSelfEncryptionKey'],
           'dummy_self_encryption_key');
+      expect(enrollParams['selfEncKeyIV'], 'G7GXk44cpIFACy31MSaUkA==');
       expect(enrollParams['encryptedAPKAMSymmetricKey'], 'dummy_pkam_sym_key');
       expect(enrollParams['apkamPublicKey'], 'abcd1234');
     });

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -32,10 +32,12 @@ void main() {
         ..apkamPublicKey = 'abcd1234'
         ..encryptedAPKAMSymmetricKey = 'dummy_pkam_sym_key'
         ..encryptedDefaultEncryptionPrivateKey = 'dummy_encrypted_private_key'
-        ..encryptedDefaultSelfEncryptionKey = 'dummy_self_encryption_key';
+        ..encPrivateKeyIV = 'dummy_iv_for_enc_private_key'
+        ..encryptedDefaultSelfEncryptionKey = 'dummy_self_encryption_key'
+        ..selfEncKeyIV = 'dummy_iv_for_self_encryption_key';
       var command = enrollVerbBuilder.buildCommand();
       expect(command,
-          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
+          'enroll:approve:{"enrollmentId":"123","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encPrivateKeyIV":"dummy_iv_for_enc_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","selfEncKeyIV":"dummy_iv_for_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234"}\n');
     });
 
     test('A test to verify enroll deny operation', () {


### PR DESCRIPTION
**- What I did**
- added IV params for encryption private key and self encryption key in enroll params. This will eliminate the use of zero IVs currently used to encrypt these keys
**- How I did it**
- added the params in verb builder and enroll_params.dart. Generated enroll_params.g.dart
- added checks to unit tests
**- How to verify it**
- tests should pass
