### PR TITLE
fix: at_auth : use different IVs for encrypting encryptionPrivateKey and selfEncryptionKey.

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.10
+- fix: Replace legacy IVs with random IVs for encrypting "defaultEncryptionPrivateKey" and "selfEncryptionKey" in APKAM flow
 ## 2.0.9
 - fix:Enable caching of encryption public key
 ## 2.0.8

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -203,32 +203,13 @@ class AtAuthImpl implements AtAuth {
       AtLookUp atLookup) async {
     atOnboardingRequest.appName ??= _defaultAppNameForOnboarding;
     atOnboardingRequest.deviceName ??= _defaultDeviceNameForOnboarding;
-    AESEncryptionAlgo symmetricEncryptionAlgo =
-        AESEncryptionAlgo(AESKey(atAuthKeys.apkamSymmetricKey!));
-    // Encrypt the defaultEncryptionPrivateKey with APKAM Symmetric key
-    String encryptedDefaultEncryptionPrivateKey = atChops!
-        .encryptString(
-            atAuthKeys.defaultEncryptionPrivateKey!, EncryptionKeyType.aes256,
-            encryptionAlgorithm: symmetricEncryptionAlgo,
-            iv: AtChopsUtil.generateIVLegacy())
-        .result;
-    // Encrypt the Self Encryption Key with APKAM Symmetric key
-    String encryptedDefaultSelfEncryptionKey = atChops!
-        .encryptString(
-            atAuthKeys.defaultSelfEncryptionKey!, EncryptionKeyType.aes256,
-            encryptionAlgorithm: symmetricEncryptionAlgo,
-            iv: AtChopsUtil.generateIVLegacy())
-        .result;
 
     _logger.finer('apkamPublicKey: ${atAuthKeys.apkamPublicKey}');
 
     FirstEnrollmentRequest firstEnrollmentRequest = FirstEnrollmentRequest(
         appName: atOnboardingRequest.appName!,
         deviceName: atOnboardingRequest.deviceName!,
-        apkamPublicKey: atAuthKeys.apkamPublicKey!,
-        encryptedDefaultEncryptionPrivateKey:
-            encryptedDefaultEncryptionPrivateKey,
-        encryptedDefaultSelfEncryptionKey: encryptedDefaultSelfEncryptionKey);
+        apkamPublicKey: atAuthKeys.apkamPublicKey!);
 
     AtEnrollmentResponse? atEnrollmentResponse;
     try {

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -43,10 +43,6 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
       ..appName = baseEnrollmentRequest.appName
       ..deviceName = baseEnrollmentRequest.deviceName;
     enrollVerbBuilder.apkamPublicKey = baseEnrollmentRequest.apkamPublicKey;
-    enrollVerbBuilder.encryptedDefaultEncryptionPrivateKey =
-        baseEnrollmentRequest.encryptedDefaultEncryptionPrivateKey;
-    enrollVerbBuilder.encryptedDefaultSelfEncryptionKey =
-        baseEnrollmentRequest.encryptedDefaultSelfEncryptionKey;
 
     String? serverResponse =
         await _executeEnrollCommand(enrollVerbBuilder, atLookUp);
@@ -116,6 +112,8 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
     // Set the APKAM Symmetric key to the AtChops Instance.
     atLookUp.atChops?.atChopsKeys.apkamSymmetricKey = AESKey(apkamSymmetricKey);
 
+    InitialisationVector encryptionPrivateKeyIV =
+        AtChopsUtil.generateRandomIV(16);
     // Fetch the encryptionPrivateKey from the atChops and encrypt with APKAM Symmetric key.
     String encryptedDefaultEncryptionPrivateKey = atLookUp.atChops
         ?.encryptString(
@@ -123,21 +121,27 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
                 .privateKey,
             EncryptionKeyType.aes256,
             keyName: 'apkamSymmetricKey',
-            iv: AtChopsUtil.generateIVLegacy())
+            iv: encryptionPrivateKeyIV)
         .result;
 
