### PR TITLE
fix: (at_onboarding_cli): write keys before deleting cram secret 

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+- feat: enable callers of `AtAuth.onboard` to control post-auth activation
+  completion (set the encryption public key on the server, delete the "cram"
+  secret)
+
 ## 2.1.0
 - fix: potential bug handling atSigns which end in `data` e.g. `@foo_data`
 

--- a/packages/at_auth/lib/src/at_auth_base.dart
+++ b/packages/at_auth/lib/src/at_auth_base.dart
@@ -14,12 +14,23 @@ abstract class AtAuth {
   Future<AtAuthResponse> authenticate(AtAuthRequest atAuthRequest);
 
   /// Onboard method is invoked when an atsign is activated for the first time from a client app.
-  /// Step 1. Perform cram auth
-  /// Step 2. Generate pkam, encryption keypairs and apkam symmetric key
-  /// Step 3. Update pkam public key to secondary
-  /// Step 4. Perform pkam auth
-  /// Step 5. Update encryption public key to server and delete cram secret from server
+  /// - Connect, and perform cram auth
+  /// - Generate pkam, encryption keypairs and apkam symmetric key
+  /// - Update pkam public key to secondary
+  /// - Close connection
+  /// - Reconnect, and perform pkam auth
+  /// - If required (legacy behaviour, but not recommended), then call
+  /// [completeActivation]
+  /// <p/>
+  ///
   /// Set [atOnboardingRequest.publicKeyId] if pkam auth mode is [PkamAuthMode.sim]
   Future<AtOnboardingResponse> onboard(
-      AtOnboardingRequest atOnboardingRequest, String cramSecret);
+    AtOnboardingRequest atOnboardingRequest,
+    String cramSecret, {
+    bool autoCompleteActivation = true,
+  });
+
+  /// - Update encryption public key to server
+  /// - Delete cram secret from server
+  Future<void> completeActivation();
 }

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -98,9 +98,17 @@ class AtAuthImpl implements AtAuth {
       ..atAuthKeys = atAuthKeys;
   }
 
