### PR TITLE
feat: at_commons: Add `EnrollmentConstants`

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.4.0
+- feat: add `EnrollmentConstants`. Contains various patterns and regular 
+  expressions for enrollment-related data
 ## 5.3.0
 - feat: add `immutable` flag to `Metadata` and `force` flag to the 
   DeleteVerbBuilder. Immutable records may not be updated once the immutable 

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -29,6 +29,7 @@ export 'package:at_commons/src/verb/update_json.dart';
 export 'package:at_commons/src/verb/verb_util.dart';
 export 'package:at_commons/src/auth/auth_mode.dart';
 export 'package:at_commons/src/verb/enroll_params.dart';
+export 'package:at_commons/src/enroll/enrollment_constants.dart';
 export 'package:at_commons/src/enroll/enrollment.dart';
 export 'package:at_commons/src/utils/at_key_regex_utils.dart';
 @experimental

--- a/packages/at_commons/lib/src/enroll/enrollment_constants.dart
+++ b/packages/at_commons/lib/src/enroll/enrollment_constants.dart
@@ -1,0 +1,22 @@
+import 'package:at_commons/at_commons.dart';
+
+class EnrollmentConstants {
+  static const String enrollManageNamespace = '__manage';
+  static const String enrollmentKeyPattern = 'new.enrollments';
+  static const String enrollmentsRegex =
+      '\\.new\\.enrollments\\.${EnrollmentConstants.enrollManageNamespace}@';
+  static const String regexForPEK =
+      '.*\\.${AtConstants.defaultEncryptionPrivateKey}\\.${EnrollmentConstants.enrollManageNamespace}@';
+  static const String regexForEnrollmentKey =
+      '^[^\\.]+\\.${EnrollmentConstants.enrollmentKeyPattern}\\.${EnrollmentConstants.enrollManageNamespace}@';
+  static const String regexForSEK =
+      '.*\\.${AtConstants.defaultSelfEncryptionKey}\\.${EnrollmentConstants.enrollManageNamespace}@';
+  static const String pkamNamespace = '__pkams';
+  static const String globalNamespace = '__global';
+  static const String allNamespaces = '*';
+  static const String perEnrollmentApproved = 'a.__e';
+  static const String perEnrollmentRevoked = 'r.__e';
+  static const String perEnrollmentDeleted = 'd.__e';
+  static const String regexForPerEnrollmentNamespaces =
+      '\\.(?<EnId>[^\\.]+)\\.[ard]\\.__e@';
+}

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.3.0
+version: 5.4.0
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 


### PR DESCRIPTION
**- What I did**
feat: add `EnrollmentConstants`. Contains various patterns and regular expressions for enrollment-related data. (Moving from a PR in at_server as these constants are useful for both atClient and atServer

**- How I did it**
See commits

**- How to verify it**
Tests pass

