### PR TITLE
feat(atcommons): Atsign string extensions

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.2.0
+- feat: add Atsign string extensions
 ## 5.1.2
 - fix: remove isPaginated check in SyncVerbBuilder and always set from: and limit: since sync:from verb
   expects these params to be set.

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -2,6 +2,7 @@ library at_commons;
 
 import 'package:meta/meta.dart';
 
+export 'package:at_commons/atsign.dart';
 export 'package:at_commons/src/at_constants.dart';
 export 'package:at_commons/src/at_message.dart';
 export 'package:at_commons/src/buffer/at_buffer.dart';

--- a/packages/at_commons/lib/atsign.dart
+++ b/packages/at_commons/lib/atsign.dart
@@ -1,0 +1,73 @@
+import 'package:at_commons/at_commons.dart';
+
+/// A fully qualified atSign (e.g. @alice)
+typedef Atsign = String;
+
+/// An atSign without the "@" (e.g. alice)
+typedef AtsignWithoutAt = String;
+
+extension AtsignString on String {
+  /// Format and validate string to a fully qualified atSign
+  /// throws [InvalidAtSignException] on failed validation
+  Atsign toAtsign() {
+    return _fixAtSign(this);
+  }
+
+  /// Format and validate string to an atSign without the "@" prefix
+  /// throws [InvalidAtSignException] on failed validation
+  AtsignWithoutAt withoutAt() {
+    return toAtsign().substring(1);
+  }
+}
+
+Atsign _fixAtSign(String atSign) {
+  // @signs are always lowercase Latin
+  if (atSign == '' || atSign.isEmpty) {
+    throw InvalidAtSignException(AtMessage.noAtSign.text);
+  }
+  atSign = atSign.toLowerCase();
+  // if atsign does not start with '@' prepend an '@'
+  if (!atSign.startsWith('@')) {
+    atSign = '@$atSign';
+  }
+  // @signs can only have one @ character in them
+  var noAT = atSign.replaceFirst('@', '');
+  if (noAT.contains(RegExp(r'@'))) {
+    throw InvalidAtSignException(AtMessage.moreThanOneAt.text);
+  }
+  // The dot "." can be used in an @sign but it is removed so @colinconstable is the same as @colin.constable
+  // home.phone@colin stays home.phone@colin
+  // but home.phone@colin.constable gets translated to home.phone@colinconstable
+  // This is for clarity for humans
+  var split = atSign.split('@');
+  var left = split[0].toString();
+  var right = split[1].toString();
+  right = right.replaceAll(r'.', '');
+  if (right.isEmpty) {
+    throw InvalidAtSignException(AtMessage.noAtSign.text);
+  }
+  // reconstruct @sign
+  atSign = '$left@$right';
+  // Some Characters are reserved
+  // If found the @sign should be rejected
+  if (atSign.contains(RegExp(r"[\!\*\'`\(\)\;\:\&\=\+\$\,\/\?\#\[\]\{\}]"))) {
+    throw InvalidAtSignException(AtMessage.reservedCharacterUsed.text);
+  }
+  // White spaces are not allowed in @signs
+  // If found the @sign should be rejected
+  // SPACE,TAB,LINEFEED etc
+  // Ref https://en.wikipedia.org/wiki/Whitespace_character
+  if (atSign.contains(RegExp(
+      r'[\u0020\u0009\u000A\u000B\u000C\u000D\u0085\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000]'))) {
+    throw InvalidAtSignException(AtMessage.whiteSpaceNotAllowed.text);
+  }
+  // ASCII control Characters are not allowed in @signs!
+  if (atSign.contains(RegExp(r'[\u0000-\u001F\u007F]'))) {
+    throw InvalidAtSignException(AtMessage.controlCharacter.text);
+  }
+  // Unicode control Characters are not allowed in @signs
+  if (atSign.contains(RegExp(r'[\u2400-\u241F\u2400\u2421\u2424\u2425]'))) {
+    throw InvalidAtSignException(AtMessage.controlCharacter.text);
+  }
+  return atSign;
+}

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,11 +1,11 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.1.2
+version: 5.2.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
   json_annotation: ^4.9.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added Atsign string extensions to replace AtUtils.fixAtsign.
  - Using an extension on String allows for values to be null coalesced which previous wasn't possible
- AtUtils.fixAtsign now calls String.toAtsign (moved to another PR so that at_commons can be published first)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
feat(atcommons): Atsign string extensions
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
