### PR TITLE
feat: at_auth: add `atLookUp` to the AtAuth interface

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+- feat: add `AtLookUp? atLookUp` to the `AtAuth` interface so that it can be 
+  reused (e.g.) by AtClient once auth is complete
+
 ## 2.2.0
 
 - feat: enable callers of `AtAuth.onboard` to control post-auth activation

--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 - feat: add `AtLookUp? atLookUp` to the `AtAuth` interface so that it can be 
-  reused (e.g.) by AtClient once auth is complete
+  reused (e.g. by AtClient) once auth is complete
 
 ## 2.2.0
 

--- a/packages/at_auth/lib/src/at_auth_base.dart
+++ b/packages/at_auth/lib/src/at_auth_base.dart
@@ -3,10 +3,12 @@ import 'package:at_auth/src/onboard/at_onboarding_response.dart';
 import 'package:at_auth/src/auth/at_auth_request.dart';
 import 'package:at_auth/src/auth/at_auth_response.dart';
 import 'package:at_chops/at_chops.dart';
+import 'package:at_lookup/at_lookup.dart';
 
 /// Interface for onboarding and authentication to a secondary server of an atsign
-abstract class AtAuth {
+abstract interface class AtAuth {
   AtChops? atChops;
+  AtLookUp? atLookUp;
 
   /// Authenticate method is invoked when an atsign wants to authenticate to secondary server with an .atKeys file
   /// Step 1. Read the keys from [atAuthRequest.atAuthKeys] or [atAuthRequest.atKeysFilePath]

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -27,6 +27,7 @@ class AtAuthImpl implements AtAuth {
 
   AtEnrollmentBase? atEnrollmentBase;
 
+  @override
   AtLookUp? atLookUp;
 
   AtAuthImpl(

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.2.0
+version: 2.3.0
 homepage: https://atsign.com/
 repository: https://github.com/atsign-foundation/at_libraries
 


### PR DESCRIPTION
**- What I did**
feat: add `AtLookUp? atLookUp` to the `AtAuth` interface so that it can be reused (e.g. by AtClient) once auth is complete. Reusing it means that the client doesn't have to wait for another authentication handshake on a new network connection.

**- How I did it**
See commit

**- How to verify it**
Tests pass

