### PR TITLE
fix: at_lookup - flush socket after write and rethrow any exceptions …

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.50
+- fix: Flush socket after write and rethrow any exceptions occurred 
 ## 3.0.49
 - build[deps]: Upgraded the following packages:
   - at_commons to v5.0.0

--- a/packages/at_lookup/lib/src/connection/base_connection.dart
+++ b/packages/at_lookup/lib/src/connection/base_connection.dart
@@ -59,9 +59,11 @@ abstract class BaseConnection extends AtConnection {
     }
     try {
       getSocket().write(data);
+      await getSocket().flush();
       getMetaData()!.lastAccessed = DateTime.now().toUtc();
     } on Exception {
       getMetaData()!.isStale = true;
+      rethrow;
     }
   }
 }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.0.49
+version: 3.0.50
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -20,5 +20,5 @@ dependencies:
 
 dev_dependencies:
   mocktail: ^1.0.1
-  lints: ^1.0.1
-  test: ^1.24.9
+  lints: ^5.0.0
+  test: ^1.25.8

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -23,6 +23,8 @@ dependency_overrides:
     path: ../../packages/at_chops
   at_cli_commons:
     path: ../../packages/at_cli_commons
+  at_lookup:
+    path: ../../packages/at_lookup
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
*- What I did*
- In at_lookup, connection.dart : 
    - call socket.flush() after socket.write()
    - Rethrow the exception from the write method.

Fixes #716

*- How to verify it*
- Created a draft [PR](https://github.com/atsign-foundation/at_client_sdk/pull/1457) in at_client pointing to this at_lookup commit and run all functional and E2E tests. All tests passed
- All the functional tests in the at_onboarding_cli passed.

*- Description for the changelog*
- fix: at_lookup - flush socket after write and rethrow any exceptions
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->