### PR TITLE
build: at_onboarding_cli: remove temporary dependency override

### DIFF
--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -12,9 +12,6 @@ executables:
   at_register: register_cli
   at_activate: activate_cli
 
-dependency_overrides:
-  at_auth:
-    path: ../at_auth
 dependencies:
    args: ^2.5.0
    crypton: ^2.2.1


### PR DESCRIPTION
**- What I did**
Remove dependency override for at_auth now that [at_auth 2.2.0](https://pub.dev/packages/at_auth/versions/2.2.0) has been published

Closes #763 

**- How I did it**

**- How to verify it**
Tests pass