### PR TITLE
fix: Decrypt the pass-phrase protected atKeys and write to stdout

### DIFF
--- a/packages/at_auth/lib/at_auth.dart
+++ b/packages/at_auth/lib/at_auth.dart
@@ -27,6 +27,8 @@ export 'src/keys/at_auth_keys.dart';
 export 'src/onboard/at_onboarding_request.dart';
 export 'src/onboard/at_onboarding_response.dart';
 
+export 'src/utils/at_auth_utils.dart';
+
 /// Global constant to access [AtAuthInterface].
 ///
 /// Serves as the primary entry point to access public methods in at_auth package.

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -49,7 +49,7 @@ class AtAuthImpl implements AtAuth {
     AtAuthKeys? atAuthKeys;
     var enrollmentIdFromRequest = atAuthRequest.enrollmentId;
     if (atAuthRequest.atKeysFilePath != null) {
-      atAuthKeys = await _prepareAtAuthKeysFromFilePath(atAuthRequest);
+      atAuthKeys = await AtAuthUtils.decryptAtKeys(atAuthRequest);
     } else if (atAuthRequest.encryptedKeysMap != null) {
       atAuthKeys = _decryptAtKeysWithSelfEncKey(
           atAuthRequest.encryptedKeysMap!, PkamAuthMode.keysFile);
@@ -262,50 +262,6 @@ class AtAuthImpl implements AtAuth {
     securityKeys.apkamSymmetricKey = jsonData[auth_constants.apkamSymmetricKey];
     securityKeys.enrollmentId = jsonData[AtConstants.enrollmentId];
     return securityKeys;
-  }
-
-  ///method to read and return data from .atKeysFile
-  ///returns map containing encryption keys
-  Future<AtAuthKeys> _prepareAtAuthKeysFromFilePath(
-      AtAuthRequest atAuthRequest) async {
-    if (atAuthRequest.atKeysFilePath == null ||
-        atAuthRequest.atKeysFilePath!.isEmpty) {
-      throw AtException(
-          'atKeys filePath is empty. atKeysFile is required to authenticate');
-    }
-    if (!File(atAuthRequest.atKeysFilePath!).existsSync()) {
-      throw AtException(
-          'provided keys file does not exist. Please check whether the file path ${atAuthRequest.atKeysFilePath} is valid');
-    }
-
-    String atAuthData =
-        await File(atAuthRequest.atKeysFilePath!).readAsString();
-    Map<String, dynamic> decodedAtKeysData = jsonDecode(atAuthData);
-    // If it contains "iv(InitializationVector)", it means the data is encrypted with a
-    // passphrase. Decrypt it.
-    if (decodedAtKeysData.containsKey('iv') &&
-        atAuthRequest.passPhrase.isNullOrEmpty) {
-      throw AtDecryptionException(
-          'Pass Phrase is required for password protected atKeys file');
-    }
-    if (decodedAtKeysData.containsKey('iv')) {
-      _logger.info(
-          'Found encrypted atKeys files. Decrypting with the given pass-phrase');
-      AtEncrypted atEncrypted = AtEncrypted.fromJson(decodedAtKeysData);
-
-      if (atEncrypted.hashingAlgoType == null) {
-        throw AtDecryptionException(
-            'Hashing algo type is required for decryption of password protected atKeys file');
-      }
-
-      String decryptedAtKeys =
-          await AtKeysCrypto.fromHashingAlgorithm(atEncrypted.hashingAlgoType!)
-              .decrypt(atEncrypted, atAuthRequest.passPhrase!);
-      decodedAtKeysData = jsonDecode(decryptedAtKeys);
-    }
-    // This is to decrypt the atKeys encrypted with self Encryption key.
-    return _decryptAtKeysWithSelfEncKey(
-        decodedAtKeysData, atAuthRequest.authMode);
   }
 
   AtAuthKeys _generateKeyPairs(PkamAuthMode authMode, {String? publicKeyId}) {

--- a/packages/at_auth/lib/src/utils/at_auth_utils.dart
+++ b/packages/at_auth/lib/src/utils/at_auth_utils.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_auth/src/auth_constants.dart' as auth_constants;
+import 'package:at_chops/at_chops.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// Utility class for handling authentication-related operations
+class AtAuthUtils {
+  /// Decrypts authentication keys from the specified `.atKeysFile`.
+  ///
+  /// This method reads the authentication keys file, checks if it is
+  /// encrypted with a passphrase, and performs decryption if necessary.
+  ///
+  /// Throws an [AtException] if the file path is invalid or the file
+  /// does not exist. If the file is encrypted, a passphrase is required
+  /// to proceed with decryption.
+  ///
+  /// Returns a map of decryption keys.
+  ///
+  /// [atAuthRequest] The authentication request containing the keys file
+  /// path and passphrase (if any).
+  static Future<AtAuthKeys> decryptAtKeys(AtAuthRequest atAuthRequest) {
+    return _decryptAtKeysFromFilePath(atAuthRequest);
+  }
+
+  static Future<AtAuthKeys> _decryptAtKeysFromFilePath(
+      AtAuthRequest atAuthRequest) async {
+    if (atAuthRequest.atKeysFilePath == null ||
+        atAuthRequest.atKeysFilePath!.isEmpty) {
+      throw AtException(
+          'atKeys filePath is empty. atKeysFile is required to authenticate');
+    }
+    if (!File(atAuthRequest.atKeysFilePath!).existsSync()) {
+      throw AtException(
+          'provided keys file does not exist. Please check whether the file path ${atAuthRequest.atKeysFilePath} is valid');
+    }
+
+    String atAuthData =
+        await File(atAuthRequest.atKeysFilePath!).readAsString();
+    Map<String, dynamic> decodedAtKeysData = jsonDecode(atAuthData);
+    // If it contains "iv(InitializationVector)", it means the data is encrypted with a
+    // passphrase. Decrypt it.
+    if (decodedAtKeysData.containsKey('iv') &&
+        atAuthRequest.passPhrase.isNullOrEmpty) {
+      throw AtDecryptionException(
+          'Pass Phrase is required for password protected atKeys file');
+    }
+    if (decodedAtKeysData.containsKey('iv')) {
+      // _logger.info(
+      //     'Found encrypted atKeys files. Decrypting with the given pass-phrase');
+      AtEncrypted atEncrypted = AtEncrypted.fromJson(decodedAtKeysData);
+
+      if (atEncrypted.hashingAlgoType == null) {
+        throw AtDecryptionException(
+            'Hashing algo type is required for decryption of password protected atKeys file');
+      }
+
+      String decryptedAtKeys =
+          await AtKeysCrypto.fromHashingAlgorithm(atEncrypted.hashingAlgoType!)
+              .decrypt(atEncrypted, atAuthRequest.passPhrase!);
+      decodedAtKeysData = jsonDecode(decryptedAtKeys);
+    }
+    // This is to decrypt the atKeys encrypted with self Encryption key.
+    return _decryptAtKeysWithSelfEncKey(
+        decodedAtKeysData, atAuthRequest.authMode);
+  }
+
+  static AtAuthKeys _decryptAtKeysWithSelfEncKey(
+      Map<String, dynamic> jsonData, PkamAuthMode authMode) {
+    var securityKeys = AtAuthKeys();
+    String decryptionKey = jsonData[auth_constants.defaultSelfEncryptionKey]!;
+    var atChops =
+        AtChopsImpl(AtChopsKeys()..selfEncryptionKey = AESKey(decryptionKey));
+    securityKeys.defaultEncryptionPublicKey = atChops
+        .decryptString(jsonData[auth_constants.defaultEncryptionPublicKey]!,
+            EncryptionKeyType.aes256,
+            keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+        .result;
+    securityKeys.defaultEncryptionPrivateKey = atChops
+        .decryptString(jsonData[auth_constants.defaultEncryptionPrivateKey]!,
+            EncryptionKeyType.aes256,
+            keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+        .result;
+    securityKeys.defaultSelfEncryptionKey = decryptionKey;
+    securityKeys.apkamPublicKey = atChops
+        .decryptString(
+            jsonData[auth_constants.apkamPublicKey]!, EncryptionKeyType.aes256,
+            keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+        .result;
+    // pkam private key will not be saved in keyfile if auth mode is sim/any other secure element.
+    // decrypt the private key only when auth mode is keysFile
+    if (authMode == PkamAuthMode.keysFile) {
+      securityKeys.apkamPrivateKey = atChops
+          .decryptString(jsonData[auth_constants.apkamPrivateKey]!,
+              EncryptionKeyType.aes256,
+              keyName: 'selfEncryptionKey', iv: AtChopsUtil.generateIVLegacy())
+          .result;
+    }
+    securityKeys.apkamSymmetricKey = jsonData[auth_constants.apkamSymmetricKey];
+    securityKeys.enrollmentId = jsonData[AtConstants.enrollmentId];
+    return securityKeys;
+  }
+}

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -274,6 +274,8 @@ Future<int> wrappedMain(List<String> arguments) async {
                 rootDomain:
                     commandArgResults[AuthCliArgs.argNameAtDirectoryFqdn],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
+      case AuthCliCommand.decrypt:
+        await decryptAtKeys(commandArgResults);
     }
   } on ArgumentError catch (e) {
     stderr
@@ -650,6 +652,8 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
 
         case AuthCliCommand.delete:
           await deleteEnrollment(commandArgResults, atClient);
+        case AuthCliCommand.decrypt:
+          await decryptAtKeys(commandArgResults);
       }
     } on ArgumentError catch (e) {
       stderr.writeln(
@@ -1030,6 +1034,16 @@ Future<void> deleteEnrollment(ArgResults ar, AtClient atClient) async {
   String? response = await atLookup.executeVerb(enrollVerbBuilder);
   response = parseServerResponse(response);
   stdout.writeln('Server response: $response');
+}
+
+Future<void> decryptAtKeys(ArgResults ar) async {
+  AtAuthRequest atAuthRequest = AtAuthRequest(ar[AuthCliArgs.argNameAtSign])
+    ..rootDomain = ar[AuthCliArgs.argNameAtDirectoryFqdn]
+    ..atKeysFilePath = ar[AuthCliArgs.argNameAtKeys]
+    ..passPhrase = ar[AuthCliArgs.argNamePassPhrase];
+
+  AtAuthKeys atAuthKeys = await AtAuthUtils.decryptAtKeys(atAuthRequest);
+  stdout.write(atAuthKeys.toJson());
 }
 
 @visibleForTesting

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -65,7 +65,10 @@ enum AuthCliCommand {
           ' be delivered to some other program(s) which have'
           ' permission to approve or deny the requests. Typically that will be'
           ' the program which first onboarded; however it can also be an enrolled'
-          ' program which has "rw" access to the "__manage" namespace.');
+          ' program which has "rw" access to the "__manage" namespace.'),
+  decrypt(
+      usage:
+          "Decrypts the pass-phrase protected atKeys and writes to the standard output terminal");
 
   const AuthCliCommand({this.usage = ''});
 
@@ -196,6 +199,9 @@ class AuthCliArgs {
 
       case AuthCliCommand.delete:
         return createDeleteCommandParser();
+
+      case AuthCliCommand.decrypt:
+        return createDecryptCommandParser();
     }
   }
 
@@ -508,6 +514,11 @@ class AuthCliArgs {
   ArgParser createDeleteCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p, mandatory: true);
+    return p;
+  }
+
+  ArgParser createDecryptCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -33,6 +33,10 @@ dependencies:
    crypto: ^3.0.5
    chalkdart: ^2.0.9
 
+dependency_overrides:
+  at_auth:
+    path: ../at_auth
+
 dev_dependencies:
   lints: ^5.0.0
   test: ^1.25.8


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add "decrypt" command to prints the decrypted version of pass-phrase protected atKeys file to the terminal.
- Move the logic in at_auth package which decrypts the pass-phrase protected atKeys file from AtAuthImpl to a new class - AtAuthUtils to reuse the logic in the AtOnboardingCli.

**- How I did it**
- In the AtAuth package, Move the method "_prepareAtAuthKeysFromFilePath" which decrypts the AtKeys file content to a new class - AtAuthUtils.
- In AtOnboardingCli, introduce "decrypt" command to the "auth_cli.dart" which will decrypt the pass-phrase protected atKeys files and writes the output to the standard output.
- To decrypt the atKeys file content, construct an AtAuthRequest and pass the request to the "AtAuthUtils->"decryptAtKeys" method which will decrypt and return the original atKeys.
- Write the original atKeys to the terminal.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
