### PR TITLE
fix: remove 'transformers' from PolicyService interface and impl

### DIFF
--- a/packages/at_policy/lib/src/policy/impl.dart
+++ b/packages/at_policy/lib/src/policy/impl.dart
@@ -35,12 +35,6 @@ class PolicyServiceImpl with AtClientBindings implements PolicyService {
   @override
   final bool allowAll;
 
-  @override
-  RpcTransformer? requestTransformer;
-
-  @override
-  RpcTransformer? responseTransformer;
-
   late final AtRpc rpc;
 
   static const JsonEncoder jsonPrettyPrinter = JsonEncoder.withIndent('    ');
@@ -53,8 +47,6 @@ class PolicyServiceImpl with AtClientBindings implements PolicyService {
     required this.loggingAtsign,
     required this.allowList,
     required this.allowAll,
-    this.requestTransformer,
-    this.responseTransformer,
   }) {
     rpc = AtRpc(
       atClient: atClient,
@@ -80,14 +72,9 @@ class PolicyServiceImpl with AtClientBindings implements PolicyService {
     logger.info('Received request from $fromAtSign: '
         '${jsonPrettyPrinter.convert(rpcRequest.toJson())}');
 
-    Map<String, dynamic> requestPayload = rpcRequest.payload;
-    if (requestTransformer != null) {
-      requestPayload = await requestTransformer!(requestPayload);
-    }
     PolicyRequest policyRequest;
-
     try {
-      policyRequest = PolicyRequest.fromJson(requestPayload);
+      policyRequest = PolicyRequest.fromJson(rpcRequest.payload);
     } catch (e) {
       final msg = 'Failed PolicyRequest.fromJson: ${e.toString()}';
       logger.severe(msg);
@@ -130,32 +117,25 @@ class PolicyServiceImpl with AtClientBindings implements PolicyService {
           '\n$st');
     }
 
-    PolicyResponse policyResponse;
     AtRpcResp rpcResponse;
     try {
-      policyResponse = await handler.getPolicyDetails(policyRequest);
-      Map<String, dynamic> responsePayload = policyResponse.toJson();
-      if (responseTransformer != null) {
-        responsePayload = await responseTransformer!(responsePayload);
-      }
+      PolicyResponse policyResponse =
+          await handler.getPolicyDetails(policyRequest);
       rpcResponse = AtRpcResp(
           reqId: rpcRequest.reqId,
           respType: AtRpcRespType.success,
-          payload: responsePayload);
+          payload: policyResponse.toJson());
     } catch (e) {
       logger.severe('Exception: $e');
-      policyResponse = PolicyResponse(
-        message: 'Exception: $e',
-        policyDetails: [],
-      );
-      Map<String, dynamic> responsePayload = policyResponse.toJson();
-      if (responseTransformer != null) {
-        responsePayload = await responseTransformer!(responsePayload);
-      }
       rpcResponse = AtRpcResp(
-          reqId: rpcRequest.reqId,
-          respType: AtRpcRespType.error,
-          payload: responsePayload);
+        reqId: rpcRequest.reqId,
+        respType: AtRpcRespType.error,
+        payload: PolicyResponse(
+          message: 'Exception: $e',
+          policyDetails: [],
+        ).toJson(),
+        message: 'Exception: $e',
+      );
     }
 
     return rpcResponse;

--- a/packages/at_policy/lib/src/policy/interfaces.dart
+++ b/packages/at_policy/lib/src/policy/interfaces.dart
@@ -52,6 +52,8 @@ abstract class PolicyService implements AtRpcCallbacks {
     String? loggingAtsign,
     Set<String>? allowList,
     bool allowAll = true,
+    RpcTransformer? requestTransformer,
+    RpcTransformer? responseTransformer,
   }) {
     return PolicyServiceImpl(
       atClient: atClient,
@@ -61,6 +63,8 @@ abstract class PolicyService implements AtRpcCallbacks {
       loggingAtsign: loggingAtsign ?? atClient.getCurrentAtSign()!,
       allowList: allowList ?? {},
       allowAll: allowAll,
+      requestTransformer: requestTransformer,
+      responseTransformer: responseTransformer,
     );
   }
 }

--- a/packages/at_policy/lib/src/policy/interfaces.dart
+++ b/packages/at_policy/lib/src/policy/interfaces.dart
@@ -9,9 +9,6 @@ abstract class PolicyRequestHandler {
   Future<PolicyResponse> getPolicyDetails(PolicyRequest req);
 }
 
-typedef RpcTransformer = Future<Map<String, dynamic>> Function(
-    Map<String, dynamic>);
-
 /// - Listens for requests for policy info from services
 /// - Returns info for each of the policy intents in the request.
 abstract class PolicyService implements AtRpcCallbacks {
@@ -37,13 +34,6 @@ abstract class PolicyService implements AtRpcCallbacks {
 
   bool get allowAll;
 
-  /// For handling requests where the request payload json is not a
-  /// [PolicyRequest], but it can be transformed into one. e.g. legacy requests
-  RpcTransformer? requestTransformer;
-
-  /// Transform PolicyResponses into some other (e.g. legacy) format
-  RpcTransformer? responseTransformer;
-
   factory PolicyService({
     required AtClient atClient,
     required String baseNamespace,
@@ -52,8 +42,6 @@ abstract class PolicyService implements AtRpcCallbacks {
     String? loggingAtsign,
     Set<String>? allowList,
     bool allowAll = true,
-    RpcTransformer? requestTransformer,
-    RpcTransformer? responseTransformer,
   }) {
     return PolicyServiceImpl(
       atClient: atClient,
@@ -63,8 +51,6 @@ abstract class PolicyService implements AtRpcCallbacks {
       loggingAtsign: loggingAtsign ?? atClient.getCurrentAtSign()!,
       allowList: allowList ?? {},
       allowAll: allowAll,
-      requestTransformer: requestTransformer,
-      responseTransformer: responseTransformer,
     );
   }
 }


### PR DESCRIPTION
**- What I did**
fix: removed `requestTransformer` and `responseTransformer` from PolicyService and PolicyServiceImpl which were introduced in order to support legacy NoPorts authorization checks - this legacy support is now being handled within the NoPorts policy service

**- How I did it**
See commits

**- How to verify it**
Tests pass
