### PR TITLE
fix: Correct temporary path for windows

### DIFF
--- a/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
@@ -72,7 +72,7 @@ class HomeDirectoryUtil {
         .replaceAll('/', Platform.pathSeparator));
   }
 
-  Directory standardWindowsAtClientStorageDir({
+  static Directory standardWindowsAtClientStorageDir({
     required String atSign,
     required String progName, // e.g. npt, sshnp, sshnpd, srvd etc
     required String uniqueID,
@@ -97,7 +97,7 @@ class HomeDirectoryUtil {
     required String uniqueID,
   }) {
     if (Platform.isWindows) {
-      return standardAtClientStorageDir(
+      return standardWindowsAtClientStorageDir(
         atSign: atSign,
         progName: progName,
         uniqueID: uniqueID,


### PR DESCRIPTION

**- What I did**
Found a bug with Windows version of at_authenticate when in interactive mode 
https://github.com/atsign-foundation/noports/issues/1650
Fixed issue in this lib 

**- How I did it**
Found that lib was not be called correctly, made the methos static and made the right call

**- How to verify it**
By hand locally

But please check to see if this might cause other issues ????

This will also need pushing up to pub.dev

**- Description for the changelog**
Fixed library creation of local temp files on Windows
