### PR TITLE
feat: add `immutable` to Metadata and `force:` flag to DeleteVerbBuilder

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.3.0
+- feat: add `immutable` flag to `Metadata` and `force` flag to the 
+  DeleteVerbBuilder. Immutable records may not be updated once the immutable 
+  flag has been set, and may not be deleted unless the `force` flag has been 
+  set in the delete command.
 ## 5.2.0
 - feat: add Atsign string extensions
 - feat: add AtServerEvent interface and AtSignPKChangedEvent class

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -69,6 +69,8 @@ class AtConstants {
   static const String sharedWithPublicKeyHashingAlgo = 'hashingAlgo';
   static const String sharedKeyEncryptedEncryptingKeyName = 'skeEncKeyName';
   static const String sharedKeyEncryptedEncryptingAlgo = 'skeEncAlgo';
+  static const String immutable = 'immutable';
+  static const String force = 'force';
   static const String firstByte = '#';
   static const String createdAt = 'createdAt';
   static const String updatedAt = 'updatedAt';

--- a/packages/at_commons/lib/src/exception/at_exception_utils.dart
+++ b/packages/at_commons/lib/src/exception/at_exception_utils.dart
@@ -38,6 +38,14 @@ class AtExceptionUtils {
         return AtTimeoutException(errorDescription);
       case 'AT0024':
         return ServerIsPausedException(errorDescription);
+      case 'AT0028':
+        return AtThrottleLimitExceeded(errorDescription);
+      case 'AT0029':
+        return AtInvalidEnrollmentException(errorDescription);
+      case 'AT0031':
+        return AtEnrollmentRevokeException(errorDescription);
+      case 'AT0032':
+        return IllegalStateException(errorDescription);
       case 'AT0401':
         return UnAuthenticatedException(errorDescription);
       default:

--- a/packages/at_commons/lib/src/exception/at_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_exceptions.dart
@@ -101,6 +101,11 @@ class InvalidSyntaxException extends AtException {
   InvalidSyntaxException(message) : super(message);
 }
 
+/// Exception thrown when a verb fails due to some state being not as expected
+class IllegalStateException extends AtException {
+  IllegalStateException(message) : super(message);
+}
+
 /// Exception thrown when an atsign name provided is invalid.
 class InvalidAtSignException extends AtException {
   InvalidAtSignException(message) : super(message);

--- a/packages/at_commons/lib/src/exception/error_message.dart
+++ b/packages/at_commons/lib/src/exception/error_message.dart
@@ -23,7 +23,8 @@ const Map error_codes = {
   'ServerIsPausedException': 'AT0024',
   'AtThrottleLimitException': 'AT0028',
   'AtInvalidEnrollmentException': 'AT0029',
-  'AtEnrollmentRevokeException': 'AT0031'
+  'AtEnrollmentRevokeException': 'AT0031',
+  'IllegalStateException': 'AT0032'
 };
 
 // ignore: constant_identifier_names
@@ -55,5 +56,6 @@ const Map error_description = {
   'AT0028': 'Too Many Requests',
   'AT0029': 'Apkam Enrollment Expired',
   'AT0030': 'Invalid Enrollment Status',
-  'AT0031': 'Cannot revoke self enrollment'
+  'AT0031': 'Cannot revoke self enrollment',
+  'AT0032': 'Illegal state exception',
 };

--- a/packages/at_commons/lib/src/exception/error_message.dart
+++ b/packages/at_commons/lib/src/exception/error_message.dart
@@ -21,7 +21,7 @@ const Map error_codes = {
   'IllegalArgumentException': 'AT0022',
   'AtTimeoutException': 'AT0023',
   'ServerIsPausedException': 'AT0024',
-  'AtThrottleLimitException': 'AT0028',
+  'AtThrottleLimitExceeded': 'AT0028',
   'AtInvalidEnrollmentException': 'AT0029',
   'AtEnrollmentRevokeException': 'AT0031',
   'IllegalStateException': 'AT0032'

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -4,7 +4,6 @@ import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
 import 'package:at_commons/src/keystore/public_key_hash.dart';
 import 'package:at_commons/src/utils/at_key_regex_utils.dart';
 import 'package:at_commons/src/utils/string_utils.dart';
-import 'package:meta/meta.dart';
 
 import '../at_constants.dart';
 import '../exception/at_exceptions.dart';
@@ -382,10 +381,6 @@ class LocalKey extends AtKey {
 }
 
 class Metadata {
-  /// When set to `false`, the Map produced by toJson will not include fields whose values are null
-  @visibleForTesting
-  bool fullJson = true;
-
   /// Time in milliseconds after which the [AtKey] expires.
   int? ttl;
 
@@ -521,6 +516,11 @@ class Metadata {
   /// * The default algorithm is `RSA`
   String? skeEncAlgo;
 
+  /// Immutable records may not be changed. They can be deleted, however
+  /// deleting an immutable record will require the `force:` flag to be set
+  /// when executing the `delete` verb.
+  bool immutable = false;
+
   @override
   String toString() {
     return 'Metadata{${jsonEncode(toJson())}}';
@@ -589,88 +589,42 @@ class Metadata {
     if (skeEncAlgo.isNotNullOrEmpty) {
       sb.write(':${AtConstants.sharedKeyEncryptedEncryptingAlgo}:$skeEncAlgo');
     }
+    if (immutable) {
+      sb.write(':${AtConstants.immutable}:$immutable');
+    }
     return sb.toString();
   }
 
   Map toJson() {
     var map = {};
-    if (fullJson || availableAt != null) {
-      map['availableAt'] = availableAt?.toUtc().toString();
-    }
-    if (fullJson || expiresAt != null) {
-      map['expiresAt'] = expiresAt?.toUtc().toString();
-    }
-    if (fullJson || refreshAt != null) {
-      map['refreshAt'] = refreshAt?.toUtc().toString();
-    }
-    if (fullJson || createdAt != null) {
-      map[AtConstants.createdAt] = createdAt?.toUtc().toString();
-    }
-    if (fullJson || updatedAt != null) {
-      map[AtConstants.updatedAt] = updatedAt?.toUtc().toString();
-    }
-    if (fullJson || isPublic) {
-      map['isPublic'] = isPublic;
-    }
-    if (fullJson || ttl != null) {
-      map[AtConstants.ttl] = ttl;
-    }
-    if (fullJson || ttb != null) {
-      map[AtConstants.ttb] = ttb;
-    }
-    if (fullJson || ttr != null) {
-      map[AtConstants.ttr] = ttr;
-    }
-    if (fullJson || ccd != null) {
-      map[AtConstants.ccd] = ccd;
-    }
-    if (fullJson || isBinary) {
-      map[AtConstants.isBinary] = isBinary;
-    }
-    if (fullJson || isEncrypted) {
-      map[AtConstants.isEncrypted] = isEncrypted;
-    }
-    if (fullJson || dataSignature != null) {
-      map[AtConstants.publicDataSignature] = dataSignature;
-    }
-    if (fullJson || sharedKeyStatus != null) {
-      map[AtConstants.sharedKeyStatus] = sharedKeyStatus;
-    }
-    if (fullJson || sharedKeyEnc != null) {
-      map[AtConstants.sharedKeyEncrypted] = sharedKeyEnc;
-    }
+    map['availableAt'] = availableAt?.toUtc().toString();
+    map['expiresAt'] = expiresAt?.toUtc().toString();
+    map['refreshAt'] = refreshAt?.toUtc().toString();
+    map[AtConstants.createdAt] = createdAt?.toUtc().toString();
+    map[AtConstants.updatedAt] = updatedAt?.toUtc().toString();
+    map['isPublic'] = isPublic;
+    map[AtConstants.ttl] = ttl;
+    map[AtConstants.ttb] = ttb;
+    map[AtConstants.ttr] = ttr;
+    map[AtConstants.ccd] = ccd;
+    map[AtConstants.isBinary] = isBinary;
+    map[AtConstants.isEncrypted] = isEncrypted;
+    map[AtConstants.publicDataSignature] = dataSignature;
+    map[AtConstants.sharedKeyStatus] = sharedKeyStatus;
+    map[AtConstants.sharedKeyEncrypted] = sharedKeyEnc;
     // ignore: deprecated_member_use_from_same_package
-    if (fullJson || pubKeyCS != null) {
-      // ignore: deprecated_member_use_from_same_package
-      map[AtConstants.sharedWithPublicKeyCheckSum] = pubKeyCS;
-    }
-    if (fullJson || pubKeyHash != null) {
-      map[AtConstants.sharedWithPublicKeyHash] = pubKeyHash?.toJson();
-    }
-    if (fullJson || encoding != null) {
-      map[AtConstants.encoding] = encoding;
-    }
-    if (fullJson || encKeyName != null) {
-      map[AtConstants.encryptingKeyName] = encKeyName;
-    }
-    if (fullJson || encAlgo != null) {
-      map[AtConstants.encryptingAlgo] = encAlgo;
-    }
-    if (fullJson || ivNonce != null) {
-      map[AtConstants.ivOrNonce] = ivNonce;
-    }
-    if (fullJson || skeEncKeyName != null) {
-      map[AtConstants.sharedKeyEncryptedEncryptingKeyName] = skeEncKeyName;
-    }
-    if (fullJson || skeEncAlgo != null) {
-      map[AtConstants.sharedKeyEncryptedEncryptingAlgo] = skeEncAlgo;
-    }
-    if (fullJson || namespaceAware) {
-      map['namespaceAware'] = namespaceAware;
-    }
-    if (fullJson || isCached) {
-      map['isCached'] = isCached;
-    }
+    map[AtConstants.sharedWithPublicKeyCheckSum] = pubKeyCS;
+    map[AtConstants.sharedWithPublicKeyHash] = pubKeyHash?.toJson();
+    map[AtConstants.encoding] = encoding;
+    map[AtConstants.encryptingKeyName] = encKeyName;
+    map[AtConstants.encryptingAlgo] = encAlgo;
+    map[AtConstants.ivOrNonce] = ivNonce;
+    map[AtConstants.sharedKeyEncryptedEncryptingKeyName] = skeEncKeyName;
+    map[AtConstants.sharedKeyEncryptedEncryptingAlgo] = skeEncAlgo;
+    map[AtConstants.immutable] = immutable;
+    map['namespaceAware'] = namespaceAware;
+    map['isCached'] = isCached;
+
     return map;
   }
 
@@ -730,6 +684,8 @@ class Metadata {
     metaData.skeEncKeyName =
         json[AtConstants.sharedKeyEncryptedEncryptingKeyName];
     metaData.skeEncAlgo = json[AtConstants.sharedKeyEncryptedEncryptingAlgo];
+    metaData.namespaceAware = json['namespaceAware'] ?? false;
+    metaData.immutable = json[AtConstants.immutable] ?? false;
 
     return metaData;
   }
@@ -765,7 +721,8 @@ class Metadata {
           encAlgo == other.encAlgo &&
           ivNonce == other.ivNonce &&
           skeEncKeyName == other.skeEncKeyName &&
-          skeEncAlgo == other.skeEncAlgo;
+          skeEncAlgo == other.skeEncAlgo &&
+          immutable == other.immutable;
 
   @override
   int get hashCode =>
@@ -795,7 +752,8 @@ class Metadata {
       encAlgo.hashCode ^
       ivNonce.hashCode ^
       skeEncKeyName.hashCode ^
-      skeEncAlgo.hashCode;
+      skeEncAlgo.hashCode ^
+      immutable.hashCode;
 }
 
 class AtValue {

--- a/packages/at_commons/lib/src/verb/delete_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/delete_verb_builder.dart
@@ -13,9 +13,15 @@ import 'package:at_commons/src/verb/verb_util.dart';
 ///    var deleteBuilder = DeleteVerbBuilder()..key = '@alice:phone@bob';
 /// ```
 class DeleteVerbBuilder extends AbstractVerbBuilder {
+  bool force = false;
+
   @override
   String buildCommand() {
-    StringBuffer serverCommandBuffer = StringBuffer('delete:${buildKey()}\n');
+    StringBuffer serverCommandBuffer = StringBuffer('delete:');
+    if (force) {
+      serverCommandBuffer.write('force:');
+    }
+    serverCommandBuffer.write('${buildKey()}\n');
     return serverCommandBuffer.toString();
   }
 
@@ -23,10 +29,21 @@ class DeleteVerbBuilder extends AbstractVerbBuilder {
   static DeleteVerbBuilder getBuilder(String command) {
     var builder = DeleteVerbBuilder();
     var verbParams = VerbUtil.getVerbParam(VerbSyntax.delete, command)!;
+
+    builder.atKey.metadata.isPublic =
+        verbParams[AtConstants.publicScopeParam] == 'public';
+    builder.force = verbParams[AtConstants.force] == AtConstants.force;
+    builder.atKey.sharedWith =
+        VerbUtil.formatAtSign(verbParams[AtConstants.forAtSign]);
+    builder.atKey.sharedBy =
+        VerbUtil.formatAtSign(verbParams[AtConstants.atSign]);
     if (verbParams[AtConstants.atKey] == null) {
       throw AtKeyException('Key cannot be null or empty');
     }
     builder.atKey.key = verbParams[AtConstants.atKey]!;
+
+    builder.validateKey();
+
     return builder;
   }
 

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -47,7 +47,8 @@ class VerbSyntax {
       r'(:encAlgo:(?<encAlgo>[^:@\s]+))?'
       r'(:ivNonce:(?<ivNonce>[^:@\s]+))?'
       r'(:skeEncKeyName:(?<skeEncKeyName>[^:@\s]+))?'
-      r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?';
+      r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?'
+      r'(:immutable:(?<immutable>true|false))?';
 
   static const update = r'^update:json:(?<json>.+)$'
       r'|'
@@ -67,6 +68,7 @@ class VerbSyntax {
       '$metadataFragment'
       r'$';
   static const delete = r'^delete'
+      r'(:(?<force>force))?'
       r'(:priority:(?<priority>low|medium|high))?'
       r'(:cached)?'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -162,6 +162,10 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
           verbParams[AtConstants.sharedWithPublicKeyHashingAlgo]!);
     }
 
+    if (verbParams[AtConstants.immutable] != null) {
+      builder.atKey.metadata.immutable =
+          _getBoolVerbParams(verbParams[AtConstants.immutable]!);
+    }
     builder.value = verbParams[AtConstants.value];
 
     return builder;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.2.0
+version: 5.3.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -999,11 +999,15 @@ void main() {
       expect(metadataMap['ivNonce'], null);
       expect(metadataMap['skeEncKeyName'], null);
       expect(metadataMap['skeEncAlgo'], null);
+      expect(metadataMap['immutable'], false);
       expect(metadataMap['pubKeyHash'], null);
     });
 
-    test('A test to verify toJson when metadata is populated', () {
-      Metadata metadata = Metadata()
+    Metadata createMetadata({
+      required bool immutable,
+      bool namespaceAware = false,
+    }) {
+      return Metadata()
         ..ttl = 100
         ..ttb = 100
         ..ttr = 1
@@ -1016,7 +1020,7 @@ void main() {
         ..dataSignature = 'dummy_data_signature'
         ..sharedKeyStatus = 'delivered'
         ..isPublic = true
-        ..namespaceAware = false
+        ..namespaceAware = namespaceAware
         ..isBinary = true
         ..isEncrypted = true
         ..isCached = false
@@ -1027,7 +1031,12 @@ void main() {
         ..encAlgo = 'RSA'
         ..ivNonce = '16'
         ..skeEncKeyName = 'dummy_enc_key_name'
-        ..skeEncAlgo = 'RSA';
+        ..skeEncAlgo = 'RSA'
+        ..immutable = immutable;
+    }
+
+    verifyToJson({required bool immutable}) {
+      Metadata metadata = createMetadata(immutable: immutable);
       Map metadataMap = metadata.toJson();
       expect(metadataMap['ttl'], 100);
       expect(metadataMap['ttb'], 100);
@@ -1058,6 +1067,47 @@ void main() {
       expect(metadataMap['ivNonce'], '16');
       expect(metadataMap['skeEncKeyName'], 'dummy_enc_key_name');
       expect(metadataMap['skeEncAlgo'], 'RSA');
+      expect(metadataMap['immutable'], immutable);
+    }
+
+    test('verify toJson when immutable is false', () {
+      verifyToJson(immutable: false);
+    });
+    test('verify toJson when immutable is true', () {
+      verifyToJson(immutable: true);
+    });
+
+    test('verify json roundtrip with immutable false namespaceAware false', () {
+      Metadata metadata = createMetadata(
+        immutable: false,
+        namespaceAware: false,
+      );
+      Metadata roundTripped = Metadata.fromJson(metadata.toJson());
+      expect(roundTripped.toJson(), metadata.toJson());
+    });
+    test('verify json roundtrip with immutable true namespaceAware false', () {
+      Metadata metadata = createMetadata(
+        immutable: true,
+        namespaceAware: false,
+      );
+      Metadata roundTripped = Metadata.fromJson(metadata.toJson());
+      expect(metadata.toJson(), roundTripped.toJson());
+    });
+    test('verify json roundtrip with immutable false namespaceAware true', () {
+      Metadata metadata = createMetadata(
+        immutable: false,
+        namespaceAware: true,
+      );
+      Metadata roundTripped = Metadata.fromJson(metadata.toJson());
+      expect(roundTripped.toJson(), metadata.toJson());
+    });
+    test('verify json roundtrip with immutable true namespaceAware true', () {
+      Metadata metadata = createMetadata(
+        immutable: true,
+        namespaceAware: true,
+      );
+      Metadata roundTripped = Metadata.fromJson(metadata.toJson());
+      expect(metadata.toJson(), roundTripped.toJson());
     });
   });
   group('A group of tests to verify key length validation', () {

--- a/packages/at_commons/test/delete_verb_test.dart
+++ b/packages/at_commons/test/delete_verb_test.dart
@@ -30,6 +30,63 @@ void main() {
 
       expect(deleteVerbBuilder.buildCommand(), 'delete:public:phone@bob\n');
     });
+
+    test('test buildCommand with the force flag', () {
+      var deleteVerbBuilder = DeleteVerbBuilder()
+        ..atKey.metadata.isPublic = true
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob'
+        ..force = true;
+
+      expect(
+          deleteVerbBuilder.buildCommand(), 'delete:force:public:phone@bob\n');
+    });
+
+    test('test getBuilder with the force flag on a public key', () {
+      String command = 'delete:force:public:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder with the force flag on a self key without sharedWith',
+        () {
+      String command = 'delete:force:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder with the force flag on a self key with sharedWith',
+        () {
+      String command = 'delete:force:@bob:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder with the force flag on a shared key', () {
+      String command = 'delete:force:@alice:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder without the force flag on a public key', () {
+      String command = 'delete:public:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test(
+        'test getBuilder without the force flag on a self key without sharedWith',
+        () {
+      String command = 'delete:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder without the force flag on a self key with sharedWith',
+        () {
+      String command = 'delete:@bob:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
+    test('test getBuilder without the force flag on a shared key', () {
+      String command = 'delete:@alice:phone.wavi@bob\n';
+      var deleteVerbBuilder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(deleteVerbBuilder.buildCommand(), command);
+    });
   });
 
   group('A group of tests to validate the exceptions', () {

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -387,7 +387,10 @@ void main() {
       expect(updateVerbBuilder.buildKey(), 'public:phone@alice');
     });
 
-    UpdateVerbBuilder createBuilderWithAllMetadata({String? sharedWith}) {
+    UpdateVerbBuilder createBuilderWithAllMetadata({
+      String? sharedWithOrPublic,
+      required bool immutable,
+    }) {
       var ttl = 12345;
       var ttb = 54321;
       var ccd = false;
@@ -407,8 +410,9 @@ void main() {
       return UpdateVerbBuilder()
         ..atKey.key = 'phone.details.wavi'
         ..atKey.sharedBy = '@alice'
-        ..atKey.sharedWith = sharedWith
-        ..atKey.metadata.isPublic = (sharedWith == null)
+        ..atKey.sharedWith =
+            sharedWithOrPublic == 'public' ? null : sharedWithOrPublic
+        ..atKey.metadata.isPublic = (sharedWithOrPublic == 'public')
         ..atKey.metadata.ttl = ttl
         ..atKey.metadata.ttb = ttb
         ..atKey.metadata.ccd = ccd
@@ -426,50 +430,21 @@ void main() {
         ..atKey.metadata.ivNonce = ivNonce
         ..atKey.metadata.skeEncKeyName = skeEncKeyName
         ..atKey.metadata.skeEncAlgo = skeEncAlgo
+        ..atKey.metadata.immutable = immutable
         ..value = 'HELLO_WORLD';
     }
-
-    /*test(
-        'verify metadata is fully passed from builder to the atKeyObj which is built by buildKey',
-        () {
-      var updateVerbBuilder = createBuilderWithAllMetadata(sharedWith: '@bob');
-      expect(updateVerbBuilder.buildKey(), '@bob:phone.details.wavi@alice');
-      expect(updateVerbBuilder.atKeyObj.metadata!.ttl, updateVerbBuilder.ttl);
-      expect(updateVerbBuilder.atKeyObj.metadata!.ttb, updateVerbBuilder.ttb);
-      expect(updateVerbBuilder.atKeyObj.metadata!.ccd, updateVerbBuilder.ccd);
-      expect(updateVerbBuilder.atKeyObj.metadata!.ttr, updateVerbBuilder.ttr);
-      expect(updateVerbBuilder.atKeyObj.metadata!.dataSignature,
-          updateVerbBuilder.dataSignature);
-      expect(updateVerbBuilder.atKeyObj.metadata!.sharedKeyStatus,
-          updateVerbBuilder.sharedKeyStatus);
-      expect(updateVerbBuilder.atKeyObj.metadata!.isBinary,
-          updateVerbBuilder.atKeyObj.metadata!.isBinary);
-      expect(updateVerbBuilder.atKeyObj.metadata!.isEncrypted,
-          updateVerbBuilder.atKeyObj.metadata!.isEncrypted);
-      expect(updateVerbBuilder.atKeyObj.metadata!.sharedKeyEnc,
-          updateVerbBuilder.atKeyObj.metadata!.sharedKeyEnc);
-      expect(updateVerbBuilder.atKeyObj.metadata!.pubKeyCS,
-          updateVerbBuilder.atKeyObj.metadata!.pubKeyCS);
-      expect(updateVerbBuilder.atKeyObj.metadata!.encoding,
-          updateVerbBuilder.atKeyObj.metadata!.encoding);
-      expect(updateVerbBuilder.atKeyObj.metadata!.encKeyName,
-          updateVerbBuilder.atKeyObj.metadata!.encKeyName);
-      expect(updateVerbBuilder.atKeyObj.metadata!.encAlgo,
-          updateVerbBuilder.atKeyObj.metadata!.encAlgo);
-      expect(updateVerbBuilder.atKeyObj.metadata!.ivNonce,
-          updateVerbBuilder.atKeyObj.metadata!.ivNonce);
-      expect(updateVerbBuilder.atKeyObj.metadata!.skeEncKeyName,
-          updateVerbBuilder.atKeyObj.metadata!.skeEncKeyName);
-      expect(updateVerbBuilder.atKeyObj.metadata!.skeEncAlgo,
-          updateVerbBuilder.atKeyObj.metadata!.skeEncAlgo);
-    });*/
 
     group(
         'A group of tests to verify round-tripping of update commands from buildCommand and getBuilder',
         () {
-      UpdateVerbBuilder roundTripUpdateTest({String? sharedWith}) {
-        var initialBuilder =
-            createBuilderWithAllMetadata(sharedWith: sharedWith);
+      UpdateVerbBuilder roundTripUpdateTest({
+        required String? sharedWithOrPublic,
+        required bool immutable,
+      }) {
+        var initialBuilder = createBuilderWithAllMetadata(
+          sharedWithOrPublic: sharedWithOrPublic,
+          immutable: immutable,
+        );
         var command = initialBuilder.buildCommand();
         var roundTrippedBuilder = UpdateVerbBuilder.getBuilder(command.trim());
         expect(initialBuilder == roundTrippedBuilder, true);
@@ -479,20 +454,62 @@ void main() {
       test(
           'verify round trip from builder, to command for update, back to builder, for public key',
           () {
-        var roundTrippedBuilder = roundTripUpdateTest(sharedWith: null);
+        var roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: 'public',
+          immutable: false,
+        );
         expect(roundTrippedBuilder.atKey.metadata.isPublic, true);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+        roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: 'public',
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, true);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
       });
 
       test(
           'verify round trip from builder, to command for update, back to builder, for shared key',
           () {
-        var roundTrippedBuilder = roundTripUpdateTest(sharedWith: '@bob');
+        var roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: '@bob',
+          immutable: false,
+        );
         expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+        roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: '@bob',
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
       });
 
-      UpdateVerbBuilder roundTripUpdateMetaTest({String? sharedWith}) {
-        var initialBuilder =
-            createBuilderWithAllMetadata(sharedWith: sharedWith);
+      test(
+          'verify round trip from builder, to command for update, back to builder, for self key',
+          () {
+        var roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: null,
+          immutable: false,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+        roundTrippedBuilder = roundTripUpdateTest(
+          sharedWithOrPublic: null,
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
+      });
+
+      UpdateVerbBuilder roundTripUpdateMetaTest({
+        required String? sharedWithOrPublic,
+        required bool immutable,
+      }) {
+        var initialBuilder = createBuilderWithAllMetadata(
+          sharedWithOrPublic: sharedWithOrPublic,
+          immutable: immutable,
+        );
         initialBuilder.operation = AtConstants.updateMeta;
 
         // When the update:meta command is built, it will NOT include the value, so
@@ -513,14 +530,51 @@ void main() {
       test(
           'verify round trip from builder, to command for update meta, back to builder, for public key',
           () {
-        var roundTrippedBuilder = roundTripUpdateMetaTest(sharedWith: null);
+        var roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: 'public',
+          immutable: false,
+        );
         expect(roundTrippedBuilder.atKey.metadata.isPublic, true);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+
+        roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: 'public',
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, true);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
       });
       test(
           'verify round trip from builder, to command for update meta, back to builder, for shared key',
           () {
-        var roundTrippedBuilder = roundTripUpdateMetaTest(sharedWith: '@bob');
+        var roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: '@bob',
+          immutable: false,
+        );
         expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+        roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: '@bob',
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
+      });
+      test(
+          'verify round trip from builder, to command for update meta, back to builder, for self key',
+          () {
+        var roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: null,
+          immutable: false,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, false);
+        roundTrippedBuilder = roundTripUpdateMetaTest(
+          sharedWithOrPublic: null,
+          immutable: true,
+        );
+        expect(roundTrippedBuilder.atKey.metadata.isPublic, false);
+        expect(roundTrippedBuilder.atKey.metadata.immutable, true);
       });
     });
   });


### PR DESCRIPTION
**- What I did**
feat: add `immutable` to Metadata and `force:` flag to DeleteVerbBuilder
Part of https://github.com/atsign-foundation/at_protocol/issues/65

**- How I did it**
- immutable
  - Added to `VerbSyntax.metadataFragment`
  - Add to Metadata class, modified its toAtProtocolFragment, toJson, fromJson, operator == and hashCode functions accordingly
  - Modified UpdateVerbBuilder.getBuilder accordingly, and added to its unit tests
  - Added unit tests
- force
  - Added to `VerbSyntax.delete`
  - Added to DeleteVerbBuilder, modified its buildCommand accordingly, fixed its getBuilder
  - Added tests using the force flag
  - Added tests round-tripping from command to builder to command
- other
  - Added "namespaceAware" to fromJson to help with test cases round-tripping toJson / fromJson

**- How to verify it**
Tests pass

