### PR TITLE
fix: `NotifyVerbBuilder.buildCommand()` uses `AtKey.toString()` inste…

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.1
+- fix: `NotifyVerbBuilder.buildCommand()` uses `AtKey.toString()` instead of 
+  doing its own thing.
+
 ## 5.4.0
 - feat: add `EnrollmentConstants`. Contains various patterns and regular 
   expressions for enrollment-related data

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -33,8 +33,10 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
   /// Latest N notifications to notify. Defaults to 1
   int? latestN;
 
+  bool useAtKeyToString = false;
+
   @override
-  String buildCommand({bool useAtKeyToString = false}) {
+  String buildCommand() {
     StringBuffer sb = StringBuffer();
     sb.write('notify:id:$id');
 

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -61,18 +61,8 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
     // Add in all of the metadata parameters in atProtocol command format
     sb.write(atKey.metadata.toAtProtocolFragment());
 
-    if (atKey.sharedWith != null) {
-      sb.write(':${VerbUtil.formatAtSign(atKey.sharedWith)}');
-    }
+    sb.write(':${atKey.toString()}');
 
-    if (atKey.metadata.isPublic == true) {
-      sb.write(':public');
-    }
-    sb.write(':${atKey.key}');
-
-    if (atKey.sharedBy != null) {
-      sb.write('${VerbUtil.formatAtSign(atKey.sharedBy)}');
-    }
     if (value != null) {
       sb.write(':$value');
     }

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -34,7 +34,7 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
   int? latestN;
 
   @override
-  String buildCommand() {
+  String buildCommand({bool useAtKeyToString = false}) {
     StringBuffer sb = StringBuffer();
     sb.write('notify:id:$id');
 
@@ -61,8 +61,9 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
     // Add in all of the metadata parameters in atProtocol command format
     sb.write(atKey.metadata.toAtProtocolFragment());
 
-    // ignore: deprecated_member_use_from_same_package
-    if (messageType == MessageTypeEnum.text) {
+    if (useAtKeyToString) {
+      sb.write(':${atKey.toString()}');
+    } else {
       if (atKey.sharedWith != null) {
         sb.write(':${VerbUtil.formatAtSign(atKey.sharedWith)}');
       }
@@ -75,8 +76,6 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
       if (atKey.sharedBy != null) {
         sb.write('${VerbUtil.formatAtSign(atKey.sharedBy)}');
       }
-    } else {
-      sb.write(':${atKey.toString()}');
     }
 
     if (value != null) {

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -1,4 +1,5 @@
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
+import 'package:at_commons/src/verb/verb_util.dart';
 import 'package:uuid/uuid.dart';
 
 import '../at_constants.dart';
@@ -60,7 +61,23 @@ class NotifyVerbBuilder extends AbstractVerbBuilder {
     // Add in all of the metadata parameters in atProtocol command format
     sb.write(atKey.metadata.toAtProtocolFragment());
 
-    sb.write(':${atKey.toString()}');
+    // ignore: deprecated_member_use_from_same_package
+    if (messageType == MessageTypeEnum.text) {
+      if (atKey.sharedWith != null) {
+        sb.write(':${VerbUtil.formatAtSign(atKey.sharedWith)}');
+      }
+
+      if (atKey.metadata.isPublic == true) {
+        sb.write(':public');
+      }
+      sb.write(':${atKey.key}');
+
+      if (atKey.sharedBy != null) {
+        sb.write('${VerbUtil.formatAtSign(atKey.sharedBy)}');
+      }
+    } else {
+      sb.write(':${atKey.toString()}');
+    }
 
     if (value != null) {
       sb.write(':$value');

--- a/packages/at_commons/lib/src/verb/notify_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/notify_verb_builder.dart
@@ -3,7 +3,6 @@ import 'package:uuid/uuid.dart';
 
 import '../at_constants.dart';
 import 'operation_enum.dart';
-import 'verb_util.dart';
 
 class NotifyVerbBuilder extends AbstractVerbBuilder {
   /// id for each notification.

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.4.0
+version: 5.4.1
 repository: https://github.com/atsign-foundation/at_libraries
 homepage: https://atsign.dev
 

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -6,6 +6,47 @@ import 'syntax_test.dart';
 
 void main() {
   group('A group of notify verb builder tests to check notify command', () {
+    test('notify without namespace', () {
+      final nvb = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'foo'
+        ..atKey.key = 'foo'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.sharedBy = '@alice';
+      expect(nvb.buildCommand(),
+          'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo@alice:foo\n');
+    });
+
+    test('notify with namespace', () {
+      final nvb = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'foo'
+        ..atKey.key = 'foo'
+        ..atKey.namespace = 'my_app'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.sharedBy = '@alice';
+      expect(nvb.buildCommand(),
+          'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
+    });
+
+    test('notify without namespace using atKey toString', () {
+      final nvb = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'foo'
+        ..atKey = AtKey.fromString('@bob:foo@alice');
+      expect(nvb.buildCommand(),
+          'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo@alice:foo\n');
+    });
+
+    test('notify with namespace using atKey toString', () {
+      final nvb = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'foo'
+        ..atKey = AtKey.fromString('@bob:foo.my_app@alice');
+      expect(nvb.buildCommand(),
+          'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
+    });
+
     test('notify public key', () {
       var notifyVerbBuilder = NotifyVerbBuilder()
         ..id = '123'

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -19,13 +19,14 @@ void main() {
 
     test('notify with namespace', () {
       final nvb = NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..id = '123'
         ..value = 'foo'
         ..atKey.key = 'foo'
         ..atKey.namespace = 'my_app'
         ..atKey.sharedWith = '@bob'
         ..atKey.sharedBy = '@alice';
-      expect(nvb.buildCommand(useAtKeyToString: true),
+      expect(nvb.buildCommand(),
           'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
     });
 
@@ -40,10 +41,11 @@ void main() {
 
     test('notify with namespace using atKey toString', () {
       final nvb = NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..id = '123'
         ..value = 'foo'
         ..atKey = AtKey.fromString('@bob:foo.my_app@alice');
-      expect(nvb.buildCommand(useAtKeyToString: true),
+      expect(nvb.buildCommand(),
           'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
     });
 

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -25,7 +25,7 @@ void main() {
         ..atKey.namespace = 'my_app'
         ..atKey.sharedWith = '@bob'
         ..atKey.sharedBy = '@alice';
-      expect(nvb.buildCommand(),
+      expect(nvb.buildCommand(useAtKeyToString: true),
           'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
     });
 
@@ -43,7 +43,7 @@ void main() {
         ..id = '123'
         ..value = 'foo'
         ..atKey = AtKey.fromString('@bob:foo.my_app@alice');
-      expect(nvb.buildCommand(),
+      expect(nvb.buildCommand(useAtKeyToString: true),
           'notify:id:123:notifier:SYSTEM:isEncrypted:false:@bob:foo.my_app@alice:foo\n');
     });
 


### PR DESCRIPTION
**- What I did**
- fix: `NotifyVerbBuilder.buildCommand()` now uses `AtKey.toString()` which ensures that namespace is transmitted when supplied
  - however, had to guard this behaviour with a flag, to preserve backwards compatibility

**- How I did it**

**- How to verify it**
- Tests pass
- Additionally tested by https://github.com/atsign-foundation/at_client_sdk/pull/1533