+    InitialisationVector selfEncryptionKeyIV = AtChopsUtil.generateRandomIV(16);
     // Fetch the selfEncryptionKey from the atChops and encrypt with APKAM Symmetric key.
     String encryptedDefaultSelfEncryptionKey = atLookUp.atChops
         ?.encryptString(atLookUp.atChops!.atChopsKeys.selfEncryptionKey!.key,
             EncryptionKeyType.aes256,
-            keyName: 'apkamSymmetricKey', iv: AtChopsUtil.generateIVLegacy())
+            keyName: 'apkamSymmetricKey', iv: selfEncryptionKeyIV)
         .result;
 
     String command = 'enroll:approve:${jsonEncode({
           'enrollmentId': enrollmentRequestDecision.enrollmentId,
           'encryptedDefaultEncryptionPrivateKey':
               encryptedDefaultEncryptionPrivateKey,
-          'encryptedDefaultSelfEncryptionKey': encryptedDefaultSelfEncryptionKey
+          AtConstants.apkamEncryptionPrivateKeyIV:
+              base64Encode(encryptionPrivateKeyIV.ivBytes),
+          'encryptedDefaultSelfEncryptionKey':
+              encryptedDefaultSelfEncryptionKey,
+          AtConstants.apkamSelfEncryptionKeyIV:
+              base64Encode(selfEncryptionKeyIV.ivBytes)
         })}';
 
     String? enrollResponse =

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -138,7 +138,7 @@ class AtEnrollmentImpl implements AtEnrollmentBase {
               encryptedDefaultEncryptionPrivateKey,
           AtConstants.apkamEncryptionPrivateKeyIV:
               base64Encode(encryptionPrivateKeyIV.ivBytes),
-          'encryptedDefaultSelfEncryptionKey':
+          AtConstants.apkamEncryptedDefaultSelfEncryptionKey:
               encryptedDefaultSelfEncryptionKey,
           AtConstants.apkamSelfEncryptionKeyIV:
               base64Encode(selfEncryptionKeyIV.ivBytes)

--- a/packages/at_auth/lib/src/enroll/first_enrollment_request.dart
+++ b/packages/at_auth/lib/src/enroll/first_enrollment_request.dart
@@ -23,13 +23,8 @@ import 'package:at_auth/src/enroll/base_enrollment_request.dart';
 /// encrypted with the APKAM symmetric key and stored into the server.
 
 class FirstEnrollmentRequest extends BaseEnrollmentRequest {
-  String encryptedDefaultEncryptionPrivateKey;
-  String encryptedDefaultSelfEncryptionKey;
-
   FirstEnrollmentRequest(
       {required super.appName,
       required super.deviceName,
-      required super.apkamPublicKey,
-      required this.encryptedDefaultEncryptionPrivateKey,
-      required this.encryptedDefaultSelfEncryptionKey});
+      required super.apkamPublicKey});
 }

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.0.9
+version: 2.0.10
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^2.4.1
-  at_commons: ^5.0.2
+  at_commons: ^5.1.1
   at_lookup: ^3.0.49
   at_chops: ^2.2.0
   at_utils: ^3.0.19

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -16,7 +16,10 @@ dependency_overrides:
   at_auth:
     path: ../../packages/at_auth
   at_onboarding_cli:
-    path: ../../packages/at_onboarding_cli
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: packages/at_onboarding_cli
+      ref: at-onboarding-cli-apkam-different-ivs
   at_commons:
     path: ../../packages/at_commons
   at_chops:


### PR DESCRIPTION
**- What I did**
- In at_auth package, remove the usage of  legacy Initialization Vector.
- In enroll approval flow, instead of legacy IV's generate random IV's for encrypting the "defaultEncryptionPrivateKey" and "selfEncryptionKey" in APKAM flow.
- The primary reason for storing the encrypted keys is to share defaultEncryptionPrivateKey and defaultSelfEncryptionKey with the app requesting enrollment access. This process is fully handled by the enroll:approve command. Therefore, remove the defaultEncryptionPrivateKey and defaultSelfEncryptionKey when submitting the initial enrollment request.(enroll:request command).

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