+  /// Keep some state so callers can call [completeActivation] later
+  late AtAuthKeys _atAuthKeys;
+  late AtOnboardingRequest _atOnboardingRequest;
+
   @override
   Future<AtOnboardingResponse> onboard(
-      AtOnboardingRequest atOnboardingRequest, String cramSecret) async {
+    AtOnboardingRequest atOnboardingRequest,
+    String cramSecret, {
+    bool autoCompleteActivation = true,
+  }) async {
+    _atOnboardingRequest = atOnboardingRequest;
     var atOnboardingResponse = AtOnboardingResponse(atOnboardingRequest.atSign);
     atEnrollmentBase = AtEnrollmentImpl(atOnboardingRequest.atSign);
     atLookUp ??= AtLookupImpl(atOnboardingRequest.atSign,
@@ -116,10 +124,10 @@ class AtAuthImpl implements AtAuth {
           ' and try again (or) contact support@atsign.com');
     }
     //2. generate key pairs
-    var atAuthKeys = _generateKeyPairs(atOnboardingRequest.authMode,
+    _atAuthKeys = _generateKeyPairs(atOnboardingRequest.authMode,
         publicKeyId: atOnboardingRequest.publicKeyId);
 
-    atChops ??= _createAtChops(atAuthKeys);
+    atChops ??= _createAtChops(_atAuthKeys);
     atLookUp!.atChops = atChops;
 
     //3. send onboarding enrollment
@@ -127,8 +135,8 @@ class AtAuthImpl implements AtAuth {
     // server will update the apkam public key during enrollment.
     // So don't have to manually update apkam public key in this scenario.
     enrollmentIdFromServer = await _sendOnboardingEnrollment(
-        atOnboardingRequest, atAuthKeys, atLookUp!);
-    atAuthKeys.enrollmentId = enrollmentIdFromServer;
+        atOnboardingRequest, _atAuthKeys, atLookUp!);
+    _atAuthKeys.enrollmentId = enrollmentIdFromServer;
 
     //4. Close connection to server
     try {
@@ -157,13 +165,27 @@ class AtAuthImpl implements AtAuth {
       throw AtAuthenticationException('Pkam auth returned false');
     }
 
-    //7. If Pkam auth is success, update encryption public key to secondary
-    // and delete cram key from server
-    final encryptionPublicKey = atAuthKeys.defaultEncryptionPublicKey;
+    //7. If so specified (default behaviour) then
+    // - set the public encryption key
+    // - delete the cram secret from the keystore
+    if (autoCompleteActivation) {
+      await completeActivation();
+    }
+
+    atOnboardingResponse.isSuccessful = true;
+    atOnboardingResponse.enrollmentId = enrollmentIdFromServer;
+    atOnboardingResponse.atAuthKeys = _atAuthKeys;
+
+    return atOnboardingResponse;
+  }
+
+  @override
+  Future<void> completeActivation() async {
+    final encryptionPublicKey = _atAuthKeys.defaultEncryptionPublicKey;
     UpdateVerbBuilder updateBuilder = UpdateVerbBuilder()
       ..atKey = (AtKey()
         ..key = 'publickey'
-        ..sharedBy = atOnboardingRequest.atSign
+        ..sharedBy = _atOnboardingRequest.atSign
         ..metadata = (Metadata()
           ..isPublic = true
           ..ttr = -1))
@@ -171,15 +193,10 @@ class AtAuthImpl implements AtAuth {
     String? encryptKeyUpdateResult = await atLookUp!.executeVerb(updateBuilder);
     _logger.info('Encryption public key update result $encryptKeyUpdateResult');
 
-    //8.  Delete cram secret from the keystore as cram auth is complete
     DeleteVerbBuilder deleteBuilder = DeleteVerbBuilder()
       ..atKey = (AtKey()..key = AtConstants.atCramSecret);
     String? deleteResponse = await atLookUp!.executeVerb(deleteBuilder);
     _logger.info('Cram secret delete response : $deleteResponse');
-    atOnboardingResponse.isSuccessful = true;
-    atOnboardingResponse.enrollmentId = enrollmentIdFromServer;
-    atOnboardingResponse.atAuthKeys = atAuthKeys;
-    return atOnboardingResponse;
   }
 
   AtChops _createAtChops(AtAuthKeys atKeysFile) {

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.1.0
+version: 2.2.0
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.9.0
+
+- fix: have `onboard` only perform post-auth activation completion once the 
+  atKeys file has been successfully saved.
+
 ## 1.8.3
 - fix: potential bug handling atSigns which end in `data` e.g. `@foo_data`
 

--- a/packages/at_onboarding_cli/lib/at_onboarding_cli.dart
+++ b/packages/at_onboarding_cli/lib/at_onboarding_cli.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'src/onboard/at_onboarding_service.dart';
+export 'src/util/at_onboarding_exceptions.dart';
 export 'src/onboard/at_onboarding_service_impl.dart';
 export 'src/register_cli/register.dart';
 export 'src/util/at_onboarding_preference.dart';

--- a/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/activate_cli/activate_cli.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_utils/at_logger.dart';
 
 @Deprecated('Use auth_cli')

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -9,7 +9,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_onboarding_cli/src/util/create_at_client_cli.dart';
 import 'package:at_onboarding_cli/src/util/print_full_parser_usage.dart';
 import 'package:at_utils/at_utils.dart';

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -8,9 +8,16 @@ import 'package:at_lookup/at_lookup.dart';
 abstract class AtOnboardingService {
   static const Duration defaultApkamRetryInterval = Duration(seconds: 10);
 
-  /// Perform initial one_time authentication to activate the atsign
-  /// returns true if successfully onboarded
-  Future<bool> onboard();
+  /// Perform initial one_time authentication to activate the atsign. Returns
+  /// true if successfully onboarded.
+  ///
+  /// When [autoCompleteActivation] is false, callers are responsible for
+  /// calling [completeActivation]
+  Future<bool> onboard({bool autoCompleteActivation = true});
+
+  /// - Update encryption public key to server
+  /// - Delete cram secret from server
+  Future<void> completeActivation();
 
   /// Authenticate into secondary server using PKAM privateKey for legacy clients
   ///

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -11,7 +11,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_onboarding_cli/src/factory/service_factories.dart';
-import 'package:at_onboarding_cli/src/util/at_onboarding_exceptions.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_server_status/at_server_status.dart';
 import 'package:at_utils/at_utils.dart';
@@ -83,7 +82,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   @override
-  Future<bool> onboard() async {
+  Future<bool> onboard({bool autoCompleteActivation = true}) async {
     // cram auth doesn't use at_chops. So create at_lookup here.
     AtLookupImpl atLookUpImpl = AtLookupImpl(_atSign,
         atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
@@ -117,8 +116,12 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     atOnboardingRequest.publicKeyId = atOnboardingPreference.publicKeyId;
     atOnboardingRequest.authMode = atOnboardingPreference.authMode;
 
-    AtOnboardingResponse atOnboardingResponse = await atAuth!
-        .onboard(atOnboardingRequest, atOnboardingPreference.cramSecret!);
+    AtOnboardingResponse atOnboardingResponse = await atAuth!.onboard(
+      atOnboardingRequest,
+      atOnboardingPreference.cramSecret!,
+      autoCompleteActivation: false, // we want to control this here
+    );
+
     logger.finer('Onboarding Response: $atOnboardingResponse');
     if (atOnboardingResponse.isSuccessful) {
       logger.finer(
@@ -127,9 +130,18 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         atOnboardingResponse.atAuthKeys!,
         enrollmentId: atOnboardingResponse.enrollmentId,
       );
+
+      if (autoCompleteActivation) {
+        await completeActivation();
+      }
     }
     _isAtsignOnboarded = atOnboardingResponse.isSuccessful;
     return _isAtsignOnboarded;
+  }
+
+  @override
+  Future<void> completeActivation() async {
+    await atAuth!.completeActivation();
   }
 
   @override

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.8.3
+version: 1.9.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -12,6 +12,9 @@ executables:
   at_register: register_cli
   at_activate: activate_cli
 
+dependency_overrides:
+  at_auth:
+    path: ../at_auth
 dependencies:
    args: ^2.5.0
    crypton: ^2.2.1
@@ -21,7 +24,7 @@ dependencies:
    meta: ^1.14.0
    path: ^1.9.0
    zxing2: ^0.2.0
-   at_auth: ^2.0.10
+   at_auth: ^2.2.0
    at_chops: ^2.2.0
    at_client: ^3.3.0
    at_commons: ^5.0.2

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 dependency_overrides:
   at_onboarding_cli:
     path: "../../packages/at_onboarding_cli"
+  at_auth:
+    path: "../../packages/at_auth"
 
 dev_dependencies:
   lints: ^5.1.1

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -170,14 +170,14 @@ void main() {
         try {
           await onboard(true);
         } catch (e) {
-          print('Caught an ${e.runtimeType} as expected');
+          print('Caught an ${e.runtimeType} as expected ($e)');
           rethrow;
         }
       },
           throwsA(predicate((dynamic e) =>
               e is AtActivateException &&
               e.message ==
-                  'atsign @local_onboarding_test is already activated')));
+                  'atsign $atSign is already activated')));
     });
 
     tearDown(() async {

--- a/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/at_onboarding_cli_test.dart
@@ -13,6 +13,7 @@ import 'utils/onboarding_service_impl_override.dart';
 
 final String atKeysFilePath = '${Platform.environment['HOME']}/.atsign/keys';
 Map<String, bool> keysCreatedMap = {};
+
 void main() {
   AtSignLogger.root_level = 'WARNING';
 
@@ -137,33 +138,46 @@ void main() {
   });
 
   group('A group of tests to verify onboard functionality', () {
-    String atSign = '@egcovidlab🛠';
-    AtOnboardingPreference atOnboardingPreference = getPreferences(atSign);
+    test('Onboard and verify failure modes', () async {
+      String atSign = '@egcovidlab🛠';
+      AtOnboardingPreference atOnboardingPreference = getPreferences(atSign);
 
-    test(
-        'A test to verify atSign is onboarded and .atKeys file is generated successfully',
-        () async {
-      AtOnboardingService atOnboardingService =
-          AtOnboardingServiceImpl(atSign, atOnboardingPreference);
-      bool status = await atOnboardingService.onboard();
-      expect(status, true);
-      // verify whether ttr is set in public encryption key
-      final atLookup = AtLookupImpl(atSign, atOnboardingPreference.rootDomain,
-          atOnboardingPreference.rootPort);
-      var encryptionPublicKey =
-          await atLookup.executeCommand('lookup:all:publickey$atSign\n');
-      expect(encryptionPublicKey, isNotNull);
-      encryptionPublicKey = encryptionPublicKey?.replaceFirst(RegExp(r'^data:'), '');
-      expect(jsonDecode(encryptionPublicKey!)['metaData'], isNotNull);
-      expect(jsonDecode(encryptionPublicKey)['metaData']['ttr'], -1);
-      print('encryptionPublicKey: $encryptionPublicKey');
-      bool status2 = await atOnboardingService.authenticate();
-      expect(status2, true);
-      expect(await atOnboardingService.isOnboarded(), true);
+      Future<void> onboard(bool autoCompleteActivation) async {
+        AtOnboardingService atOnboardingService = AtOnboardingServiceImpl(
+          atSign,
+          atOnboardingPreference,
+        );
+        bool status = await atOnboardingService.onboard(
+          autoCompleteActivation: autoCompleteActivation,
+        );
+        expect(status, true);
+        expect(await atOnboardingService.isOnboarded(), autoCompleteActivation);
 
-      /// Assert .atKeys file is generated for the atSign
-      expect(await File(atOnboardingPreference.atKeysFilePath!).exists(), true);
-      await atLookup.close();
+        File atKeysFile = File(atOnboardingPreference.atKeysFilePath!);
+
+        /// Assert .atKeys file is generated for the atSign
+        expect(await atKeysFile.exists(), true);
+      }
+
+      // onboard without removing cram secret
+      await onboard(false);
+
+      // do it again, but remove the cram secret (should succeed)
+      await onboard(true);
+
+      // try to do it again (should fail)
+      await expectLater(() async {
+        try {
+          await onboard(true);
+        } catch (e) {
+          print('Caught an ${e.runtimeType} as expected');
+          rethrow;
+        }
+      },
+          throwsA(predicate((dynamic e) =>
+              e is AtActivateException &&
+              e.message ==
+                  'atsign @local_onboarding_test is already activated')));
     });
 
     tearDown(() async {


### PR DESCRIPTION
**- What I did**
Fixes #763 
- at_auth:
  - feat: enable callers of `AtAuth.onboard` to control post-auth activation completion (set the encryption public key on the server, delete the "cram" secret)
- at_onboarding_cli:
  - fix: have `AtOnboardingServiceImpl.onboard` only perform post-auth activation completion once the atKeys file has been successfully saved
  - feat: Enable callers of `AtOnboardingServiceImpl.onboard` to control post-auth activation completion (set the encryption public key on the server, delete the "cram" secret)
- at_onboarding_cli_functional_tests:
  - test: Have the onboarding test call onboard three times instead of once:
    1. onboard and write atKeys file, but do not "complete activation" post-auth
    2. onboard again, and complete the activation - should succeed because activation was not completed before
    3. onboard again - will fail because the activation was previously completed

**- How I did it**
See commits

**- How to verify it**
Tests pass

