### PR TITLE
build: Use latest at_client in order to remove unnecessary direct dependency from at_onboarding_cli

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.1
+- feat: remove unnecessary dependency on at_persistence_secondary_server
+
 ## 1.10.0
 
 - feat: better user feedback during onboarding / enrollment / etc

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -11,7 +11,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
 import 'package:at_onboarding_cli/src/factory/service_factories.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_server_status/at_server_status.dart';
 import 'package:at_utils/at_progress.dart';
 import 'package:at_utils/at_utils.dart';
@@ -193,22 +192,13 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
     await _initAtClient(_atLookUp!.atChops!,
         enrollmentId: enrollmentResponse.enrollmentId);
-    var atData = AtData();
     var enrollmentDetails = EnrollmentDetails();
     enrollmentDetails.namespace = namespaces;
-    atData.data = jsonEncode(enrollmentDetails);
-    // Cannot use atClient.put since The "_isAuthorized" method fetches enrollment
-    // info from the key-store. Since there is no enrollment info,
-    // it returns null and throws throws AtKeyNotFoundException.
     var localEnrollmentKey = AtKey()
       ..isLocal = true
       ..key = enrollmentResponse.enrollmentId
       ..sharedBy = atClient!.getCurrentAtSign();
-    final putResult = await atClient!
-        .getLocalSecondary()!
-        .keyStore!
-        .put(localEnrollmentKey.toString(), atData);
-    logger.finer('putResult for storing enrollment details: $putResult');
+    await atClient!.put(localEnrollmentKey, jsonEncode(enrollmentDetails));
 
     await createAtKeysFile(
       enrollmentResponse,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -198,7 +198,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       ..isLocal = true
       ..key = enrollmentResponse.enrollmentId
       ..sharedBy = atClient!.getCurrentAtSign();
-    await atClient!.put(localEnrollmentKey, jsonEncode(enrollmentDetails));
+    await atClient!.getLocalSecondary()!.putValue(
+          localEnrollmentKey.toString(),
+          jsonEncode(enrollmentDetails.toJson()),
+        );
 
     await createAtKeysFile(
       enrollmentResponse,

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
    zxing2: ^0.2.0
    at_auth: ^2.2.0
    at_chops: ^2.2.0
-   at_client: ^3.3.0
+   at_client: ^3.4.3
    at_commons: ^5.0.2
    at_lookup: ^3.0.52
    at_server_status: ^1.0.5
@@ -32,13 +32,6 @@ dependencies:
    duration: ^4.0.3
    crypto: ^3.0.5
    chalkdart: ^2.0.9
-
-dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: at-rpc-enable-same-atsign
-      path: packages/at_client
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.10.0
+version: 1.10.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -29,10 +29,16 @@ dependencies:
    at_lookup: ^3.0.52
    at_server_status: ^1.0.5
    at_utils: ^3.2.0
-   at_persistence_secondary_server: ^3.1.0
    duration: ^4.0.3
    crypto: ^3.0.5
    chalkdart: ^2.0.9
+
+dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: at-rpc-enable-same-atsign
+      path: packages/at_client
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -7,6 +7,8 @@ import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+
+// ignore: depend_on_referenced_packages
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
@@ -112,8 +114,11 @@ void main() {
           LocalSecondary(mockAtClient, keyStore: keyStore);
 
       // mocking OnboardingServiceImpl
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath =
+            '${Directory.current.path}/test/storage/keys/${atsign}_key.atKeys';
       AtOnboardingServiceImpl onboardingService =
-          AtOnboardingServiceImpl(atsign, getOnboardingPreference());
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
       onboardingService.atClient = mockAtClient;
       onboardingService.enrollmentBase = mockEnrollmentBase;
       onboardingService.atLookUp = mockAtLookup;
@@ -135,6 +140,12 @@ void main() {
       when(() => mockAtClient.getCurrentAtSign()).thenReturn(atsign);
       when(() => mockAtClient.getLocalSecondary()).thenReturn(localSecondary);
 
+      registerFallbackValue(AtKey.fromString('local:test.test$atsign'));
+      when(() => mockAtClient.put(any(), any())).thenAnswer((i) async {
+        AtKey atKey = i.positionalArguments[0];
+        dynamic value = i.positionalArguments[1];
+        return await localSecondary.putValue(atKey.toString(), value);
+      });
       // mock EncryptionPrivateKey and SelfEncryption retrieval from server
       // server encrypts these keys with APKAMSymmetricKey
       String encryptedEncryptionPrivateKey = EncryptionUtil.encryptValue(

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -13,6 +13,11 @@ dependencies:
   at_demo_data: ^1.2.0
 
 dependency_overrides:
+  at_client:
+    git:
+      url: https://github.com/atsign-foundation/at_client_sdk
+      ref: at-rpc-enable-same-atsign
+      path: packages/at_client
   at_onboarding_cli:
     path: "../../packages/at_onboarding_cli"
   at_auth:

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -8,16 +8,11 @@ environment:
 
 dependencies:
   at_lookup: ^3.0.49
-  at_client: ^3.4.0
+  at_client: ^3.4.3
   at_commons: ^5.3.0
   at_demo_data: ^1.2.0
 
 dependency_overrides:
-  at_client:
-    git:
-      url: https://github.com/atsign-foundation/at_client_sdk
-      ref: at-rpc-enable-same-atsign
-      path: packages/at_client
   at_onboarding_cli:
     path: "../../packages/at_onboarding_cli"
   at_auth:

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_test.dart
@@ -24,19 +24,32 @@ void main() {
   AtSignLogger.root_level = 'WARNING';
   String storageDir = 'test/storage';
 
+  String atSign1 = '@naresh🛠';
+  String atSign2 = '@eggovagency🛠';
+  String atSign3 = '@ashish🛠';
+  String atSign4 = '@colin🛠';
+  String atSign5 = '@purnima🛠';
+  String atSign6 = '@srie';
+  // String atSign1 = '@cli_test_01';
+  // String atSign2 = '@cli_test_02';
+  // String atSign3 = '@cli_test_03';
+  // String atSign4 = '@cli_test_04';
+  // String atSign5 = '@cli_test_05';
+  // String atSign6 = '@cli_test_06';
+
   group('A group of tests to assert on authenticate functionality', () {
     test(
         'A test to verify send enroll request, approve enrollment and auth by enrollmentId',
         () async {
       // if onboard is testing use distinct demo atsign per test,
       // since cram keys get deleted on server for already onboarded atsign
-      String atSign = '@naresh🛠';
-      //1. Onboard first client
-      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
-      AtOnboardingService? onboardingService_1 =
-          AtOnboardingServiceImpl(atSign, preference_1);
 
-      logger.info('onboarding $atSign');
+      //1. Onboard first client
+      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign1);
+      AtOnboardingService? onboardingService_1 =
+          AtOnboardingServiceImpl(atSign1, preference_1);
+
+      logger.info('onboarding $atSign1');
       bool status = await onboardingService_1.onboard();
       expect(status, true);
 
@@ -50,19 +63,19 @@ void main() {
       expect(keysFileJson['apkamSymmetricKey'], isNotEmpty);
 
       //2. authenticate first client
-      logger.info('authenticating $atSign using onboarding keys');
+      logger.info('authenticating $atSign1 using onboarding keys');
       var authResult = await onboardingService_1.authenticate();
       expect(authResult, true);
       await _setLastReceivedNotificationDateTime(
-          onboardingService_1.atClient!, atSign);
+          onboardingService_1.atClient!, atSign1);
 
       Map<String, String> namespaces = {"buzz": "rw"};
       //3.1 test invalid otp
       String totp = 'a6b4df';
       AtOnboardingPreference enrollPreference_2 =
-          getPreferenceForEnroll(atSign);
+          getPreferenceForEnroll(atSign1);
       AtOnboardingService? onboardingService_2 =
-          AtOnboardingServiceImpl(atSign, enrollPreference_2);
+          AtOnboardingServiceImpl(atSign1, enrollPreference_2);
 
       logger.info('trying enrollment with invalid OTP');
       await expectLater(
@@ -158,11 +171,10 @@ void main() {
         () async {
       // if onboard is testing use distinct demo atsign per test,
       // since cram keys get deleted on server for already onboarded atsign
-      String atSign = '@ashish🛠';
       //1. Onboard first client
-      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
+      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign3);
       AtOnboardingService? onboardingService_1 =
-          AtOnboardingServiceImpl(atSign, preference_1);
+          AtOnboardingServiceImpl(atSign3, preference_1);
       bool status = await onboardingService_1.onboard();
       expect(status, true);
       preference_1.privateKey = pkamPrivateKey;
@@ -180,20 +192,19 @@ void main() {
         () async {
       // when testing onboard() use distinct demo atsign per test,
       // since cram keys get deleted on server for already onboarded atsign
-      String atSign = '@colin🛠';
       // preference without appName and deviceName
       AtOnboardingPreference preference_1 = AtOnboardingPreference()
         ..rootDomain = 'vip.ve.atsign.zone'
         ..isLocalStoreRequired = true
         ..hiveStoragePath = 'storage/hive/client'
         ..commitLogPath = 'storage/hive/client/commit'
-        ..cramSecret = at_demos.cramKeyMap[atSign]
+        ..cramSecret = at_demos.cramKeyMap[atSign4] ?? atSign4.substring(1)
         ..namespace =
             'wavi' // unique identifier that can be used to identify data from your app
         ..rootDomain = 'vip.ve.atsign.zone';
 
       AtOnboardingService? onboardingService_1 =
-          AtOnboardingServiceImpl(atSign, preference_1);
+          AtOnboardingServiceImpl(atSign4, preference_1);
       bool onboardStatus = await onboardingService_1.onboard();
       expect(onboardStatus, true);
 
@@ -206,11 +217,10 @@ void main() {
         () async {
       // if onboard is testing use distinct demo atsign per test,
       // since cram keys get deleted on server for already onboarded atsign
-      String atSign = '@purnima🛠';
       //1. Onboard first client
-      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign);
+      AtOnboardingPreference preference_1 = getPreferenceForAuth(atSign5);
       AtOnboardingService? onboardingService_1 =
-          AtOnboardingServiceImpl(atSign, preference_1);
+          AtOnboardingServiceImpl(atSign5, preference_1);
       bool status = await onboardingService_1.onboard();
       expect(status, true);
       preference_1.privateKey = pkamPrivateKey;
@@ -218,7 +228,7 @@ void main() {
       //2. authenticate first client
       await onboardingService_1.authenticate();
       await _setLastReceivedNotificationDateTime(
-          onboardingService_1.atClient!, atSign);
+          onboardingService_1.atClient!, atSign5);
 
       //3. run otp:get from first client
       String? totp = await onboardingService_1.atClient!
@@ -258,9 +268,9 @@ void main() {
           }, count: 1, max: -1));
 
       //5. enroll second client
-      preference_1 = getPreferenceForEnroll(atSign);
+      preference_1 = getPreferenceForEnroll(atSign5);
       AtOnboardingServiceImpl? onboardingService_2 =
-          AtOnboardingServiceImpl(atSign, preference_1);
+          AtOnboardingServiceImpl(atSign5, preference_1);
 
       expectLater(
           onboardingService_2.enroll(
@@ -288,13 +298,12 @@ void main() {
         () async {
       // creates an enrollment with rw access to wavi namespace. Then validate
       // that updating a key with buzz namespace fails.
-      String atsign = '@srie';
       String appName = 'test_app_name';
       String deviceName = 'functional_test_1';
       Map<String, String> namespaces = {'wavi': 'rw'};
-      String masterKeysFilePath = '$storageDir/keys/${atsign}_key.atKeys';
+      String masterKeysFilePath = '$storageDir/keys/${atSign6}_key.atKeys';
       String enrollmentAtKeysFilePath =
-          '$storageDir/keys/${atsign}_wavi_key.atKeys';
+          '$storageDir/keys/${atSign6}_wavi_key.atKeys';
 
       AtOnboardingPreference preference = AtOnboardingPreference()
         ..rootDomain = 'vip.ve.atsign.zone'
@@ -308,9 +317,9 @@ void main() {
       // Init an OnboardingService instance and onboard. Creates a master
       // atKeys file at the location provided in variable 'masterKeysFilePath'
       AtOnboardingService? onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign6,
         preference
-          ..cramSecret = at_demos.cramKeyMap[atsign]
+          ..cramSecret = at_demos.cramKeyMap[atSign6] ?? atSign6.substring(1)
           ..atKeysFilePath = masterKeysFilePath,
       );
       await onboardingService.onboard();
@@ -319,14 +328,14 @@ void main() {
       AtClientManager.getInstance().reset();
 
       // Fetch otp
-      EnrollmentOperations? enrollmentOperations = EnrollmentOperations(atsign);
+      EnrollmentOperations? enrollmentOperations = EnrollmentOperations(atSign6);
       String? otp = await enrollmentOperations.getOtp(masterKeysFilePath);
 
       // Create a new instance of OnboardingService that will be used to send an
       // enrollment request. Once this request is approved, this creates a new
       // atKeys file at the location provided in 'enrollmentAtKeysFilePath'
       onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign6,
         preference..atKeysFilePath = enrollmentAtKeysFilePath,
       );
 
@@ -363,7 +372,7 @@ void main() {
       // Create a new instance of OnboardingCli and authenticate using the newly
       // created atKeys file that only has access to wavi namespace
       onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign6,
         preference..atKeysFilePath = enrollmentAtKeysFilePath,
       );
       bool authStatus = await onboardingService.authenticate(
@@ -377,7 +386,7 @@ void main() {
       AtKey buzzKey = AtKey.public(
         'dummy_key_27',
         namespace: 'buzz',
-        sharedBy: atsign,
+        sharedBy: atSign6,
       ).build();
       String expectedExceptionMessage =
           'Exception: Cannot perform update on $buzzKey due to insufficient privilege';
@@ -397,13 +406,12 @@ void main() {
         () async {
       // creates an enrollment with r access to 'delta' namespace.
       // Then validate that updating a key with buzz namespace fails.
-      String atsign = '@eggovagency🛠';
       String appName = 'access_test_appname';
       String deviceName = 'functional_test_2';
       Map<String, String> namespaces = {'delta': 'r'};
-      String masterKeysFilePath = '$storageDir/keys/${atsign}_key.atKeys';
+      String masterKeysFilePath = '$storageDir/keys/${atSign2}_key.atKeys';
       String enrollmentAtKeysFilePath =
-          '$storageDir/keys/${atsign}_wavi_key.atKeys';
+          '$storageDir/keys/${atSign2}_wavi_key.atKeys';
 
       AtOnboardingPreference preference = AtOnboardingPreference()
         ..rootDomain = 'vip.ve.atsign.zone'
@@ -417,9 +425,9 @@ void main() {
       // Init an OnboardingService instance and onboard. Creates a master
       // atKeys file at the location provided in variable 'masterKeysFilePath'
       AtOnboardingService? onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign2,
         preference
-          ..cramSecret = at_demos.cramKeyMap[atsign]
+          ..cramSecret = at_demos.cramKeyMap[atSign2] ?? atSign2.substring(1)
           ..atKeysFilePath = masterKeysFilePath,
       );
       await onboardingService.onboard();
@@ -428,14 +436,14 @@ void main() {
       AtClientManager.getInstance().reset();
 
       // Fetch otp
-      EnrollmentOperations enrollmentOperations = EnrollmentOperations(atsign);
+      EnrollmentOperations enrollmentOperations = EnrollmentOperations(atSign2);
       String? otp = await enrollmentOperations.getOtp(masterKeysFilePath);
 
       // Create a new instance of OnboardingService that will be used to send an
       // enrollment request. Once this request is approved, this creates a new
       // atKeys file at the location provided in 'enrollmentAtKeysFilePath'
       onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign2,
         preference..atKeysFilePath = enrollmentAtKeysFilePath,
       );
 
@@ -471,7 +479,7 @@ void main() {
       // Create a new instance of OnboardingCli and authenticate using the newly
       // created atKeys file that only has access to wavi namespace
       onboardingService = AtOnboardingServiceImpl(
-        atsign,
+        atSign2,
         preference..atKeysFilePath = enrollmentAtKeysFilePath,
       );
       bool authStatus = await onboardingService.authenticate(
@@ -485,7 +493,7 @@ void main() {
       AtKey deltaKey = AtKey.public(
         'dummy_key_28',
         namespace: 'delta',
-        sharedBy: atsign,
+        sharedBy: atSign2,
       ).build();
       String expectedExceptionMessage =
           'Exception: Cannot perform update on $deltaKey due to insufficient privilege';
@@ -579,7 +587,7 @@ AtOnboardingPreference getPreferenceForAuth(String atSign) {
     ..isLocalStoreRequired = true
     ..hiveStoragePath = 'storage/hive/client'
     ..commitLogPath = 'storage/hive/client/commit'
-    ..cramSecret = at_demos.cramKeyMap[atSign]
+    ..cramSecret = at_demos.cramKeyMap[atSign] ?? atSign.substring(1)
     ..namespace =
         'wavi' // unique identifier that can be used to identify data from your app
     ..atKeysFilePath =


### PR DESCRIPTION
**- What I did**
build: Use latest at_client in order to remove unnecessary direct dependency from at_onboarding_cli

**- How I did it**
- eliminated use of `AtData` (which is part of the at_persistence packages) in at_onboarding_cli. AtData was being used because AtClient hadn't fully / correctly implemented the apkam authorization check such that it doesn't check for `local:` keys.

**- How to verify it**
Tests pass
